### PR TITLE
fixes fsharp/FAKE#302 FAKE will pass -d: args to fsi.exe

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -38,11 +38,13 @@ try
         | None ->
             let buildScriptArg = if cmdArgs.Length > 1 && cmdArgs.[1].EndsWith ".fsx" then cmdArgs.[1] else Seq.head buildScripts
             let args = CommandlineParams.parseArgs (cmdArgs |> Seq.filter ((<>) buildScriptArg) |> Seq.filter ((<>) "details"))
+            let fakeArgs = args |> List.filter (fun (k,v) -> k.StartsWith "-d:" = false)
+            let fsiArgs = args |> List.filter (fun (k,v) -> k.StartsWith "-d:") |> List.map fst
             traceStartBuild()
             let printDetails = containsParam "details" cmdArgs
             if printDetails then
-                printEnvironment cmdArgs args
-            if not (runBuildScript printDetails buildScriptArg args) then
+                printEnvironment cmdArgs fakeArgs
+            if not (runBuildScript printDetails buildScriptArg fsiArgs fakeArgs) then
                 Environment.ExitCode <- 1
             else
                 if printDetails then log "Ready."

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -63,9 +63,9 @@ let executeFSIWithArgs workingDirectory script extraFsiArgs args =
     result = 0
 
 /// Run the given buildscript with fsi.exe at the given working directory.
-let runBuildScriptAt workingDirectory printDetails script args =
+let runBuildScriptAt workingDirectory printDetails script extraFsiArgs args =
     if printDetails then traceFAKE "Running Buildscript: %s" script
-    let result = ExecProcess (fsiStartInfo script workingDirectory args) System.TimeSpan.MaxValue
+    let result = ExecProcess (FsiStartInfo script workingDirectory extraFsiArgs args) System.TimeSpan.MaxValue
     Thread.Sleep 1000
     result = 0
 


### PR DESCRIPTION
I limited the scope of the change to just -d: fsi.exe arguments. I would love to see this in the build of FAKE. It allows you to use symbols with #if #else #endif in your FAKE scripts.
