### PR TITLE
Roundhouse Cleanup

### DIFF
--- a/src/app/FakeLib/RoundhouseHelper.fs
+++ b/src/app/FakeLib/RoundhouseHelper.fs
@@ -154,25 +154,28 @@ let RoundhouseDefaults = {
 let private getStringParam k (v : string)=
     match isNullOrEmpty v with
     | true -> None
-    | false -> Some (k, v)
+    | false -> Some (k, sprintf "\"%s\"" v) //string escape
 
-let getBoolParam k (v : bool) =
+let private getBoolParam k (v : bool) =
     match v with
     | true -> Some (k, String.Empty)
     | false -> None
 
-let getIntParam k (v : int) =
+let private getIntParam k (v : int) =
     Some(k, v.ToString())
 
-let private serializeArgs args =
+let private formatArgs args pre split delim =
     args
+    |> Seq.filter Option.isSome
     |> Seq.map (function 
            | None -> ""
            | Some(k, v) -> 
-               "/" + k + (if isNullOrEmpty v then ""
-                          else ":" + v))
-    |> separated " "
-    
+               pre + k + (if isNullOrEmpty v then ""
+                          else sprintf "%s%s" split v))
+    |> separated delim
+
+let private serializeArgs args =
+    formatArgs args "/" "=" " "   
 
 let private getParamPairs (rh: RoundhouseParams) =
     let dbName = getStringParam "d" rh.DatabaseName
@@ -181,6 +184,26 @@ let private getParamPairs (rh: RoundhouseParams) =
     let connString = getStringParam "cs" rh.ConnectionString
     let connStringAdmin = getStringParam "csa" rh.ConnectionStringAdmin
     let cmdTimeout = getIntParam "ct" rh.CommandTimeout
+    let cmdTimeoutAdmin = getIntParam "ct" rh.CommandTimeoutAdmin
+    let dbType = getStringParam "dt" rh.DatabaseType
+    let outPath = getStringParam "o" rh.OutputPath
+    let versionFile = getStringParam "vf" rh.VersionFile
+    let versionXPath = getStringParam "vx" rh.VersionXPath
+    let repoPath = getStringParam "r" rh.RepositoryPath
+    let env = getStringParam "env" rh.Environment
+    let customCreateScript = getStringParam "cds" rh.CustomCreateScript
+    let restoreFilePath = getStringParam "rfp" rh.RestoreFilePath
+    let alterFolderPath = getStringParam "ad" rh.AlterDatabaseFolderName
+    let runAfterOtherTimeFolderPath = getStringParam "ra" rh.RunAfterOtherAnyTimeScriptsFolderName
+    let runAfterCreateFolderPath = getStringParam "racd" rh.RunAfterCreateDatabaseFolderName
+    let runBeforeUpFolderPath = getStringParam "rb" rh.RunBeforeUpFolderName
+    let upFolderPath = getStringParam "u" rh.UpFolderName
+    let runFirstAfterUpdateFolderPath = getStringParam "rf" rh.RunFirstAfterUpdateFolderName
+    let funcFolderPath = getStringParam "fu" rh.FunctionsFolderName
+    let viewsFolderPath = getStringParam "vw" rh.ViewsFolderName
+    let sprocsFolderPath = getStringParam "sp" rh.SprocsFolderName
+    let indexFolderPath = getStringParam "ix" rh.IndexesFolderName
+    let permissionsFolderPath = getStringParam "p" rh.PermissionsFolderName
     let drop = getBoolParam "drop" rh.Drop
     let simple = getBoolParam "simple" rh.Simple
     let transaction = getBoolParam "t" rh.WithTransaction
@@ -188,6 +211,9 @@ let private getParamPairs (rh: RoundhouseParams) =
     let silent = getBoolParam "silent" rh.Silent
     let warn = getBoolParam "w" rh.WarnOnOneTimeScriptChanges
 
+    [dbName;sqlFilesDir;server;connString;connStringAdmin;cmdTimeout;cmdTimeoutAdmin;dbType;outPath;versionFile;versionXPath;repoPath;env;customCreateScript;restoreFilePath;alterFolderPath;
+    runAfterOtherTimeFolderPath;runAfterCreateFolderPath;runBeforeUpFolderPath;upFolderPath;runFirstAfterUpdateFolderPath;funcFolderPath;viewsFolderPath;sprocsFolderPath;indexFolderPath;
+    permissionsFolderPath;drop;simple;transaction;restore;silent;warn;]
 
 
 /// This task to can be used to run [RoundhousE](http://projectroundhouse.org/) for database migrations.
@@ -206,9 +232,6 @@ let private getParamPairs (rh: RoundhouseParams) =
 let Roundhouse setParams = 
     let parameters = setParams RoundhouseDefaults
 
-    
-
-    //let args = sprintf "/d=%s /f=%s /s=%s /cs=%s /csa=%s /ct=%i /cta=%i /dt=%s /o=%s /vf=%s /vx=%s /r=%s /env=%s /cds=%s /rfp=%s /ad=%s /ra=%s /racd=%s /rb=%s /u=%s /rf=%s /fu=%s /vw=%s /sp=%s /ix=%s /p=%s %s %s %s %s %s %s" parameters.DatabaseName parameters.SqlFilesDirectory parameters.ServerDatabase parameters.ConnectionString parameters.ConnectionStringAdmin parameters.CommandTimeout parameters.CommandTimeoutAdmin parameters.DatabaseType parameters.OutputPath parameters.VersionFile parameters.VersionXPath parameters.RepositoryPath parameters.Environment parameters.CustomCreateScript parameters.RestoreFilePath parameters.AlterDatabaseFolderName parameters.RunAfterOtherAnyTimeScriptsFolderName parameters.RunAfterCreateDatabaseFolderName parameters.RunBeforeUpFolderName parameters.UpFolderName parameters.RunFirstAfterUpdateFolderName parameters.FunctionsFolderName parameters.ViewsFolderName parameters.SprocsFolderName parameters.IndexesFolderName parameters.PermissionsFolderName drop simple transaction restore silent warn
     let args = parameters |> getParamPairs |> serializeArgs
 
     traceStartTask "Roundhouse" args


### PR DESCRIPTION
This pull request cleans up some of the command line calls generated by the roundhouse helper.  String values get quoted now, and args that have not been specified are no longer passed to the command line.

Further down the road, I'd like to unify some of the command-line arg creation stuff in the various helpers by using UnionArgParser some more, because as it stands now the MSBuild and Roundhouse helpers have these huge methods that are mostly boilerplate.
