### PR TITLE
Update Xamarin component packing to newer xamarin-component tool

### DIFF
--- a/src/app/FakeLib/XpkgHelper.fs
+++ b/src/app/FakeLib/XpkgHelper.fs
@@ -1,6 +1,6 @@
 ﻿[<AutoOpen>]
 /// Contains tasks to create packages in [Xamarin's xpkg format](http://components.xamarin.com/)
-/// Using the xpkg/xamarin-component.exe tool.
+/// using the [xamarin-component.exe](https://components.xamarin.com/submit/xpkg) tool.
 module Fake.XpkgHelper
 
 open System
@@ -88,7 +88,7 @@ type xpkgParams =
 
 /// Creates xpkg default parameters
 let XpkgDefaults() = 
-    { ToolPath = findToolInSubPath "xpkg.exe" (currentDirectory @@ "tools" @@ "xpkg")
+    { ToolPath = findToolInSubPath "xamarin-component.exe" (currentDirectory @@ "tools" @@ "xpkg")
       WorkingDir = "./"
       TimeOut = TimeSpan.FromMinutes 5.
       Package = null
@@ -135,8 +135,8 @@ let private getPackageFileName parameters = sprintf "%s-%s.xam" parameters.Packa
 ///                  Icons = ["./Xamarin/Portable.Licensing_512x512.png"
 ///                           "./Xamarin/Portable.Licensing_128x128.png"]
 ///                  Libraries = ["mobile", "./Distribution/lib/Portable.Licensing.dll"]
-///                  Samples = ["Android Sample.", "./Samples/Android/Android.Sample.sln"
-///                             "iOS Sample.", "./Samples/iOS/iOS.Sample.sln"]
+///                  Samples = ["Android Sample. Sample description.", "./Samples/Android/Android.Sample.sln"
+///                             "iOS Sample. Sample description.", "./Samples/iOS/iOS.Sample.sln"]
 ///              }
 ///          )
 ///      )


### PR DESCRIPTION
**DO NOT MERGE** (just yet; see below)

The xpkg helper no longer works with the newer xamarin-component.exe tool:
- The `create` command which was used merely creates a skeleton but cannot be used to actually create a component package (`create-manually` must be used instead).
- Support for additional arguments
- Inline doc of the parameter type

Even though the previous implementation does not work with the xamarin-component.exe tool, it must have worked at some point (or it would not be as it was). While the new arguments do not have any effect if not provided, the change from create to create-manually could break old scripts.

Options:
- A) Keep the old `xpkgPack` as it was with `create` an add a new function that uses `create-manually`
- B) Add another property to the `xpkgParams`. If present, use `create-manually`, else `create`.
- C) Create an independent helper specifically for xamarin-component and leave xpkg as it was.
- D) Try to detect tool version automatically (probably not a good idea)
- E) Drop support for the old tools (I suspect Xamarin will reject packages created with the old tool at some point)
- F) ?

What would be the preferred way to deal with this, so we do not break anything?

See also:
- https://components.xamarin.com/guidelines
- http://forums.xamarin.com/discussion/11524
- https://github.com/xamarin/component-template
- Help output of `xamarin-component.exe help create-manually`
