### PR TITLE
Generate internal AssemblyInfo module

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -55,7 +55,7 @@ let CreateCSharpAssemblyInfo outputFileName attributes =
 let CreateFSharpAssemblyInfo outputFileName attributes =
     traceStartTask "AssemblyInfo" outputFileName
 
-    ["module AssemblyInfo"] @
+    ["module internal AssemblyInfo"] @
     (getDependencies attributes |> List.map (sprintf "open %s")) @ [""] @
     (attributes |> Seq.toList |> List.map (fun (attr:Attribute) -> sprintf "[<assembly: %sAttribute(%s)>]" attr.Name attr.Value)) @ [""] @
     ["()"]


### PR DESCRIPTION
This does not seem to break anything and it means that the generated module will not be visible in automatically generated documentation from the XML comments associated with a `dll` file built using FAKE.
