### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #getting latest FAKE via NuGet
-mono tools/NuGet/NuGet.exe install FAKE -OutputDirectory tools -ExcludeVersion -Prerelease
+mono tools/NuGet/nuget.exe install FAKE -OutputDirectory tools -ExcludeVersion -Prerelease
 
 #build FAKE
 mono tools/FAKE/tools/FAKE.exe build.fsx


### PR DESCRIPTION
linux file systems are case sensitive.  The current distibution has `nuget.exe`.  Update build.sh to reflect this
