### PR TITLE
List all msbuild errors in exception raised when msbuild fails

### DIFF
--- a/src/app/FakeLib/BuildException.fs
+++ b/src/app/FakeLib/BuildException.fs
@@ -1,0 +1,4 @@
+﻿namespace Fake
+
+    exception BuildException of string*list<string>
+

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="FSharpHelpers\SeqExtensions.fs" />
     <Compile Include="FSharpHelpers\OptionExtensions.fs" />
     <Compile Include="FSharpHelpers\AsyncHelper.fs" />
+    <Compile Include="BuildException.fs" />
     <Compile Include="RegistryHelper.fs" />
     <Compile Include="FileSystemHelper.fs" />
     <Compile Include="StringHelper.fs" />

--- a/src/app/FakeLib/MsBuildLogger.fs
+++ b/src/app/FakeLib/MsBuildLogger.fs
@@ -4,18 +4,45 @@ open Microsoft.Build
 open Microsoft.Build.Framework
 open System
 open System.Collections.Generic
+open System.IO
 
-type TeamCityLogger () =
+type MSBuildLogger () = 
     let mutable Verbosity = LoggerVerbosity.Normal
     let mutable Parameters = ""
+
+    abstract member RegisterEvents : IEventSource -> unit
+    default t.RegisterEvents e = ()
+
+    member this.errToStr (a:BuildErrorEventArgs) = 
+        sprintf "%s: %s(%d,%d): %s [%s]" a.Code a.File a.LineNumber a.ColumnNumber a.Message a.ProjectFile
 
     interface ILogger with
         member this.Parameters with get() = Parameters and set(value) = Parameters <- value
         member this.Verbosity with get() = Verbosity and set(value) = Verbosity <- value
         member this.Shutdown () = ()
-        member this.Initialize(eventSource) = 
-            eventSource.ErrorRaised.Add(fun a ->
-                let str = sprintf "%s(%d,%d): ERROR %s: `%s` [%s]" a.File a.LineNumber a.ColumnNumber a.Code a.Message a.ProjectFile
-                printfn "==> %s" str
-                str |> TeamCityHelper.sendTeamCityError
-            )
+        member this.Initialize(eventSource) = this.RegisterEvents(eventSource)
+
+type TeamCityLogger () =
+    inherit MSBuildLogger()
+        override this.RegisterEvents(eventSource) = 
+            eventSource.ErrorRaised.Add(fun a -> this.errToStr a |> TeamCityHelper.sendTeamCityError )
+
+let ErrorLoggerFile = Path.Combine(Path.GetTempPath(), "Fake.Errors.txt")
+
+type ErrorLogger () =
+    inherit MSBuildLogger()
+
+    let errors = new List<BuildErrorEventArgs>()
+
+    
+    override this.RegisterEvents(eventSource) = 
+        eventSource.ErrorRaised.Add(fun a -> errors.Add a)
+
+        eventSource.BuildFinished.Add(fun a ->
+            let errMsg = 
+                errors 
+                |> Seq.map this.errToStr
+                |> fun e -> String.Join(Environment.NewLine, e)
+                |> fun e -> if a.Succeeded then "" else e
+            File.WriteAllText(ErrorLoggerFile, errMsg)
+        )


### PR DESCRIPTION
if msbuild fails all errors will be listed in the summary:
## Example:
## Build Time Report

Target                     Duration

---

Clean                      00:00:00.0173582
Set teamcity buildnumber   00:00:00.0002607
Restore nuget packages     00:00:00.2135085
InstallNUnitRunners        00:00:06.1929361
AssemblyInfo               00:00:00.0077050
Total:                     00:00:07.0663078
## Status:                    Failure

  1) Building C:\code\TeamCityTest\src/TeamCityTest.sln project failed.
  2) CS0266: Class1.cs(13,26): Cannot implicitly convert type 'int' to 'Foo.SomeEnum'. An explicit conversion exists (are you missing a cast?) [C:\code\TeamCityTest\src\Foo\Foo.csproj]
##   3) CS0029: Dummy.cs(7,24): Cannot implicitly convert type 'int' to 'string' [C:\code\TeamCityTest\src\Foo\Foo.csproj]
