### PR TITLE
Add space after appendWithoutQuotes to fix XUnit include/exclude traits issue

### DIFF
--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -58,7 +58,7 @@ let replaceFirst (pattern : string) replacement (text : string) =
 let inline append text (builder : StringBuilder) = builder.Append(sprintf "\"%s\" " text)
 
 /// Appends a text to a StringBuilder without surrounding quotes.
-let inline appendWithoutQuotes (text : string) (builder : StringBuilder) = builder.Append(text)
+let inline appendWithoutQuotes (text : string) (builder : StringBuilder) = builder.Append(sprintf "%s " text)
 
 /// Appends string of function value if option has some value
 let inline appendIfSome o f builder = 

--- a/src/test/Test.FAKECore/XUnitHelperSpecs.cs
+++ b/src/test/Test.FAKECore/XUnitHelperSpecs.cs
@@ -12,6 +12,8 @@ namespace Test.FAKECore
         It args_should_include_two_traits = () => BuildXUnitArgs(Trait("name", "value1,value2"), XUnitHelper.emptyTrait).ShouldContain(@" /trait ""name=value1"" /trait ""name=value2""");
         It args_should_exclude_one_trait = () => BuildXUnitArgs(XUnitHelper.emptyTrait, Trait("name", "value")).ShouldContain(@"/-trait ""name=value""");
         It args_should_exclude_two_traits = () => BuildXUnitArgs(XUnitHelper.emptyTrait, Trait("name", "value1,value2")).ShouldContain(@" /-trait ""name=value1"" /-trait ""name=value2""");
+        It args_should_include_and_exclude_traits = () => BuildXUnitArgs(Trait("name", "value1"), Trait("name", "value2")).ShouldContain(@" /trait ""name=value1"" /-trait ""name=value2""");
+        It args_should_include_and_exclude_multiple_traits = () => BuildXUnitArgs(Trait("name", "value1,value2"), Trait("name", "value3")).ShouldContain(@" /trait ""name=value1"" /trait ""name=value2"" /-trait ""name=value3""");       
 
         private static FSharpOption<Tuple<string, string>> Trait(string name, string values)
         {


### PR DESCRIPTION
When adding `IncludeTraits` and `ExcludeTraits` together, `XUnitHelper` doesn't add a space before `/-trait` which cause issue with `xunit.console.clr4.exe`.