### PR TITLE
Fix for getting the branch name with Git >= 1.9

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="SCPHelper.fs" />
     <Compile Include="XCopyHelper.fs" />
     <Compile Include="XpkgHelper.fs" />
+    <Compile Include="VersionHelper.fs" />
     <Compile Include="MSBuild\ProjectSystem.fs" />
     <Compile Include="MSBuild\SpecsRemovement.fs" />
     <Compile Include="Git\CommandHelper.fs" />

--- a/src/app/FakeLib/VersionHelper.fs
+++ b/src/app/FakeLib/VersionHelper.fs
@@ -1,0 +1,41 @@
+﻿[<AutoOpen>]
+module Fake.VersionHelper
+
+open System
+
+/// Contains the version information.
+[<CustomEquality; CustomComparison>]
+type VerInfo =
+    { /// MAJOR version when you make incompatible API changes.
+      Major: int
+      /// MINOR version when you add functionality in a backwards-compatible manner.
+      Minor: int
+      /// PATCH version when you make backwards-compatible bug fixes.
+      Patch: int
+     }
+
+    override x.Equals(yobj) =
+        match yobj with
+        | :? VerInfo as y -> (x.Minor,x.Minor,x.Patch) = (y.Minor,y.Minor,y.Patch)
+        | _ -> false
+ 
+    override x.GetHashCode() = hash (x.Minor,x.Minor,x.Patch)
+    
+    interface System.IComparable with
+        member x.CompareTo yobj =
+            match yobj with
+            | :? VerInfo as y ->
+                if x.Major <> y.Major then compare x.Major y.Major else
+                if x.Minor <> y.Minor then compare x.Minor y.Minor else
+                if x.Patch <> y.Patch then compare x.Patch y.Patch else                
+                    0
+            | _ -> invalidArg "yobj" "cannot compare values of different types"
+
+let parseVersion version =
+    let splitted = split '.' version
+    let l = splitted.Length
+    
+    { Major = if l > 0 then Int32.Parse splitted.[0] else 0
+      Minor = if l > 1 then Int32.Parse splitted.[1] else 0
+      Patch = if l > 2 then Int32.Parse splitted.[2] else 0
+    }


### PR DESCRIPTION
The commandline output of git 1.9 changed a little bit. Therefore getting the branch name didn't work as expected

Before git 1.9
`# On branch`
With git 1.9
`On branch`

Bare with my F# skills. I'm still learning 
