### PR TITLE
BulkReplaceAssemblyInfoVersions: F# + VB are respected too now, Sample code snippet added

### DIFF
--- a/src/app/FakeLib/AssemblyInfoHelper.fs
+++ b/src/app/FakeLib/AssemblyInfoHelper.fs
@@ -236,15 +236,22 @@ let ReplaceAssemblyInfoVersions param =
     |> Seq.toList // break laziness
     |> WriteFile parameters.OutputFileName
 
-/// Update all AssemblyInfo.cs files in the specified directory and its subdirectories
+/// Update all AssemblyInfo.[fs|cs|vb] files in the specified directory and its subdirectories
 /// ## Parameters
 ///
-/// - 'dir' - The directory (subdirectories will be included), which inhabits the AssemblyInfo.cs files
-/// - 'replacementParameters' - The replacement parameters for the AssemblyInfo.cs files
-let BulkReplaceAssemblyInfoVersions (dir : string) replacementParameters = 
+/// - 'dir' - The directory (subdirectories will be included), which inhabits the AssemblyInfo files
+/// - 'replacementParameters' - The replacement parameters for the AssemblyInfo files
+///
+/// ## Sample
+///
+/// BulkReplaceAssemblyInfoVersions "test/" (fun f -> {f with
+///                                                     AssemblyVersion = "1.1.1.1"
+///                                                     AssemblyInformationalVersion = "1.1.1.1"})
+let BulkReplaceAssemblyInfoVersions (dir:string) (replacementParameters:AssemblyInfoReplacementParams->AssemblyInfoReplacementParams) = 
     let directory = directoryInfo dir
     if directory.Exists then 
-        !!(directory.FullName @@ "**/AssemblyInfo.*s") 
-        |> Seq.iter 
-               (fun file -> ReplaceAssemblyInfoVersions ((fun p -> { p with OutputFileName = file }) >> replacementParameters))
+        !!(directory.FullName @@ @"\**\AssemblyInfo.*s")
+          ++(directory.FullName @@ @"\**\AssemblyInfo.vb")
+            |> Seq.iter(fun file ->
+              ReplaceAssemblyInfoVersions ((fun p -> {p with OutputFileName = file }) >> replacementParameters))
     else logfn "%s does not exist." directory.FullName


### PR DESCRIPTION
I changed the code so that it will now also respect AssemblyInfo.fs and AssemblyInfo.vb files.
In addition to that, the AssemblyInfo files do not have to be stored in a "Properties" folder, as many F# projects seem to not use such a folder.
I added a sample code snippet on how to use it in the XML comment, I hope I understood forki's request correct by adding the sample in this way.
