### PR TITLE
fake.exe --break

### DIFF
--- a/src/app/FAKE/Cli.fs
+++ b/src/app/FAKE/Cli.fs
@@ -15,6 +15,7 @@ type FakeArg =
     | [<AltCommandLine("-v")>] Version
     | [<Rest>] [<AltCommandLine("-fa")>] FsiArgs of string
     | [<AltCommandLine("-b")>] [<Rest>] Boot of string
+    | [<AltCommandLine("-br")>] Break
     interface IArgParserTemplate with
         member x.Usage = 
             match x with
@@ -25,6 +26,7 @@ type FakeArg =
             | FsiArgs _ -> "Pass args after this switch to FSI when running the build script."
             | Version _ -> "Print FAKE version information."
             | Boot _ -> "Boostrapp your FAKE script."
+            | Break _ -> "Pauses FAKE with a Debugger.Break() near the start"
 
 /// Return the parsed FAKE args or the parse exception.
 let parsedArgsOrEx args = 

--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -53,6 +53,9 @@ try
 
         //We have new style help args!
         | Choice1Of2(fakeArgs) ->
+            
+            //Break to allow a debugger to be attached here
+            if fakeArgs.Contains <@ Cli.Break @> then Diagnostics.Debugger.Break()
 
             //Boot and version force us to ignore other args, so check for them and handle.
             let isBoot, bootArgs = fakeArgs.Contains <@ Cli.Boot @>, fakeArgs.GetResults <@ Cli.Boot @>


### PR DESCRIPTION
I mentioned in #480 that it would be nice if I could attach a debugger near the start of execution. Here is the simple implementation. It is very useful for breaking when exceptions occur and then being able to troubleshoot.
