### PR TITLE
Fix NuGet command line parameter PreRelease

### DIFF
--- a/src/app/FakeLib/RestorePackageHelper.fs
+++ b/src/app/FakeLib/RestorePackageHelper.fs
@@ -57,8 +57,8 @@ let buildNuGetArgs setParams packageId =
         | (true, false, None)     -> args + " \"-ExcludeVersion\""
         | (false, _, Some(v))     -> args + " \"-Version\" \"" + v.ToString() + "\""
         | (false, false, None)    -> args
-        | (false, true, _)        -> args + " \"-IncludePreRelease\""
-        | (true, true, _)         -> args + " \"-ExcludeVersion\" \"-IncludePreRelease\""
+        | (false, true, _)        -> args + " \"-PreRelease\""
+        | (true, true, _)         -> args + " \"-ExcludeVersion\" \"-PreRelease\""
 
 let RestorePackageId setParams packageId = 
     traceStartTask "RestorePackageId" packageId

--- a/src/test/Test.FAKECore/RestorePackageHelperSpecs.cs
+++ b/src/test/Test.FAKECore/RestorePackageHelperSpecs.cs
@@ -89,7 +89,7 @@ namespace Test.FAKECore
                     true);
                 var result = Run(packageParams);
                 result.ShouldStartWith(" \"install\" \"thePackage\" \"-OutputDirectory\" \"");
-                result.ShouldEndWith("\\test\\myPackageFolder\\\" \"-IncludePreRelease\"");
+                result.ShouldEndWith("\\test\\myPackageFolder\\\" \"-PreRelease\"");
             };
 
         It should_restore_package_by_package_id_with_ExcludeVersion_and_PreReleasePackage =
@@ -105,7 +105,7 @@ namespace Test.FAKECore
                     true);
                 var result = Run(packageParams);
                 result.ShouldStartWith(" \"install\" \"thePackage\" \"-OutputDirectory\" \"");
-                result.ShouldEndWith("\\test\\myPackageFolder\\\" \"-ExcludeVersion\" \"-IncludePreRelease\"");
+                result.ShouldEndWith("\\test\\myPackageFolder\\\" \"-ExcludeVersion\" \"-PreRelease\"");
             };
     }
 }


### PR DESCRIPTION
The NuGet parameter is called -PreRelease, not -IncludePreRelease: http://docs.nuget.org/docs/reference/command-line-reference#Install_Command
