### PR TITLE
Support for TypeScript 1.0

### DIFF
--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -24,7 +24,7 @@ type TypeScriptParams =
       TimeOut : TimeSpan }
 
 let private TypeScriptCompilerPath = 
-    @"[ProgramFilesX86]\Microsoft SDKs\TypeScript\0.9\;[ProgramFiles]\Microsoft SDKs\TypeScript\0.9\"
+    @"[ProgramFilesX86]\Microsoft SDKs\TypeScript\1.0\;[ProgramFiles]\Microsoft SDKs\TypeScript\1.0\;[ProgramFilesX86]\Microsoft SDKs\TypeScript\0.9\;[ProgramFiles]\Microsoft SDKs\TypeScript\0.9\"
 
 let typeScriptCompilerPath = 
     if isUnix then "tsc"


### PR DESCRIPTION
Left in 0.9 as 1.0 is included in RC update of VS and some might not use it until VS update is fully released
