### PR TITLE
Add TargetBuilder computation expression

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -109,6 +109,7 @@
     <Compile Include="HTMLHelpWorkShopHelper.fs" />
     <Compile Include="ConfigurationHelper.fs" />
     <Compile Include="TargetHelper.fs" />
+    <Compile Include="TargetBuilder.fs" />
     <Compile Include="AdditionalSyntax.fs" />
     <Compile Include="PermissionsHelper.fs" />
     <Compile Include="SpecFlowHelper.fs" />

--- a/src/app/FakeLib/TargetBuilder.fs
+++ b/src/app/FakeLib/TargetBuilder.fs
@@ -1,0 +1,30 @@
+﻿module Fake.TargetBuilder
+
+type TargetBuilder (name) =
+    member x.Zero () = ()
+    member x.Delay f = f
+    member x.Run f = Target name f
+
+    member x.While (guard, body) : unit =
+        if not (guard()) 
+        then x.Zero() 
+        else 
+            body()
+            x.While (guard, body)  
+    
+    member x.TryWith (body, handler) = try body() with e -> handler e
+    member x.TryFinally(body, compensation) = try body() finally compensation() 
+
+    member x.Using (disposable: #System.IDisposable, body) =
+        let body' = fun () -> body disposable
+        x.TryFinally(body', fun () -> 
+            match disposable with 
+                | null -> () 
+                | disp -> disp.Dispose())
+
+    member x.For(sequence: seq<_>, body) =
+      x.Using(sequence.GetEnumerator(), fun enum -> 
+            x.While(enum.MoveNext, 
+                x.Delay(fun () -> body enum.Current)))
+
+let Target name = TargetBuilder(name)


### PR DESCRIPTION
It seems to support all kinds of expressions:

``` fsharp
Target "All features" {
    let f x = x * x
    printfn "f 2 = %d" (f 2)

    try
        for i in [1..10] do
            try
                printfn "%d" i
                failwith "an exn"
            with e -> printfn "exn catched %A" e
    finally
        printfn "from finally"
}
```
