### PR TITLE
ignore unknown project references.

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -82,7 +82,7 @@ let rec getProjectReferences (projectFileName : string) =
     else // exclude .sln-files since the are not XML
          
     let doc = loadProject projectFileName
-    let references = getReferenceElements "ProjectReference" projectFileName doc |> Seq.map snd
+    let references = getReferenceElements "ProjectReference" projectFileName doc |> Seq.map snd |> Seq.filter File.Exists
     references
       |> Seq.map getProjectReferences
       |> Seq.concat


### PR DESCRIPTION
Assume you have the following in your msbuild file:

```xml
  <Import Project="includes.targets" />
  <ItemGroup>
    <ProjectReference Include="@(ProjectReferenceImports)" />
  </ItemGroup>
```

and in `includes.targets`:
```xml
  <ItemGroup>
    <ProjectReferenceImports Include="..\MyProject\MyProject.$(CustomBuildName).csproj">
      <Project>{337804c8-9420-4e2d-a918-a62ac2f84555}</Project>
      <Name>MyProject.$(CustomBuildName)</Name>
    </ProjectReferenceImports>
  </ItemGroup>
```

While Visual Studio and msbuild will work fine with this FAKE will throw an exception like:
```
---------------------------------------------------------------------
  1) System.IO.FileNotFoundException: Could not find file 'C:\Projects\MyProject\src\source\MyProject\@(ProjectReferenceImports)'.
File name: 'C:\Projects\MyProject\src\source\MyProject\@(ProjectReferenceImports)'
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize)
   at System.Xml.XmlDownloadManager.GetStream(Uri uri, ICredentials credentials, IWebProxy proxy, RequestCachePolicy cachePolicy)
   at System.Xml.XmlUrlResolver.GetEntity(Uri absoluteUri, String role, Type ofObjectToReturn)
   at System.Xml.XmlTextReaderImpl.FinishInitUriString()
   at System.Xml.XmlTextReaderImpl..ctor(String uriStr, XmlReaderSettings settings, XmlParserContext context, XmlResolver uriResolver)
   at System.Xml.XmlReaderSettings.CreateReader(String inputUri, XmlParserContext inputContext)
   at System.Xml.XmlReader.Create(String inputUri, XmlReaderSettings settings, XmlParserContext inputContext)
   at System.Xml.Linq.XDocument.Load(String uri, LoadOptions options)
   at Fake.MSBuildHelper.getProjectReferences(String projectFileName) in D:\code\fake\src\app\FakeLib\MSBuildHelper.fs:line 84
   at Fake.MSBuildHelper.getProjectReferences@87.Invoke(String projectFileName) in D:\code\fake\src\app\FakeLib\MSBuildHelper.fs:line 87
   at Microsoft.FSharp.Collections.IEnumerator.map@107.DoMoveNext(b& )
   at Microsoft.FSharp.Collections.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext()
   at Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.takeOuter@667[T,TResult](ConcatEnumerator`2 x, Unit unitVar0)
   at Microsoft.FSharp.Collections.Generator.Microsoft-FSharp-Collections-Generator-Generator-1-get_Apply@496-1.Invoke(Unit unitVar0)
   at Microsoft.FSharp.Collections.Generator.appG[a](Generator`1 g)
   at Microsoft.FSharp.Collections.Generator.EnumeratorWrappingLazyGenerator`1.System-Collections-IEnumerator-MoveNext()
   at Microsoft.FSharp.Collections.SetTreeModule.mkFromEnumerator[a](IComparer`1 comparer, SetTree`1 acc, IEnumerator`1 e)
   at Microsoft.FSharp.Collections.SetTreeModule.ofSeq[a](IComparer`1 comparer, IEnumerable`1 c)
   at Fake.MSBuildHelper.getProjectReferences(String projectFileName) in D:\code\fake\src\app\FakeLib\MSBuildHelper.fs:line 86
   at Fake.MSBuildHelper.dependencies@371.Invoke(String projectFileName) in D:\code\fake\src\app\FakeLib\MSBuildHelper.fs:line 371
   at Microsoft.FSharp.Primitives.Basics.List.map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 x)
   at Fake.MSBuildHelper.MSBuildWithProjectProperties(String outputPath, String targets, FSharpFunc`2 properties, IEnumerable`1 projects) in D:\code\fake\src\app\FakeLib\MSBuildHelper.fs:line 369
   at FSI_0001.BuildConfig.buildApp(BuildParams buildParams) in C:\Projects\MyProject\buildConfig.fsx:line 100
   at FSI_0001.Build.clo@93-14.Invoke(Boolean _arg5) in C:\Projects\MyProject\build.fsx:line 93
   at Fake.TargetHelper.runTarget@326(String targetName) in D:\code\fake\src\app\FakeLib\TargetHelper.fs:line 340
---------------------------------------------------------------------
```

Ignoring such references seems to work fine in my case.