### PR TITLE
Fix for Issue 262 : xml encoding during nuspec replacements

### DIFF
--- a/src/app/FakeLib/NuGetHelper.fs
+++ b/src/app/FakeLib/NuGetHelper.fs
@@ -107,7 +107,8 @@ let private createNuspecFile parameters nuSpec =
     let dependenciesXml = 
         sprintf "<dependencies>%s</dependencies>" (dependencies + dependenciesByFramework)
 
-    let xmlEncode (notEncodedText:string) = 
+    let xmlEncode (notEncodedText:string) =
+        if isNullOrEmpty notEncodedText then "" else
         XText(notEncodedText).ToString()
 
     let replacements =


### PR DESCRIPTION
Added xml encoding before replacing parameters in the nuget specification template file
Fixes #262
