### PR TITLE
XUnitHelper fails as soon as the test run for any single assembly fails, not running tests for other assemblies.

### DIFF
--- a/src/app/FakeLib/XUnitHelper.fs
+++ b/src/app/FakeLib/XUnitHelper.fs
@@ -42,7 +42,12 @@ let XUnitDefaults =
       TimeOut = TimeSpan.FromMinutes 5.
       OutputDir = null}
 
-/// Runs xUnit unit tests via the given xUnit runner.
+/// Runs xUnit unit tests in the given assemblies via the given xUnit runner.
+/// Will fail if the runner terminates with non-zero exit code for any of the assemblies.
+/// Offending assemblies will be listed in the error message.
+///
+/// The xUnit runner terminates with a non-zero exit code if any of the tests
+/// in the given assembly fail.
 /// ## Parameters
 /// 
 ///  - `setParams` - Function used to manipulate the default XUnitParams value.


### PR DESCRIPTION
The `XUnitHelper` will fail as soon as a signle test failed, not continuing to run the rest of the tests, in other assemblies.

It is useful to see all test results, regardless of whether any tests fail. I found it especially useful for generating test reports for a CI server.

I've changed the `xUnit` function to call xunit runner for every assembly, and in the end, if any of the calls failed, to `failwith` and report a list of offending assemblies. It works fine in my environment.
