### PR TITLE
ReFake: an incremental build logic DSL

### DIFF
--- a/help/refake.md
+++ b/help/refake.md
@@ -1,0 +1,151 @@
+# ReFake - a DSL for Specifying Incremental Builds in FAKE
+
+ReFake is a domain-specific language (DSL) for telling FAKE how to do
+incremental builds natively, without using any other build tool (like
+MSBuild or `xbuild`).
+
+ReFake will build only those parts of the project that are absolutely
+necessary. All the logic for this is built into the FAKE library, so you
+can specify _everything_ in F# instead of XML configuration files or
+whatever.
+
+The idea behind ReFake is exactly the same as the one behind `make`,
+with which you're probably already familiar. To illustrate, let me use a
+simple example 'makefile':
+
+    myapp.dll: myapp.fs
+      fsc -o myapp.dll -a myapp.fs
+
+    myapp.exe: myapp.dll main.fs
+      fsc -o myapp.exe -r myapp.dll main.fs
+
+Here's a direct translation of this simple makefile into ReFake format:
+
+    #r "/path/to/FakeLib.dll"
+    open Fake.FscHelper
+    open Fake.ReFake
+
+    let myapp_dll =
+      rx' "myapp.dll" [fx "myapp.fs"] (fun name dependencies ->
+        fxs dependencies // A list of source files.
+        // Pipeline into the 'fsc' function with the following
+        // parameters.
+        |> fsc (fun parameters ->
+          { parameters with Output = name
+                            FscTarget = Library }))
+
+    let myapp_exe =
+      fx' "myapp.exe" [myapp_dll; fx "main.fs"] (fun name deps ->
+        fxs deps // A list of source files.
+        // Pipeline into the 'fsc' function with the following
+        // parameters.
+        |> fsc (fun ps ->
+          { ps with References = rxs deps // A list of references.
+                    Output = name }))
+
+    reRunAndExit myapp_exe
+
+## Explanation
+
+Here's an explanation of each important part of the ReFake script:
+
+  - The script starts with a reference to the FAKE library, as usual. It
+    then uses two modules designed to work together to implement the
+    ReFake format.
+
+  - In the makefile, each 'paragraph' is dedicated to building one
+    artifact, a single file (i.e. `myapp.dll` or `myapp.exe`). In the
+    ReFake script, each paragraph serves the same purpose, but we
+    explicitly define what we call 'targets' and capture their
+    definitions in the names `myapp_dll` and `myapp_exe`. The names are
+    arbitrary; you can have whatever you like according to standard F#
+    naming rules.
+
+  - The targets are defined using helper functions. The first one,
+    `myapp_dll`, is defined using the `rx'` function. The second one
+    uses the `fx'` function. These functions allow us to define targets
+    while also specifying how they should be built. The difference
+    between them is, the `rx'` function defines a 'reference' target,
+    that is a target that will be used as a reference by the compiler
+    (i.e., passed in to another compile with the `--reference` switch).
+    The `fx'` function defines a 'file' target, which will simply be an
+    output file, like an executable.
+
+  - There are two other corresponding helper functions, `fx` and `rx`,
+    which let you create targets that _don't_ have any dependencies, and
+    _don't_ specify how to build the files. In other words, you use them
+    when you want to say that those files are not outputs of some build
+    process, but rather _inputs_ to a build process. For example, you'd
+    use `fx` to wrap up an F# source file as a target (as done above),
+    and `rx` to wrap up a third-party library which you don't compile,
+    but just download and use in your project.
+
+  - Each of the helper functions `rx'`, `fx'`, and `vx` (which I'll
+    discuss later) allows us to specify three things: (1) the name of
+    the target; (2) the dependencies of the target; and (3) how to
+    actually go about building the target. You'll notice this is exactly
+    the same way a makefile works.
+
+  - For the `rx'`, `fx'`, `rx` and `fx` functions, the name should be
+    the name of the target file. For the `vx` function, the name is
+    simply descriptive.
+
+  - The dependencies of the target are a list of previously-defined
+    targets, or simple source files wrapped in the `fx` function (which
+    turns them into targets, as described above).
+
+  - The target builder function (`fun name deps -> ...`) takes the
+    output name and the list of dependencies and lets you specify what
+    steps to take to actually build the output. It also needs you to
+    return an integer status code in the style of a command-line exit
+    status code: 0 for success, anything else for failure. Usually
+    you'll be calling the `fsc` function inside the builder function.
+    `fsc` will return a status code.
+
+  - The `fsc` function takes two arguments: (1) a function that lets you
+    specify parameters for the compile, and (2) a list of input source
+    files to compile. ReFake provides you with helper functions to
+    easily pass along input source files and reference files to the
+    `fsc` function. Since you define input files and references using
+    the `fx`, `fx'`, `rx`, and `rx'` functions, you can use the
+    corresponding `fxs` and `rxs` functions to extract a list of input
+    files and reference files from the dependency list.
+
+    The `fsc` function lets you specify all F# compile parameters. To
+    learn more, look up the [tutorial](./fsc.html) and the [API
+    reference](apidocs/fake-fschelper.html).
+
+  - Finally, the `reRunAndExit` function lets you run any target (i.e.,
+    incrementally build the target) and immediately after finishing the
+    run, exits the script with the exit code returned by the run. If
+    there are any compile errors, the exit code will be set properly.
+    You can also use the `reRun` function if you want to run a target
+    without immediately exiting the script.
+
+## Virtual Targets
+
+I haven't talked much about _virtual_ targets so far, but you can
+probably guess what they are:
+
+    let build = vx "Build" [myapp_exe] nop
+    reRunAndExit build
+
+A virtual target is one that doesn't specify any output file, but still
+depends on other targets. The unique feature of a virtual target is that
+it always requires its dependencies to be built. If all its dependencies
+are up-to-date (if the `myapp.exe` file is up-to-date in the above
+example), then nothing further will happen. But if it's out of date, it
+will be rebuilt.
+
+The `nop` function is a 'no-op', that is it successfully returns without
+doing anything. If you pass in your own defined function with tasks
+instead of the `nop` function, you can use virtual targets to clean your
+project directory, deploy a website, set configuration parameters for a
+build, and do many other useful tasks.
+
+## Conclusion
+
+With the F# compile task and an incremental build script written in
+ReFake, you can start developing F# straightaway, without the need for
+any IDE, build tool, or complex XML build specs. Everything stays in F#.
+

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -137,6 +137,7 @@
     <Compile Include="RoundhouseHelper.fs" />
     <Compile Include="FscHelper.fs" />
     <None Include="app.config" />
