### PR TITLE
MSBuild\14.0\Bin

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -22,6 +22,7 @@ let msBuildExe =
     if isUnix then "xbuild"
     else
         let MSBuildPath = 
+            (ProgramFilesX86 @@ @"\MSBuild\14.0\Bin") + ";" +
             (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin") + ";" +
             (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin\amd64") + ";" + 
             @"c:\Windows\Microsoft.NET\Framework\v4.0.30319\;" + 


### PR DESCRIPTION
Here is the build path needed for MSBuild 14.0 that ships with Visual Studio 2015. I opted not to include the `amd64` path. Looking at the build path order for `12.0`, I don't see how its `amd64` would ever get loaded.
