### PR TITLE
Update SemVerHelper.fs

### DIFF
--- a/src/app/FakeLib/SemVerHelper.fs
+++ b/src/app/FakeLib/SemVerHelper.fs
@@ -8,9 +8,9 @@ open System.Text.RegularExpressions
 type PreRelease = 
     { Origin: string
       Name: string
-      Number: int option }
+      Number: string option }
     static member TryParse str = 
-        let m = Regex("^(?<name>[a-zA-Z]+)(?<number>\d*)$").Match(str)
+        let m = Regex("^(?<name>[a-zA-Z]+)(?<number>[0-9A-Za-z-]+)$").Match(str)
         match m.Success, m.Groups.["name"].Value, m.Groups.["number"].Value with
         | true, name, "" -> Some { Origin = str; Name = name; Number = None }
         | true, name, number -> Some { Origin = str; Name = name; Number = Some (int number) }


### PR DESCRIPTION
Changes for #522: SemVerHelper.PreRelease.TryParse cannot parse valid nuget pre-release identifiers
Make number string option
Change regex accordingly.
No tests found:
Tested via fsi.exe:
val x : PreRelease option = Some {Origin = "dev20140819130924";
                                  Name = "dev";
                                  Number = Some "20140819130924";}

> let x = PreRelease.TryParse("dev-2014-08-19T130924");;

val x : PreRelease option = Some {Origin = "dev-2014-08-19T130924";
                                  Name = "dev";
                                  Number = Some "-2014-08-19T130924";}
