### PR TITLE
Made the NUnit task use hyphens rather than forward slashes.

### DIFF
--- a/src/app/FakeLib/NUnitHelper.fs
+++ b/src/app/FakeLib/NUnitHelper.fs
@@ -69,7 +69,7 @@ let NUnit setParams (assemblies: string seq) =
     let assemblies =  assemblies |> Seq.toArray
     let commandLineBuilder =
         new StringBuilder()
-          |> append "/nologo"
+          |> append "-nologo"
           |> appendIfTrue parameters.DisableShadowCopy "-noshadow" 
           |> appendIfTrue parameters.ShowLabels "-labels" 
           |> appendIfTrue parameters.TestInNewThread "-thread" 


### PR DESCRIPTION
The NUnit task does not work under OS X. It complains, that the file type /xxx is unknown, where xxx is just a nunit parameter. The documentation suggests a work-around.

> **Note:** Under the Windows operating system, options may be prefixed by either a forward slash or a hyphen. Under Linux, a hyphen must be used. Options that take values may use an equal sign, a colon or a space to separate the option from its value.

I could not test if it actually works, though, because I can't build FAKE on mono.
