### PR TITLE
Changes to NuGet task.

### DIFF
--- a/src/app/FakeLib/NuGetHelper.fs
+++ b/src/app/FakeLib/NuGetHelper.fs
@@ -56,7 +56,7 @@ let private runNuget parameters nuSpec =
     // create .nuspec file
     CopyFile parameters.OutputPath nuSpec
 
-    let specFile = parameters.OutputPath @@ nuSpec
+    let specFile = parameters.OutputPath @@ (nuSpec |> Path.GetFileName)
     let packageFile = sprintf "%s.%s.nupkg" parameters.Project version
     let dependencies =
         if parameters.Dependencies = [] then "" else
@@ -88,7 +88,7 @@ let private runNuget parameters nuSpec =
         parameters.OutputPath @@ packageFile |> DeleteFile
 
     // create package
-    let args = sprintf "pack %s" nuSpec
+    let args = sprintf "pack %s" (Path.GetFileName specFile)
     let result = 
         ExecProcess (fun info ->
             info.FileName <- parameters.ToolPath


### PR DESCRIPTION
Hi,
I've changed NuGet task a little so it would be possible to point to .nuspec file in any subdirectory of base directory. 

In current version it is possible to use .nuspec only in base directory, but if we build several projects with different .nuspec files it would be very inconvenient to store them all in one base directory. It would be more natural to keep every .nuspec near corresponding .*sproj file.
