### PR TITLE
Fixes backslash escaping in the MSTest module

### DIFF
--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -6,9 +6,9 @@ open System.Text
 
 /// [omit]
 let mstestPaths = 
-    [| "[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE"; 
-       "[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE"; 
-       "[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]
+    [| @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE";
+       @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE";
+       @"[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]
 
 /// [omit]
 let mstestexe = 


### PR DESCRIPTION
Not currently broken as they're not valid escape characters. Looking to fix tool warnings + avoid future confusion.