### PR TITLE
Update SpecFlowHelper to search for tools folder

### DIFF
--- a/src/app/FakeLib/SpecFlowHelper.fs
+++ b/src/app/FakeLib/SpecFlowHelper.fs
@@ -22,12 +22,14 @@ type SpecFlowParams = {
     XsltFile:           string
 }
 
+let toolname = "specflow.exe"
+
 /// SpecFlow default execution parameters.
 let SpecFlowDefaults = { 
     SubCommand =        "generateall"
     ProjectFile =       null
-    ToolName =          "specflow.exe"
-    ToolPath =          findToolFolderInSubPath ToolName (currentDirectory @@ "tools" @@ "SpecFlow")
+    ToolName =          toolname
+    ToolPath =          findToolFolderInSubPath toolname (currentDirectory @@ "tools" @@ "SpecFlow")
     WorkingDir =        null
     BinFolder =         null
     OutputFile =        null


### PR DESCRIPTION
Changed default SpecFlowHelper ToolPath to search sub folders for the correct tools directory so you don't have to change this for each new version of SpecFlow.  Works same as NUnit.
