### PR TITLE
Build and deploy Azure web jobs

### DIFF
--- a/src/app/FakeLib/AzureWebJobs.fs
+++ b/src/app/FakeLib/AzureWebJobs.fs
@@ -1,0 +1,30 @@
+﻿/// Contains tasks to package and deploy [Azure Web Jobs](http://azure.microsoft.com/en-gb/documentation/articles/web-sites-create-web-jobs/) via the [Kudu](https://github.com/projectkudu/kudu) Zip controller
+module Fake.AzureWebJobs
+
+/// The running modes of webjobs
+[<RequireQualifiedAccess>]
+type WebJobType = 
+    | Continuous
+    | Triggered
+
+/// WebJob type
+type WebJob = 
+    { 
+      /// The name of the web job, this will also be the name out of zip file.
+      Name : string
+      /// Specifies what type of webjob this is. Note that this also determines it's deployment location on Azure
+      JobType : WebJobType
+      /// The project to be zipped and deployed as a webjob
+      Project : string }
+
+/// The website that webjobs are deployed to
+type WebSite = 
+    { 
+      /// The url of the website, usually in the format of https://<yourwebsite>.scm.azurewebsites.net
+      Url : string
+      /// The FTP username, usually the $username from the site's publish profile
+      UserName : string
+      /// The FTP Password
+      Password : string
+      /// The webjobs to deploy to this web site
+      WebJobs : WebJob list }

--- a/src/app/FakeLib/AzureWebJobs.fs
+++ b/src/app/FakeLib/AzureWebJobs.fs
@@ -1,6 +1,9 @@
 ﻿/// Contains tasks to package and deploy [Azure Web Jobs](http://azure.microsoft.com/en-gb/documentation/articles/web-sites-create-web-jobs/) via the [Kudu](https://github.com/projectkudu/kudu) Zip controller
 module Fake.AzureWebJobs
 
+open System.IO
+open System
+
 /// The running modes of webjobs
 [<RequireQualifiedAccess>]
 type WebJobType = 
@@ -21,10 +24,39 @@ type WebJob =
 type WebSite = 
     { 
       /// The url of the website, usually in the format of https://<yourwebsite>.scm.azurewebsites.net
-      Url : string
+      Url : Uri
       /// The FTP username, usually the $username from the site's publish profile
       UserName : string
       /// The FTP Password
       Password : string
       /// The webjobs to deploy to this web site
       WebJobs : WebJob list }
+
+/// TypeScript task parameter type
+type WebJobParams =
+    { 
+      /// Specifies the zip output path.
+      OutputPath : string }
+
+/// Default parameters for the WebJobs task
+let WebJobDefaultParams = 
+    { OutputPath = null}
+
+/// This task to can be used create a zip for each webjob to deploy to a website
+/// The output structure is: `outputpath/{websitename}/webjobs/{continuous/triggered}/{webjobname}.zip`
+/// ## Parameters
+///
+///  - `setParams` - Function used to overwrite webjobs outputpath.
+///  - `websites` - The websites and webjobs to build zips from.
+let BuildZip setParams websites =
+    let parameters = setParams WebJobDefaultParams 
+    let zipWebJob siteOutputPath webJob = 
+        let releaseDirectory = directoryInfo ("src/" + webJob.Project + "/bin/Release")
+        let zipDirectory = directoryInfo siteOutputPath
+        ensureDirExists zipDirectory
+        let zipName = Path.Combine(zipDirectory.FullName, webJob.Name + ".zip")
+        let fileToZip = releaseDirectory.GetFiles() |> Array.map (fun f -> f.FullName)
+        CreateZip releaseDirectory.FullName zipName "" 0 false fileToZip
+    websites |> List.iter (fun website -> 
+                    let siteOutputPath = parameters.OutputPath + "/" + website.Url.Host
+                    website.WebJobs |> List.iter (zipWebJob siteOutputPath))

--- a/src/app/FakeLib/AzureWebJobs.fs
+++ b/src/app/FakeLib/AzureWebJobs.fs
@@ -5,9 +5,7 @@ open Fake
 open System.IO
 open System
 open System.Net
-
-type Uri with
-    member this.SubDomain = this.Host.Split([|'.'|],2).[0]
+open System.Collections.Generic
 
 /// The running modes of webjobs
 [<RequireQualifiedAccess>]
@@ -23,7 +21,11 @@ type WebJob =
       /// Specifies what type of webjob this is. Note that this also determines it's deployment location on Azure
       JobType : WebJobType
       /// The project to be zipped and deployed as a webjob
-      Project : string }
+      Project : string
+      /// The directory path of the webjob to zip
+      DirectoryToPackage : string
+      // The package path to once zipped
+      PackageLocation: string }
 
 /// The website that webjobs are deployed to
 type WebSite = 
@@ -37,65 +39,42 @@ type WebSite =
       /// The webjobs to deploy to this web site
       WebJobs : WebJob list }
 
-/// TypeScript task parameter type
-type WebJobParams =
-    {
-      /// Specifies the directory of the files to
-      InputPath : string  
-      /// Specifies the zip output path.
-      OutputPath : string }
-
-/// Default parameters for the WebJobs task
-let WebJobDefaultParams webJobProject = 
-    { OutputPath = "bin"
-      InputPath = "src/" + webJobProject + "/bin/Release"}
-
-let private jobTypePath webJob = 
-    match webJob.JobType with
+let private jobTypePath webJobType = 
+    match webJobType with
     | WebJobType.Continuous -> "continuous"
     | WebJobType.Triggered -> "triggered"
 
