### PR TITLE
Add support for MSBuild Distributed Loggers

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -248,8 +248,8 @@ let serializeMSBuildParams (p : MSBuildParams) =
                 (match dlogger.Parameters with 
                     | None -> "" 
                     | Some vars -> vars 
-                                    |> List.fold (fun acc (k,v) -> sprintf "%s%s=%s," acc k v) ""
-                                    |> sprintf ";\"%s;\""
+                                    |> List.fold (fun acc (k,v) -> sprintf "%s%s=%s;" acc k v) ""
+                                    |> sprintf ";\"%s\""
                 )
 
         let createLoggerString cl fl =

--- a/src/test/testscripts/test1.fsx
+++ b/src/test/testscripts/test1.fsx
@@ -10,10 +10,34 @@ Target "blah" (fun _ ->
     }
     
     let nameConfig = {simpleConfig with ClassName = Some "simpleClass"}
-    let simpleWithParams = {simpleConfig with Parameters = Some [("Verbosity", "High")]}
+    let simpleWithParams = {simpleConfig with Parameters = Some [("Verbosity", "High"); ("dupe2", "wat");]}
     let fullConfig = {simpleConfig with 
                         ClassName = nameConfig.ClassName 
                         Parameters = simpleWithParams.Parameters}
+
+    let wcl = Some [
+                    {
+                        ClassName = Some "WorkflowCentralLogger"
+                        AssemblyPath = "C:\Program Files\Microsoft Team Foundation Server 12.0\Tools\Microsoft.TeamFoundation.Build.Server.Logger.dll"
+                        Parameters =
+                            Some [
+                                "Verbosity", "Normal"
+                                "BuildUri", "vstfs:///Build/Build/364"
+                                "IgnoreDuplicateProjects", "False"
+                                "InformationNodeId", sprintf "%d" 8
+                                "TargetsNotLogged", "GetNativeManifest,GetCopyToOutputDirectoryItems,GetTargetPath"
+                                "TFSUrl", "https://ctaggart.visualstudio.com/DefaultCollection"
+                            ]
+                    }, 
+                    Some {
+                        ClassName = Some "WorkflowForwardingLogger"
+                        AssemblyPath = "C:\Program Files\Microsoft Team Foundation Server 12.0\Tools\Microsoft.TeamFoundation.Build.Server.Logger.dll"
+                        Parameters =
+                            Some [
+                                "Verbosity", "Normal"
+                            ]
+                    }
+                ]
 
     let simpleRun = 
         [simpleConfig; nameConfig; simpleWithParams; fullConfig]
@@ -22,8 +46,8 @@ Target "blah" (fun _ ->
         [simpleConfig; nameConfig; simpleWithParams; fullConfig]
         |> List.map (fun x -> (x, Some fullConfig))
 
-    simpleRun @ complexRun
-    |> List.map (fun x -> {MSBuildDefaults with DistributedLoggers = Some [x; x]})
+    [wcl]
+    |> List.map (fun x -> {MSBuildDefaults with DistributedLoggers = x})
     |> List.map MSBuildHelper.serializeMSBuildParams
     |> List.iter (logfn "%s")
 )


### PR DESCRIPTION
MsBuild allows for the configuration of distributed loggers to allow build tasks to be farmed out to agents and the logs of those agents to be collected by some central logger.  This pull request adds support for configuring these loggers via FAKE, mimicing the existing FileLogger configuration.

This pull request will allow for all TFS Builds to receive good, detailed logs for FAKE builds, while allowing the configuration of those logs to be a part of the overall product.

This also happens to bring us to feature parity with PSake in this regard.

@ctaggart and I have been testing this today with some builds of Sourcelink to great success, and adding this support to FAKE would close an issue he's been tracking in that project as well.
