### PR TITLE
Small tweaks to mono build

### DIFF
--- a/mono_build.sh
+++ b/mono_build.sh
@@ -8,6 +8,10 @@ srcfakepath='src/app/FAKE/'
 srcfakelibpath='src/app/FakeLib/'
 unamestr=`uname`
 
+if [ ! -d "$buildpath" ]; then
+	mkdir "$buildpath"
+fi
+
 if [ "$unamestr" == "Darwin" ]; then
 	monopath='/Library/Frameworks/Mono.framework/libraries/mono/4.0/'
 	fscorepath='/Library/Frameworks/Mono.framework/libraries/mono/4.0/'


### PR DESCRIPTION
Just two small changes to mono_build.sh worth sharing;
- Made the script executable
- Creates build directory if doesn't exist (errors otherwise)
