### PR TITLE
fsc compilation fix

### DIFF
--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -61,6 +61,8 @@ let fscList (srcFiles : string list) (opts : string list) : int =
         |> Array.ofList
 
     trace <| sprintf "FSC with args:%A" optsArr
+    // Always prepend "fsc.exe" since fsc compiler skips the first argument
+    let optsArr = Array.append [|"fsc.exe"|] optsArr
     let errors, exitCode = scs.Compile(optsArr)
     // Better compile reporting thanks to:
     // https://github.com/jbtule/ComposableExtensions/blob/5b961b30668bb7f4d17238770869b5a884bc591f/tools/CompilerHelper.fsx#L233


### PR DESCRIPTION
Since Fsc always skips the first argument, it is important to use a dummy argument when calling a Compile function. Otherwise, following compiler options can be ignored. For example, the current version of FAKE always ignores Output parameter, because "-o" is the first argument that appears in optsArr (thus, it is ignored along with the second argument that specifies the output file name). For your [reference](https://github.com/fsharp/FSharp.Compiler.Service/blob/6637eec059597667fa33038a3b65978d73d32624/tests/service/FscTests.fs#L127), Fsc compiler test code also includes "fsc.exe" as the first argument when calling the Compile function.
