### PR TITLE
Cannot create NuGet package with version "1.0.0"

### DIFF
--- a/src/app/FakeLib/NuGetHelper.fs
+++ b/src/app/FakeLib/NuGetHelper.fs
@@ -54,12 +54,11 @@ let GetPackageVersion deploymentsDir package =
 let private replaceAccessKey key (s:string) = s.Replace(key,"PRIVATEKEY")
 
 let private runNuget parameters nuSpec =
-    let version = NormalizeVersion parameters.Version
     // create .nuspec file
     CopyFile parameters.OutputPath nuSpec
 
     let specFile = parameters.OutputPath @@ (nuSpec |> Path.GetFileName)
-    let packageFile = sprintf "%s.%s.nupkg" parameters.Project version
+    let packageFile = sprintf "%s.%s.nupkg" parameters.Project parameters.Version
     let dependencies =
         if parameters.Dependencies = [] then "" else
         parameters.Dependencies
@@ -68,7 +67,7 @@ let private runNuget parameters nuSpec =
           |> fun s -> sprintf "<dependencies>\r\n%s\r\n</dependencies>" s
 
     let replacements =
-        ["@build.number@",version
+        ["@build.number@",parameters.Version
          "@authors@",parameters.Authors |> separated ", "
          "@project@",parameters.Project
          "@summary@",if isNullOrEmpty parameters.Summary then "" else parameters.Summary


### PR DESCRIPTION
I currently have the problem that I cannot build a NuGet package for [Machine.Fakes](https://github.com/machine/machine.fakes) with version "1.0.0", because Fake normalizes the version to "1", which is not accepted by nuget.exe.

I suppose there are other ways to solve this, but I don't see why FAKE should tamper with the version supplied by the user anyway. If I want the version normalized, I can always call the `NormalizeVersion` function in my build script.
