### PR TITLE
ProcessHelper.tryFindFileOnPath

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -329,6 +329,16 @@ let findFile dirs file =
     | Some found -> found
     | None -> failwithf "%s not found in %A." file dirs
 
+/// Searches the current directory and the directories within the PATH
+/// environment variable for the given file. If successful returns the full
+/// path to the file.
+/// ## Parameters
+///  - `exe` - The executable file to locate
+let tryFindFileOnPath (file : string) : string option =
+    Environment.GetEnvironmentVariable("PATH").Split([| Path.PathSeparator |])
+    |> Seq.append ["."]
+    |> fun path -> tryFindFile path file
+
 /// Returns the AppSettings for the key - Splitted on ;
 /// [omit]
 let appSettings (key : string) (fallbackValue : string) = 


### PR DESCRIPTION
Redoing #490 to use existing `tryFindFile` method. This is an attempt to help [port scripts that shell out to the command line](http://stackoverflow.com/q/24543048/906).

Any suggestions on how to test this? 
# 

Searches the current directory and the directories in the PATH
  environment variable for the given file.

Aims to replicate executing a command directly from the command line, where
  both the current directory and PATH are normally searched.
