### PR TITLE
fixes the include of Octokit.fsx in Paket build.fsx

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -1,3 +1,4 @@
+#I __SOURCE_DIRECTORY__
 #r @"../../../../../packages/Octokit/lib/net45/Octokit.dll"
 
 open Octokit


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/80104/4970961/97fafc44-688d-11e4-8b4f-ad1d80563303.png)

I do this in SourceLink.fsx files as well. https://github.com/ctaggart/SourceLink/blob/master/Fake/SourceLink.fsx#L5
