### PR TITLE
Fix: Do not append a newline if using ReplaceInFile:

### DIFF
--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -60,7 +60,7 @@ let ReplaceFile fileName text =
     if fi.Exists then
         fi.IsReadOnly <- false
         fi.Delete()
-    WriteStringToFile false fileName text
+    File.WriteAllText (fileName, text)
 
 let Colon = ','
 


### PR DESCRIPTION
Use File.WriteAllText in ReplaceFile instead of WriteStringToFile false.
WriteStringToFile false has the behaviour, that in every case a newline is appended, because the text is passed as a singleton list of lines and WriteToFile appends each line using a StreamWriter.WriteLine thus resulting in the last line introducing an additional newline.
