### PR TITLE
Introduce a private constructor for the AssemblyVersionInformation class

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -72,7 +72,7 @@ let CreateCSharpAssemblyInfo outputFileName attributes =
     (attributes |> Seq.toList |> List.map (fun (attr:Attribute) -> sprintf "[assembly: %sAttribute(%s)]" attr.Name attr.Value)) @
     (attributes |> Seq.toList |> List.map (fun (attr:Attribute) ->  
                                                   if attr.Name = "AssemblyVersion" then
-                                                      sprintf "class AssemblyVersionInformation { public const string Version = %s; }" attr.Value
+                                                      sprintf "class AssemblyVersionInformation { AssemblyVersionInformation() { } public const string Version = %s; }" attr.Value
                                                   else ""))
     |> writeToFile outputFileName
     


### PR DESCRIPTION
This resolves warning CA1812 from running Code Analysis against your generated SolutionInfo.cs file.