+    <Compile Include="ReFake.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Compiler.Service">

--- a/src/app/FakeLib/ReFake.fs
+++ b/src/app/FakeLib/ReFake.fs
@@ -1,0 +1,185 @@
+﻿module Fake.ReFake
+
+/// Types of ReTargets. They can be 'virtual', 'file', or 'reference'.
+type ReTargetType = Vx | Fx | Rx
+/// Type that represents an action that's carried out to build a target.
+/// It takes the name of the target, which may be a file name; a list of
+/// the target's dependencies, which may be empty; and returns the exit
+/// status code of the action.
+type BuildAction = string -> ReTarget list -> int
+/// Type that represents a ReFake target.
+and ReTarget =
+  { /// The target type
+    ReTargetType: ReTargetType
+    /// The name of the target. If target type is virtual, this is just
+    /// descriptive. Otherwise it's the name of the output file that
+    /// will be built.
+    Name: string
+    /// Other targets that this target depends on. The entire
+    /// dependency tree for a target is captured within the target
+    /// itself. If the list is empty, the target doesn't have any
+    /// dependencies and is at the lowest level in the tree.
+    Dependencies: ReTarget list
+    /// The build action that will be carried out for the target to be
+    /// built.
+    Action: BuildAction }
+
+let private targetInfoFunc typ name deps action =
+  { ReTargetType = typ
+    Name = name
+    Dependencies = deps
+    Action = action }
+
+/// An empty build action that always succeeds.
+let nop _ _ = 0
+
+/// A reference file with no dependencies and no build action. This
+/// will usually be a pre-built library that your project depends on.
+///
+/// ## Parameters
+///
+/// - `name`: the name of the reference DLL.
+///
+/// ## Returns
+///
+/// The DLL file wrapped up as a reference 'target'.
+let rx (name: string): ReTarget = targetInfoFunc Rx name [] nop
+
+/// A helper function to create a 'reference' target, one that will be
+/// passed in as a reference to an F# compile.
+///
+/// ## Parameters
+///
+/// - `name`: the name of the reference target. This will usually become
+///   the DLL file name.
+/// - `deps`: a list of targets that _this_ target will depend on.
+/// - `action`: a function to run to build this target.
+///
+/// ## Returns
+///
+/// The reference target.
+let rx'
+  (name: string)
+  (deps: ReTarget list)
+  (action: BuildAction): ReTarget =
+  targetInfoFunc Rx name deps action
+
+/// A helper function to create a 'virtual' target. A virtual target
+/// has the property of always requiring its dependencies to be built.
+///
+/// ## Parameters
+///
+/// - `name`: the name of the virtual target. This is usually just for
+///   descriptive purposes.
+/// - `deps`: a list of targets that _this_ target will depend on.
+/// - `action`: a function to run to build this target.
+///
+/// ## Returns
+///
+/// The virtual target.
+let vx
+  (name: string)
+  (deps: ReTarget list)
+  (action: BuildAction): ReTarget =
+  targetInfoFunc Vx name deps action
+
+/// A source file with no dependencies and no build action. Lowest
+/// level of dependency that other targets can depend on.
+///
+/// ## Parameters
+///
+/// - `name`: the name of the reference target. This is the name of the
+///   source file.
+///
+/// ## Returns
+///
+/// The source file wrapped up as a file 'target'.
+let fx (name: string): ReTarget = targetInfoFunc Fx name [] nop
+
+/// A file target with dependencies and a build action, like an
+/// executable output file. A slightly more inconvenient name because
+/// this function will probably be used less often than `fx`.
+///
+/// ## Parameters
+///
+/// - `name`: the name of the file target. This will usually become the
+///   name of the output file.
+/// - `deps`: a list of targets that _this_ target will depend on.
+/// - `action`: a function to run to build this target.
+///
+/// ## Returns
+///
+/// The file target.
+let fx'
+  (name: string)
+  (deps: ReTarget list)
+  (action: BuildAction): ReTarget =
+  targetInfoFunc Fx name deps action
+
+// Returns a list of the names of the targets.
+let private targetsOfType typ =
+  List.filter (fun dep -> dep.ReTargetType = typ)
+    >> List.map (fun dep -> dep.Name)
+
+/// Returns a list of names of all virtual targets in `targets`.
+let vxs (targets: ReTarget list): string list = targetsOfType Vx targets
+/// Returns a list of names of all file targets in `targets`.
+let fxs (targets: ReTarget list): string list = targetsOfType Fx targets
+/// Returns a list of names of all reference targets in `targets`.
+let rxs (targets: ReTarget list): string list = targetsOfType Rx targets
+
+/// Do an incremental build.
+///
+/// ## Parameters
+///
+/// - `target`: the target to incrementally build.
+///
+/// ## Returns
+///
+/// The exit status code of the compile run.
+let rec reRun (target: ReTarget): int =
+  let name = target.Name
+  let deps = target.Dependencies
+  let action = target.Action
+
+  let reRunDepsAndBuild () =
+    for dep in deps do reRun dep |> ignore
+    trace ("ReFake: Building " + name)
+    let res = action name deps
+    // Exit as soon as possible if anything is wrong.
+    if res <> 0 then exit res
+    res
+
+  // This does a depth-first traversal of the target's dependency
+  // tree, building anything that doesn't exist or was modified.
+  match target.ReTargetType with
+  | Vx -> reRunDepsAndBuild ()
+  | Fx | Rx ->
+    // If there are no 'virtual' dependencies, we have a chance to skip
+    // this build step.
+    if deps |> vxs |> List.isEmpty
+      then
+        let targetInfo = System.IO.FileInfo(name)
+
+        if not targetInfo.Exists
+          then reRunDepsAndBuild ()
+          else
+            // LaterDeps is a list of all the dependencies which either
+            // don't exist or were modified after the target file.
+            let laterDeps =
+              deps |> List.filter (fun dep ->
+                let depInfo = System.IO.FileInfo(dep.Name)
+                (not depInfo.Exists)
+                  || (depInfo.LastWriteTime > targetInfo.LastWriteTime))
+
+            // No dependencies modified after the target file.
+            if laterDeps.IsEmpty
+              then 0 // No build necessary.
+              // Rebuild everything that's necessary.
+              else reRunDepsAndBuild ()
+      // If there are 'virtual' dependencies we need to build all of them.
+      else reRunDepsAndBuild ()
+
+/// Same as reRun, but immediately exit with the status code returned by
+/// the compile process.
+let reRunAndExit (target: ReTarget): 'T = reRun target |> exit


