### PR TITLE
shortened the failure message reported to teamcity

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -145,7 +145,9 @@ let targetError targetName (exn:System.Exception) =
         sprintf "%O%s" exn (if exn.InnerException <> null then "\n" + (exn.InnerException.ToString()) else "")
             
     traceError <| sprintf "Running build failed.\nError:\n%s" msg
-    sendTeamCityError msg        
+
+    let tcMsg = sprintf "%s" exn.Message
+    sendTeamCityError tcMsg        
  
 let addExecutedTarget target time =
     ExecutedTargets.Add target |> ignore


### PR DESCRIPTION
This is to help prevent monster failure messages in TeamCity as can be seen below...

![image](https://f.cloud.github.com/assets/156495/46978/ae8ffa9a-58a9-11e2-981b-b658f39f6d5b.png)
