### PR TITLE
Let CreateCSharpAssemblyInfo work with as-yet-uncreated paths

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -98,6 +98,7 @@ type Attribute(name, value, inNamespace) =
 let private writeToFile outputFileName (lines : seq<string>) = 
     let fi = fileInfo outputFileName
     fi.Delete()
+    System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outputFileName)) |> ignore
     use writer = new System.IO.StreamWriter(outputFileName, false, System.Text.Encoding.UTF8)
     lines |> Seq.iter writer.WriteLine
     tracefn "Created AssemblyInfo file \"%s\"." outputFileName


### PR DESCRIPTION
If some directories in the path of the desired AssemblyInfo's path are missing, create the missing directory/directories.

This lets you put AssemblyInfo files where C# projects like the - in MyApp/Properties/ - without having to manually create the directory.
