### PR TITLE
Choose specific nunit-console

### DIFF
--- a/src/app/FakeLib/NUnitHelper.fs
+++ b/src/app/FakeLib/NUnitHelper.fs
@@ -81,7 +81,10 @@ let NUnit setParams (assemblies: string seq) =
           |> appendIfNotNull parameters.Framework  "/framework:"
           |> appendIfNotNull parameters.ErrorOutputFile "/err:"
 
-    let tool = parameters.ToolPath @@ toolName
+    let tool = if parameters.ToolPath.EndsWith("exe") then
+                 parameters.ToolPath
+               else
+                 parameters.ToolPath @@ toolName
     let args = commandLineBuilder.ToString()
     trace (tool + " " + args)
     let result =


### PR DESCRIPTION
I, with my humble F#-knowledge, haven't found a way to choose a specific nunit-console. Now it's possible to define which nunit-console to take (standard / x86 on a 64bit-system) by adding the filename to the ToolPath.
