### PR TITLE
FscHelper: separate `fsc` function with exit code, &c.

### DIFF
--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -5,6 +5,7 @@ let private scs =
 
 /// 'fsc.exe' output target types
 type FscTarget = Exe | Winexe | Library | Module
+/// 'fsc.exe' output platforms
 type FscPlatform = X86 | Itanium | X64 | AnyCpu32BitPreferred | AnyCpu
 
 /// 'fsc.exe' command line parameters
@@ -22,8 +23,8 @@ type FscParams =
     /// Specifies other params for the compilation. Freeform strings.
     OtherParams: string list }
 
-let FscDefaultParams =    
-    // These are the default params to the compiler service.
+  /// The default parameters to the compiler service.
+  static member Default =
     { Output = ""
       FscTarget = Exe
       Platform = AnyCpu
@@ -37,7 +38,7 @@ let FscDefaultParams =
 ///
 /// Example usage:
 /// Target "MyFile" (fun _ ->
-///   fsc ["MyFile.fs"] ["-a"; "-r"; "Common.dll"])
+///   fscList ["MyFile.fs"] ["-a"; "-r"; "Common.dll"])
 let fscList (srcFiles: string list) (opts: string list): int =
   let optsArr =
     // If output file name is specified, pass it on to fsc.
@@ -55,24 +56,31 @@ let fscList (srcFiles: string list) (opts: string list): int =
     |> Array.ofList
   let errors, exitCode = scs.Compile(optsArr)
 
-  errors |> Seq.iter (fun (e: Microsoft.FSharp.Compiler.ErrorInfo) ->
-    traceError e.Message)
+  // Better compile reporting thanks to:
+  // https://github.com/jbtule/ComposableExtensions/blob/5b961b30668bb7f4d17238770869b5a884bc591f/tools/CompilerHelper.fsx#L233
+  for e in errors do
+    let errMsg = e.ToString()
+    match e.Severity with
+    | Microsoft.FSharp.Compiler.Warning -> traceImportant errMsg
+    | Microsoft.FSharp.Compiler.Error -> traceError errMsg
+
   exitCode
 
 /// Compiles one or more F# source files with the specified parameters.
 /// Can be called as:
 ///
-/// Fsc (fun params ->
-///   { params with
-///     Inputs = ...
-///     Output = ...
-///     FscTarget = ...
-///     ... })
-///   ["file1.fsx"; "file2.fsx"]
-let Fsc (fscParamSetter: FscParams -> FscParams) inputFiles =
+/// ["file1.fs"; "file2.fs"]
+/// |> fsc (fun parameters ->
+///   { parameters with Output = ...
+///                     FscTarget = ...
+///                     ... })
+///
+/// Returns the exit code of the compile run.
+let fsc
+  (fscParamSetter: FscParams -> FscParams)
+  (inputFiles: string list): int =
   let inputFiles = inputFiles |> Seq.toList
-  traceStartTask "Fsc " (inputFiles |> separated ", ")
-  let fscParams = fscParamSetter FscDefaultParams
+  let fscParams = fscParamSetter FscParams.Default
   let output = fscParams.Output
   let argList =
     if output <> "" then ["-o"; output] else []
@@ -91,5 +99,28 @@ let Fsc (fscParamSetter: FscParams -> FscParams) inputFiles =
     @ if fscParams.Debug then ["-g"] else []
     @ fscParams.OtherParams
     
-  fscList inputFiles argList |> ignore
+  traceStartTask "Fsc " (inputFiles |> separated ", ")
+  let res = fscList inputFiles argList
   traceEndTask "Fsc " (inputFiles |> separated ", ")
+  res
+
+/// Compiles one or more F# source files with the specified parameters.
+/// Can be called as:
+///
+/// ["file1.fs"; "file2.fs"]
+/// |> Fsc (fun parameters ->
+///   { parameters with Output = ...
+///                     FscTarget = ...
+///                     ... })
+let Fsc
+  (fscParamSetter: FscParams -> FscParams)
+  (inputFiles: string list): unit =
+  let res = fsc fscParamSetter inputFiles
+
+  if res <> 0
+    then
+      raise
+        (Fake.MSBuildHelper.BuildException(
+            "Fsc: compile failed with exit code"
+          , [string res]))
+  ()


### PR DESCRIPTION
FscHelper: separate `fsc` function with exit code, &c.

This commit contains several small-ish changes. In order of appearance:
- Use an `FscParams.Default` static member instead of a free variable,
  to express the tight coupling of the defaults with the type itself.
- Print compile errors and warnings with the appropriate `trace...`
  functions.
- Return an exit code from the `fsc` function as I intend to use it to
  help implement incremental build logic. The `Fsc` function
  (uppercase 'F') still doesn't return anything so it can continue to
  be used in the existing framework.

The `Fsc` call syntax looks very similar to what was originally proposed
in #235.
