### PR TITLE
fixed traceStartTarget, should not be  before recursive call

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -311,11 +311,11 @@ let run targetName =
         try      
             if errors = [] && ExecutedTargets.Contains (toLower targetName) |> not then
                 let target = getTarget targetName      
-                traceStartTarget target.Name target.Description (dependencyString target)
       
                 List.iter runTarget target.Dependencies
       
                 if errors = [] then
+                    traceStartTarget target.Name target.Description (dependencyString target)
                     let watch = new System.Diagnostics.Stopwatch()
                     watch.Start()
                     target.Function()


### PR DESCRIPTION
For [SourceLink#11](https://github.com/ctaggart/SourceLink/issues/11#issuecomment-46180314) I was expecting there to only be one open target at a time. The problem was that `traceStartTarget` was being called before the recursive call. If it is put just before the `watch`, it behaves as expected.
