### PR TITLE
update NuGet packages including assembly references

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -124,7 +124,7 @@
     <Compile Include="ReleaseNotesHelper.fs" />
     <None Include="Targets.fsx" />
     <Compile Include="FixieHelper.fs" />
-    <Compile Include="NugetUpdate.fs" />
+    <Compile Include="NuGet\Update.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -169,4 +169,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Folder Include="NuGet\" />
+  </ItemGroup>
 </Project>

--- a/src/app/FakeLib/NuGet/Update.fs
+++ b/src/app/FakeLib/NuGet/Update.fs
@@ -1,8 +1,8 @@
-[<AutoOpen>]
 /// Contains tasks for updating NuGet packages including assembly hint paths in the project files using the [nuget.exe update command](http://docs.nuget.org/docs/reference/command-line-reference#Update_Command).
-module Fake.NugetUpdate
+module Fake.NuGet.Update
 
 open System
+open Fake
 
 /// Nuget update parameters. All optional.
 type NugetUpdateParams =


### PR DESCRIPTION
Use it like this in order to update all packages in a solution:

```
Target "UpdatePackages" (fun _ ->
    !! "*.sln"
    |> Seq.iter (NugetUpdate id)
)
```

Finer-grained control is available over the `setParams` function.

Any ideas how to reduce boilerplate with the parameters structs, default values and command line builders?
