### PR TITLE
ProcessHelper.findExecutableInPath

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -468,6 +468,17 @@ let ensureProcessesHaveStopped name timeout =
 /// [omit]
 let shellExec args = args |> asyncShellExec |> Async.RunSynchronously
 
+/// Tries to find the given file within the current directory or in
+/// one of the paths in the PATH environment variable. If successful
+/// it returns the full path to the file.
+/// ## Parameters
+///  - `exe` - The executable file to locate
+let findExecutableInPath (exe:String) =
+    Environment.GetEnvironmentVariable("PATH").Split([| Path.PathSeparator |])
+    |> Seq.append ["."]
+    |> Seq.map (fun p -> p @@ exe)
+    |> Seq.tryFind (File.Exists)
+
 /// Allows to exec shell operations synchronously and asynchronously.
 type Shell() = 
     


### PR DESCRIPTION
Attempts to locate an executable file normally run from the command line.
Will search the current directory, then the paths in the PATH environment variable.
**Caution: no automated tests. If this is something useful for FAKE please review carefully before merging. :)**

This is an attempt to deal [porting scripts that shell out to the command line](http://stackoverflow.com/q/24543048/906).

Here is an [example of using it](https://github.com/dtchepak/NSubstitute/blob/0f45567df3adde18124bb5ef8969824015b21f5e/build.fsx#L131) to shell out to `bundle exec jekyll docs`.
