### PR TITLE
Fix xpaths in ConfigurationHelper

### DIFF
--- a/src/app/FakeLib/ConfigurationHelper.fs
+++ b/src/app/FakeLib/ConfigurationHelper.fs
@@ -54,7 +54,7 @@ let updateConfigSetting fileName xpath attribute value =
 ///
 ///     updateAppSetting "DatabaseName" targetDatabase (navServicePath @@ "CustomSettings.config")
 let updateAppSetting key value fileName =
-    updateConfigSetting fileName ("appSettings/add[@key='" + key + "']") "value" value
+    updateConfigSetting fileName ("configuration/appSettings/add[@key='" + key + "']") "value" value
 
 /// Reads a config file from the given file name, replaces the connection string value and writes it back.   
 /// ## Parameters
@@ -62,4 +62,4 @@ let updateAppSetting key value fileName =
 ///  - `value` - The new connection string value.
 ///  - `fileName` - The file name of the config file.     
 let updateConnectionString connectionStringKey value fileName =
-    updateConfigSetting fileName ("connectionStrings/add[@name='" + connectionStringKey + "']") "connectionString" value
+    updateConfigSetting fileName ("configuration/connectionStrings/add[@name='" + connectionStringKey + "']") "connectionString" value

--- a/src/test/Test.FAKECore/ConfigSpecs.cs
+++ b/src/test/Test.FAKECore/ConfigSpecs.cs
@@ -16,4 +16,14 @@ namespace Test.FAKECore.ConfigHandling
         It should_equal_the_target_text =
             () => File.ReadAllText(OriginalFile).ShouldContain("MyDatabase");
     }
+
+    public class when_modifying_connection_strings
+    {
+        const string OriginalFile = "Small.txt";
+
+        Because of = () => ConfigurationHelper.updateConnectionString("basic", "New Connection String", OriginalFile);
+
+        It should_equal_the_target_text =
+            () => File.ReadAllText(OriginalFile).ShouldContain("New Connection String");
+    }
 }

--- a/src/test/Test.FAKECore/Small.txt
+++ b/src/test/Test.FAKECore/Small.txt
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<appSettings>
-  <add key="DatabaseName" value="Demo Database NAV (7-0)" />
-</appSettings>
+<configuration>
+    <appSettings>
+        <add key="DatabaseName" value="Demo Database NAV (7-0)" />
+    </appSettings>
+    <connectionStrings>
+        <add name="basic" connectionString="original connection string" />
+    </connectionStrings>
+</configuration>


### PR DESCRIPTION
I was using the ConfigurationHelper to modify my app.config file after a build and it was throwing an exception saying the element path could not be found.

A standard .NET configuration file has `<configuration>` as the root element. `<appSettings>` and `<connectionStrings>` both live under that root element. I modified the `ConfigurationHelper` to use the correct xpath and updated the tests.
