### PR TITLE
Add UploadTestResultsXml function to the AppVeyor module

### DIFF
--- a/src/app/FakeLib/AppVeyor.fs
+++ b/src/app/FakeLib/AppVeyor.fs
@@ -131,10 +131,10 @@ type TestResultsType =
 
 /// Uploads the test results .xml file to the Test tab of the build console.
 let UploadTestResultsXml testResultsType outputDir =
-    let resultsType = (sprintf "%A" testResultsType).ToLower()
-    let url = sprintf "https://ci.appveyor.com/api/testresults/%s/%s" resultsType AppVeyorEnvironment.JobId
-    let files = System.IO.Directory.GetFiles(path = outputDir, searchPattern = "*.xml")
-    if buildServer = BuildServer.AppVeyor then 
+    if buildServer = BuildServer.AppVeyor then
+        let resultsType = (sprintf "%A" testResultsType).ToLower()
+        let url = sprintf "https://ci.appveyor.com/api/testresults/%s/%s" resultsType AppVeyorEnvironment.JobId
+        let files = System.IO.Directory.GetFiles(path = outputDir, searchPattern = "*.xml")
         use wc = new System.Net.WebClient()
         files
         |> Seq.iter (fun file ->

--- a/src/app/FakeLib/AppVeyor.fs
+++ b/src/app/FakeLib/AppVeyor.fs
@@ -124,20 +124,15 @@ let FinishTestCase testSuiteName testCaseName (duration : System.TimeSpan) =
     sendToAppVeyor <| sprintf "UpdateTest \"%s\" -Duration %s" (testSuiteName + " - " + testCaseName) duration
 
 /// Union type representing the available test result formats accepted by AppVeyor.
-type ResultsType =
+type TestResultsType =
     | MsTest
     | NUnit
     | Xunit
 
 /// Uploads the test results .xml file to the Test tab of the build console.
-let UploadTestResultsXml resultsType outputDir =
-    let runnerType =
-        match resultsType with
-        | MsTest -> "mstest"
-        | NUnit -> "nunit"
-        | Xunit -> "xunit"
-
-    let url = sprintf "https://ci.appveyor.com/api/testresults/%s/%s" runnerType AppVeyorEnvironment.JobId
+let UploadTestResultsXml testResultsType outputDir =
+    let resultsType = (sprintf "%A" testResultsType).ToLower()
+    let url = sprintf "https://ci.appveyor.com/api/testresults/%s/%s" resultsType AppVeyorEnvironment.JobId
     let files = System.IO.Directory.GetFiles(path = outputDir, searchPattern = "*.xml")
     if buildServer = BuildServer.AppVeyor then 
         use wc = new System.Net.WebClient()


### PR DESCRIPTION
Credit due to @ctaggart and @kimsk. This addition to the `AppVeyor` module provides a function that can be used to upload the `TestResults.xml` file generated by `MsTest`, `NUnit`, or `Xunit` to the [AppVeyor build console's Test tab](http://www.appveyor.com/docs/running-tests#test-results).

This is the approach we are currently using. I don't believe we ever figured out how to push each test to the Test tab using the existing functions, and I could find no examples anywhere demonstrating their use.

NOTE: This PR does not include tests, as I'm not certain how to add effective tests for the file upload. Please advise on any additional changes you would like to see; I'm happy to adjust to fit your goals. 