### PR TITLE
User AppVeyor's build version instead of the build number

### DIFF
--- a/src/app/FakeLib/BuildServerHelper.fs
+++ b/src/app/FakeLib/BuildServerHelper.fs
@@ -46,7 +46,7 @@ let ccBuildLabel = environVar "CCNETLABEL"
 
 /// AppVeyor build number
 /// [omit]
-let appVeyorBuildNumber = environVar "APPVEYOR_BUILD_NUMBER"
+let appVeyorBuildVersion = environVar "APPVEYOR_BUILD_VERSION"
 
 /// The current build server
 let buildServer = 
@@ -54,7 +54,7 @@ let buildServer =
     elif not (isNullOrEmpty tcBuildNumber) then TeamCity
     elif not (isNullOrEmpty ccBuildLabel) then CCNet
     elif not (isNullOrEmpty travisBuildNumber) then Travis
-    elif not (isNullOrEmpty appVeyorBuildNumber) then AppVeyor
+    elif not (isNullOrEmpty appVeyorBuildVersion) then AppVeyor
     else LocalBuild
 
 /// The current build version as detected from the current build server.
@@ -65,7 +65,7 @@ let buildVersion =
     | TeamCity -> getVersion tcBuildNumber
     | CCNet -> getVersion ccBuildLabel
     | Travis -> getVersion travisBuildNumber
-    | AppVeyor -> getVersion appVeyorBuildNumber
+    | AppVeyor -> getVersion appVeyorBuildVersion
     | LocalBuild -> getVersion localBuildLabel
 
 /// Is true when the current build is a local build.


### PR DESCRIPTION
 for the variable buildVersion.
