### PR TITLE
Update the CCNet integration howto URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ For instance custom build tasks can be added simply by referencing .NET assembli
 <li><a href="http://www.navision-blog.de/2009/04/04/modifying-assemblyinfo-and-version-via-fake-f-make">Modifying AssemblyInfo and Version via "FAKE - F# Make"</a></li>
 <li><a href="http://www.navision-blog.de/2009/04/14/writing-custom-tasks-for-fake-f-make">Writing custom tasks for "FAKE - F# Make"</a></li>
 <li><a href="http://www.navision-blog.de/2009/04/15/integrate-a-fake-f-make-build-script-into-teamcity">Integrating a "FAKE - F# Make" build script into TeamCity</a></li>
-<li><a href="http://www.navision-blog.de/2009/10/14/integrating-a-fake-f-make-build-script-into-cruisecontrol-net">Integrating a "FAKE - F# Make" build script into CruiseControl.NET</a></li>
+<li><a href="http://cruisecontrolnet.org/projects/ccnet/wiki/FAKE_Task">Integrating a "FAKE - F# Make" build script into CruiseControl.NET</a></li>
 <li><a href="http://www.navision-blog.de/2012/01/16/building-fake-scripts-with-jenkins/">Building FAKE scripts with Jenkins</a></li>
 <li><a href="http://www.navision-blog.de/2010/11/03/running-specific-targets-in-fake-f-make/">Running specific targets in "FAKE – F# Make"</a></li>
 </ul><h2>Main Features</h2>


### PR DESCRIPTION
The blog post is a little bit our of date. Switched the URL to the
up2date CruiseControl.NET documentation on how to use FAKE with CCNet.
