### PR TITLE
Use Travis CI language support for .NET

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
-language: c
+language: csharp
 
-install:
-  - curl -sLo /tmp/mono.gpg http://download.mono-project.com/repo/xamarin.gpg
-  - sudo apt-key add /tmp/mono.gpg
-  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq mono-complete nuget mono-vbnc fsharp libgdiplus=2.10-3
-  - mozroots --import --sync --quiet
+sudo: false  # use the new container-based Travis infrastructure
 
 script: 
   - ./build.sh Default


### PR DESCRIPTION
Travis CI [now supports](http://blog.travis-ci.com/2014-12-10-community-driven-language-support-comes-to-travis-ci/) C#, F#, VB projects. It uses Mono internally, just like you did previously in your .travis.yml. I also added `sudo: false`, so builds get routed to the new [container infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).

I'm one of the contributors that worked on this for Travis, feel free to ask me any questions :)
