### PR TITLE
Add FileSetBuilder

### DIFF
--- a/src/app/Fake.Experimental/ComputationExpressions.fs
+++ b/src/app/Fake.Experimental/ComputationExpressions.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module Fake.TargetBuilder
+module Fake.ComputationExpressions
 
 type TargetBuilder (name) =
     member x.Zero () = ()
@@ -29,3 +29,22 @@ type TargetBuilder (name) =
                 x.Delay(fun () -> body enum.Current)))
 
 let Target name = TargetBuilder(name)
+
+type FileSetBuilder() =
+    member x.Delay f = f
+    member x.Run f = f()
+    member x.Yield (()) = { Include "" with Includes = [] }
+    
+    [<CustomOperation ("add", MaintainsVariableSpace = true)>]
+    member x.Add (fs, pattern: string) = fs ++ pattern
+ 
+    [<CustomOperation ("addMany", MaintainsVariableSpace = true)>]
+    member x.AddMany (fs, patterns: string list) = { fs with Includes = fs.Includes @ patterns }
+
+    [<CustomOperation ("exclude", MaintainsVariableSpace = true)>]
+    member x.Exclude (fs: FileIncludes, pattern: string) = fs -- pattern
+
+    [<CustomOperation ("excludeMany", MaintainsVariableSpace = true)>]
+    member x.ExcludeMany (fs: FileIncludes, patterns: string list) = { fs with Excludes = fs.Excludes @ patterns }
+ 
+let files = FileSetBuilder()

--- a/src/app/Fake.Experimental/Fake.Experimental.fsproj
+++ b/src/app/Fake.Experimental/Fake.Experimental.fsproj
@@ -40,7 +40,7 @@
     <DocumentationFile>..\..\..\build\FAKE.Experimental\Fake.Experimental.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="TargetBuilder.fs" />
+    <Compile Include="ComputationExpressions.fs" />
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
It allows to define file sets using CE syntax instead of operators, like this:

``` fsharp
let fs = [ "*Tests22.dll" ]

Target "Build" {
    files { 
        addMany fs
        add "**\bin\**\*Tests.dll"
        add "**\bin2\**\*Tests.dll"
        add "**\binaries\**\*"
        add "**\binaries2\**\*"
        exclude "**\bin2\Special*\*"
        excludeMany [ "*t2"; "*t3" ]
    }
    |> MSBuildDebug @".\out1" "Build"
    |> Log "AppBuild-Output: " 
}
```
