### PR TITLE
NuGet: support fallback framework groups

### DIFF
--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -116,16 +116,18 @@ let private createNuspecFile parameters nuSpec =
                    |> FullName
     tracefn "Creating .nuspec file at %s" specFile
     fi.CopyTo(specFile, true) |> ignore
-    let getFrameworkGroup (frameworkTags : (string * string) seq) = 
+
+    let getFrameworkGroup (frameworkTags : (string * string) seq) =
         frameworkTags
-        |> Seq.map 
-               (fun (frameworkVersion, tags) -> sprintf "<group targetFramework=\"%s\">%s</group>" frameworkVersion tags)
+        |> Seq.map (fun (frameworkVersion, tags) ->
+                    if isNullOrEmpty frameworkVersion then sprintf "<group>%s</group>" tags
+                    else sprintf "<group targetFramework=\"%s\">%s</group>" frameworkVersion tags)
         |> toLines
-    
-    let getGroup items toTags = 
+
+    let getGroup items toTags =
         if items = [] then ""
         else sprintf "<group>%s</group>" (items |> toTags)
-    
+
     let getReferencesTags references = 
         references
         |> Seq.map (fun assembly -> sprintf "<reference file=\"%s\" />" assembly)


### PR DESCRIPTION
Since NuGet 2.0, dependencies and references can be specified by target
framework, where only the entries from the matching group are considered.
NuGet also allows defining a fallback group where the targetFramework is
missing, which is used if none of the other groups match.

Previously FAKE did emit the empty targetFramework attribute, which causes
NuGet to complain. This change skips the attribute if its value is null
or empty, in compliance with the nuget specs.