-let private webJobPath outputPath webSite webJob = 
-    sprintf "%s/%s/webjobs/%s" outputPath webSite.Url.SubDomain (jobTypePath webJob)
-
-let private webJobZipPath outputPath webSite webJob = 
-    sprintf "%s/%s.zip" (webJobPath outputPath webSite webJob) webJob.Name
-
-let private zipWebJob setParams webSite webJob = 
-    let parameters = setParams (WebJobDefaultParams webJob.Project)
-    let zipDirectory = directoryInfo (webJobPath parameters.OutputPath webSite webJob)
-    ensureDirExists zipDirectory
-    let zipName = Path.Combine(zipDirectory.FullName, webJob.Name + ".zip")
-    let filesToZip = Directory.GetFiles(parameters.InputPath, "*.*", SearchOption.AllDirectories)
-    tracefn "Zipping %s webjob to %O" webJob.Project zipDirectory
-    CreateZip parameters.InputPath zipName "" 0 false filesToZip
+let private zipWebJob webSite webJob = 
+    let packageFile = fileInfo webJob.PackageLocation
+    ensureDirExists packageFile.Directory
+    let zipName = webJob.PackageLocation
+    let filesToZip = Directory.GetFiles(webJob.DirectoryToPackage, "*.*", SearchOption.AllDirectories)
+    tracefn "Zipping %s webjob to %s" webJob.Project webJob.PackageLocation
+    CreateZip webJob.DirectoryToPackage zipName "" 0 false filesToZip
 
 /// This task to can be used create a zip for each webjob to deploy to a website
 /// The output structure is: `outputpath/{websitename}/webjobs/{continuous/triggered}/{webjobname}.zip`
 /// ## Parameters
 ///
-///  - `setParams` - Function used to overwrite webjobs outputpath.
 ///  - `webSites` - The websites and webjobs to build zips from.
-let PackageWebJobs setParams webSites =
-    webSites |> List.iter (fun webSite -> webSite.WebJobs |> List.iter (zipWebJob setParams webSite))
+let PackageWebJobs webSites =
+    webSites |> List.iter (fun webSite -> webSite.WebJobs |> List.iter (zipWebJob webSite))
 
-let private deployWebJobToWebSite setParams webSite webJob =
-    let parameters = setParams WebJobDefaultParams webJob.Project
-    let uploadApi = Uri(webSite.Url, sprintf"api/zip/site/wwwroot/App_Data/jobs/%s/%s" (jobTypePath webJob) webJob.Name)
-    let filePath = (webJobZipPath parameters.OutputPath webSite webJob)
+let private deployWebJobToWebSite webSite webJob =
+    let uploadApi = Uri(webSite.Url, sprintf"api/zip/site/wwwroot/App_Data/jobs/%s/%s" (jobTypePath webJob.JobType) webJob.Name)
+    let filePath = webJob.PackageLocation
     tracefn "Deploying %s webjob to %O" filePath uploadApi
     use client = new WebClient()
 
     client.Credentials <-NetworkCredential(webSite.UserName, webSite.Password)
     client.UploadData(uploadApi,"PUT",File.ReadAllBytes(filePath)) |> ignore
 
-let private deployWebJobsToWebSite setParams webSite = 
-    webSite.WebJobs |> List.iter (deployWebJobToWebSite setParams webSite)
+let private deployWebJobsToWebSite webSite = 
+    webSite.WebJobs |> List.iter (deployWebJobToWebSite webSite)
 
 /// This task to can be used deploy a prebuilt webjob zip to a website
 /// ## Parameters
 ///
-///  - `setParams` - Function used to overwrite webjobs outputpath.
 ///  - `webSites` - The websites and webjobs to deploy.
-let DeployWebJobs setParams webSites = 
-    webSites |> List.iter(deployWebJobsToWebSite setParams)
+let DeployWebJobs webSites = 
+    webSites |> List.iter deployWebJobsToWebSite  

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -146,6 +146,7 @@
     <Compile Include="HipChatNotificationHelper.fs" />
     <Compile Include="XamarinHelper.fs" />
     <Compile Include="XDTHelper.fs" />
+    <Compile Include="AzureWebJobs.fs" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Deploying webjobs via msdeploy is awkward for my self so I built this bit of code to build a zip of the files in the release folder and and push it via the rest api that Azure Websites have.

This makes use of the [zip controller](https://github.com/projectkudu/kudu/wiki/REST-API#zip).

It works but is a bit rough in some places, for example it dependent on "/bin/release" for the location of the dlls to zip up.

This is an example of how you'd call it:

    // Define webjobs/website
    let webJobs = [{Name = "webjob1"; JobType= WebJobType.Continuous; Project ="WebJobProject1"}
                           {Name = "webjob2"; JobType= WebJobType.Triggered; Project ="WebJobProject2"}]
    let webSite = {WebSite.Url = Uri("https://yoursite.scm.azurewebsites.net")
                          UserName = "$yoursite"
                          Password = "somepassword"
                          WebJobs = webJobs }

    // Targets to build/deploy

    Target "PackageWebJobs" (fun _ ->
        PackageWebJobs(fun p -> {p with OutputPath = "bin"}) [webSite]
    )
    Target "DeployWebJobs" (fun _ ->
        DeployWebJobs(fun p -> {p with OutputPath = "bin"}) [webSite]
    )