### PR TITLE
Check if AssemblyInfo file exists before deletion

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -100,7 +100,7 @@ type Attribute(name, value, inNamespace) =
 
 let private writeToFile outputFileName (lines : seq<string>) = 
     let fi = fileInfo outputFileName
-    fi.Delete()
+    if fi.Exists then fi.Delete()
     System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(outputFileName)) |> ignore
     use writer = new System.IO.StreamWriter(outputFileName, false, System.Text.Encoding.UTF8)
     lines |> Seq.iter writer.WriteLine


### PR DESCRIPTION
AssemblyInfoFile.writeFile did not check if the assembly info file existed before calling delete.
