### PR TITLE
Add custom dictionary support to FxCop

### DIFF
--- a/src/app/FakeLib/FXCopHelper.fs
+++ b/src/app/FakeLib/FXCopHelper.fs
@@ -42,7 +42,8 @@ type FxCopParams =
       FailOnError : FxCopErrorLevel
       TimeOut : TimeSpan
       ToolPath : string
-      ForceOutput : bool }
+      ForceOutput : bool
+      CustomDictionary : string }
 
 /// This checks the result file with some XML queries for errors
 /// [omit]
@@ -80,7 +81,8 @@ let FxCopDefaults =
       FailOnError = FxCopErrorLevel.DontFailBuild
       TimeOut = TimeSpan.FromMinutes 5.
       ToolPath = ProgramFilesX86 @@ @"Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\FxCopCmd.exe"
-      ForceOutput = false }
+      ForceOutput = false
+      CustomDictionary = String.Empty }
 
 /// Run FxCop on a group of assemblies.
 let FxCop setParams (assemblies : string seq) = 
@@ -122,6 +124,7 @@ let FxCop setParams (assemblies : string seq) =
         append param.SaveResultsInProjectFile "/u "
         append param.Verbose "/v "
         append param.UseGACSwitch "/gac "
+        appendFormat "/dic:\"{0}\" " param.CustomDictionary
         (!args).ToString()
     
     tracefn "FxCop command\n%s %s" param.ToolPath commandLineCommands


### PR DESCRIPTION
It's not a misspelling, if I say so.

On a related note I have this:

```
let GetProjectCodeAnalysisDictionary projectFile =
  XMLRead true projectFile msbuildNamespace "msbuild" ("msbuild:Project/msbuild:ItemGroup/msbuild:CodeAnalysisDictionary/@Include")
    |> Seq.head
```

To extract, from my Visual Studio project the file that is my custom dictionary. Not sure where this might belong but I'd be happy to put it there if you have an idea.
