### PR TITLE
Upgraded to use and auto-ref NuGet.Core 2.5 in fake boot

### DIFF
--- a/src/app/FakeLib/Boot.fs
+++ b/src/app/FakeLib/Boot.fs
@@ -1,4 +1,4 @@
-﻿/// Implements support for boostrapping FAKE scripts.  A bootstrapping
+/// Implements support for boostrapping FAKE scripts.  A bootstrapping
 /// `build.fsx` script executes twice (in two stages), allowing to
 /// download dependencies with NuGet and do other preparatory work in
 /// the first stage, and have these dependencies available in the
@@ -256,6 +256,7 @@ module private Implementation =
             w.Write("#r ")
             writeString path
             w.WriteLine()
+        writeRef (fakeDir +/ "NuGet.Core.dll")
         writeRef (fakeDir +/ "FakeLib.dll")
         for r in refs do
             writeRef r

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -149,7 +149,7 @@
       <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core">
-      <HintPath>..\..\..\packages\NuGet.Core.2.3.0-alpha003\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\NuGet.Core.2.5.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -160,11 +160,4 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-	     Other similar extension points exist, see Microsoft.Common.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
 </Project>

--- a/src/app/FakeLib/packages.config
+++ b/src/app/FakeLib/packages.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net35" />
-  <package id="Nuget.Core" version="2.3.0-alpha003" targetFramework="net40" />
+  <package id="Nuget.Core" version="2.5.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
1. Updated FakeLib NuGet.Core dependency to use NuGet.Core 2.5.0 package (was: 2.3.x-alpha). AFAIK NuGet.Core is only being used by `fake boot` so far, but anyhow it is nice to stay current.
2. When generating automatic references file in `fake boot`, added an #r directive to include NuGet.Core 2.5.0 from the FAKE build folder before referencing FakeLib. This makes sure that NuGet API is 2.5.0 in your build scripts even when an older NuGet is present in the GAC.

Thanks.
