### PR TITLE
fixes fsharp/FAKE#165 for 32-bit machines

### DIFF
--- a/src/app/FAKE/app.config
+++ b/src/app/FAKE/app.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="MSBuildPath" value="[ProgramFilesX86]\MSBuild\12.0\bin\amd64\;[ProgramFilesX86]\MSBuild\12.0\bin\;c:\Windows\Microsoft.NET\Framework\v4.0.30319\;c:\Windows\Microsoft.NET\Framework\v4.0.30128\;c:\Windows\Microsoft.NET\Framework\v3.5\" />
+    <add key="MSBuildPath" value="[ProgramFilesX86]\MSBuild\12.0\bin\amd64\;[ProgramFiles]\MSBuild\12.0\bin\;c:\Windows\Microsoft.NET\Framework\v4.0.30319\;c:\Windows\Microsoft.NET\Framework\v4.0.30128\;c:\Windows\Microsoft.NET\Framework\v3.5\" />
     <add key="FSIPath" value=".\tools\FSharp\;.\lib\FSharp\;[ProgramFilesX86]\Microsoft SDKs\F#\3.1\Framework\v4.0;[ProgramFilesX86]\Microsoft SDKs\F#\3.0\Framework\v4.0;[ProgramFiles]\Microsoft F#\v4.0\;[ProgramFilesX86]\Microsoft F#\v4.0\;[ProgramFiles]\FSharp-2.0.0.0\bin\;[ProgramFilesX86]\FSharp-2.0.0.0\bin\;[ProgramFiles]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\FSharp-1.9.9.9\bin\" />
     <add key="GitPath" value="[ProgramFilesX86]\Git\bin\;[ProgramFiles]\Git\bin\" />
   </appSettings>


### PR DESCRIPTION
"On 32-bit machines they can be found in: C:\Program Files\MSBuild\12.0\bin"
http://blogs.msdn.com/b/visualstudio/archive/2013/07/24/msbuild-is-now-part-of-visual-studio.aspx