### PR DESCRIPTION
My effort at creating an incremental build DSL on top of FAKE. For several reasons, as explained in the commit message, I did this by creating a new type of build 'target' that stores more information about the target and its dependencies. The implementation is as simple as possible; there are no lookups of target names to objects happening in the background. The build script writer directly creates target objects using the helper functions, and arranges them into a dependency network at the same time. They then run the topmost target in the network to lazily build whatever needs to be built.

This also allows a pretty elegant way of setting up multiple build configurations in the same script using what I call 'virtual targets'. A simple example:

    #r "/path/to/FakeLib.dll"
    open Fake.FscHelper
    open Fake.ReFake
    
    // Debug configuration is default.
    let debug = ref true
    let outputPath = ref "bin/Debug/"
    let optimize = ref "--optimize-"
    
    // A virtual target that sets up a release configuration and doesn't have any dependencies.
    let releaseConfig = vx "Release Configuration" [] (fun _ _ ->
      debug := false
      outputPath := "../../../build/"
      optimize := "--optimize+"
      0) // Need to return an exit code from build function

    // A file target that depends on 'Main.fs'.
    let Main_exe = fx' "Main.exe" [fx "Main.fs"] (fun name deps ->
      fxs deps // Gets list of names of input files.
      |> fsc (fun ps -> // 'fsc' automatically returns exit code.
        { ps with Output = !outputPath + name
                  Debug = !debug
                  OtherParams = [!optimize] }))

    // A virtual target that depends on 'Main.exe'.
    let debugBuild = vx "Debug Build" [Main_exe] nop
    // A virtual target that depends on 'releaseConfig' _and_ 'Main.exe' (list order matters).
    let releaseBuild = vx "Release Build" [releaseConfig; Main_exe] nop

    reRunAndExit debugBuild
    //reRunAndExit releaseBuild

Because the `releaseConfig` target is a dependency of the `releaseBuild` target, it will always be run before `releaseBuild`; and will thus set up the release parameters.

I'm currently trying to convert the `FakeLib.fsproj` file into a ReFake build script, and am about 80% there. Just ironing out a few referencing issues now.

This is a first effort, so I'd welcome feedback.

Relates to issue #235.