### PR TITLE
Allow explicit file specification on the NuGetParams Type.

### DIFF
--- a/help/create-nuget-package.md
+++ b/help/create-nuget-package.md
@@ -24,6 +24,7 @@ The following code shows such .nuspec file from the [OctoKit](https://github.com
 		<tags>GitHub API Octokit</tags>
 		@dependencies@
 		@references@
+		@files@
 	  </metadata>
 	</package>
 
@@ -124,12 +125,14 @@ If you want to specify exactly what files are packaged and where they are placed
 Here is a code snippet showing how to use this:
 
 	// Here we are specifically only taking the js and css folders from our project and placing them in matching target folder in the resulting nuspec.
+	// Note that the include paths are relative to the location of the .nuspec file
+	// See [Nuget docs](http://docs.nuget.org/docs/reference/nuspec-reference#Specifying_Files_to_Include_in_the_Package) for more detailed examples of how to specify file includes, as this follows the same syntax.
 	NuGet (fun p ->
 		{p with
 			// ...
 			Files = [
-				("..\..\js\**\**.*", "js")
-				("..\..\css\**\**.*", "css")
+				(@"tools\**\*.*", None, None)
+				(@"bin\Debug\*.dll", Some "lib", Some "badfile.css;otherbadfile.css")
 			]
 			// ...
 		})

--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -45,7 +45,7 @@ type NuGetParams =
       PublishTrials : int
       Publish : bool
       Properties : list<string * string>
-      Files : list<string*string*string>}
+      Files : list<string*string option*string option>}
 
 /// NuGet default parameters  
 let NuGetDefaults() = 
@@ -142,7 +142,15 @@ let private createNuspecFile parameters nuSpec =
     
     let filesTags =
         parameters.Files
-        |> Seq.map (fun (source, target, exclude) -> sprintf "<file src=\"%s\" target=\"%s\" exclude=\"%s\" />" source target exclude)
+        |> Seq.map (fun (source, target, exclude) -> 
+            let excludeStr = 
+                if exclude.IsSome then sprintf " exclude=\"%s\"" exclude.Value
+                else String.Empty
+            let targetStr = 
+                if target.IsSome then sprintf " target=\"%s\"" target.Value
+                else String.Empty
+
+            sprintf "<file src=\"%s\"%s%s />" source targetStr excludeStr)
         |> toLines
 
     let filesXml = sprintf "<files>%s</files>" filesTags


### PR DESCRIPTION
With these changes users can specify a list of file includes that follow the existing [Nuget Packaging guidelines](http://docs.nuget.org/docs/reference/nuspec-reference#Specifying_Files_to_Include_in_the_Package) so that the contents of a packages can be generated dynamically at build time.
