### PR TITLE
Potential fix for issue #291

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -12,7 +12,7 @@ open System.Collections.Generic
 let startedProcesses = HashSet()
 let start (proc:Process) =
     proc.Start() |> ignore
-    startedProcesses.Add proc.Id |> ignore
+    startedProcesses.Add (proc.Id, proc.ProcessName) |> ignore
 
 /// [omit]
 let mutable redirectOutputToTrace = false 
@@ -434,13 +434,14 @@ let killMSBuild() = killProcess "msbuild"
 /// Kills all processes that are created by the FAKE build script.
 let killAllCreatedProcesses() =
     let traced = ref false
-    for id in startedProcesses do
+    for (id, name) in startedProcesses do
         try
             let p = Process.GetProcessById id
             if !traced |> not then
                 tracefn "Killing all processes that are created by FAKE and are still running."
                 traced := true
-            kill p
+            if p.ProcessName = name 
+            then kill p
         with
         | exn -> ()
     startedProcesses.Clear()


### PR DESCRIPTION
I think it is actually possible to get re-use of a PID when a process with that ID is not actually dead, but orphaned. 
I think it would be better to use a tuple of the process name and the id and just do a quick comparison after you have got that process to make sure you are killing the correct thing.
