### PR TITLE
Support test settings in MSTest

### DIFF
--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -27,6 +27,8 @@ type MSTestParams =
       ResultsDir : string
       /// Path to the Test Metadata file (.vdmdi)  (optional)
       TestMetadataPath : string
+      /// Path to the Test Settings file (.testsettings)  (optional)
+      TestSettingsPath : string
       /// Working directory (optional)
       WorkingDir : string
       /// A timeout for the test runner (optional)
@@ -43,6 +45,7 @@ let MSTestDefaults =
     { Category = null
       ResultsDir = null
       TestMetadataPath = null
+      TestSettingsPath = null
       WorkingDir = null
       TimeOut = TimeSpan.FromMinutes 5.
       ToolPath = 
@@ -62,6 +65,8 @@ let buildMSTestArgs parameters assembly =
     new StringBuilder()
     |> appendIfNotNull assembly "/testcontainer:"
     |> appendIfNotNull parameters.Category "/category:"
+    |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
+    |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
     |> appendIfNotNull testResultsFile "/resultsfile:"
     |> appendIfTrue parameters.NoIsolation "/noisolation"
     |> toText


### PR DESCRIPTION
Not sure I'm missing something but FAKE doesn't seem to support MSTest test settings out of the box. I need it for specifying test settings in VFPT.

I added:
- `TestSettingsPath` which specifies paths to *.testsettings files
- the use of `TestMetadataPath` in `buildMSTestArgs` (I did Find All References and found that this field hasn't been used anywhere :-) )
