### PR TITLE
add --package options for octo create-release

### DIFF
--- a/src/app/FakeLib/OctoTools.fs
+++ b/src/app/FakeLib/OctoTools.fs
@@ -15,7 +15,7 @@ type CreateReleaseOptions = {
     Project                 : string
     Version                 : string
     PackageVersion          : string
-    [<Obsolete "use Packages instead of PackageVersionOverride">]
+//    [<Obsolete "use Packages instead of PackageVersionOverride">] // warns on any use of the record
     PackageVersionOverride  : string option
     Packages                : string list
     PackagesFolder          : string option


### PR DESCRIPTION
fixes https://github.com/fsharp/FAKE/issues/313

I commented out the obsolete attribute because it put the warning on every record instance. Is there a better way to mark it obsolete?
