### PR TITLE
Implement functions to replace text in one or more files using regular expressions for the search pattern

### DIFF
--- a/src/app/FakeLib/FileHelper.fs
+++ b/src/app/FakeLib/FileHelper.fs
@@ -425,10 +425,10 @@ let ReplaceInFiles replacements files = processTemplates replacements files
 /// Replace all occurences of the regex pattern with the given replacement in the specified file
 /// ## Parameters
 ///
-/// - `file` - The path of the file to process
 /// - `pattern` - The string to search for a match
 /// - `replacement` - The replacement string
 /// - `encoding` - The encoding to use when reading and writing the file
+/// - `file` - The path of the file to process
 let RegexReplaceInFileWithEncoding pattern (replacement:string) encoding file =
     let oldContent = File.ReadAllText(file, encoding)
     let newContent = System.Text.RegularExpressions.Regex.Replace(oldContent, pattern, replacement)
@@ -437,10 +437,10 @@ let RegexReplaceInFileWithEncoding pattern (replacement:string) encoding file =
 /// Replace all occurences of the regex pattern with the given replacement in the specified files
 /// ## Parameters
 ///
-/// - `file` - The path of the file to process
 /// - `pattern` - The string to search for a match
 /// - `replacement` - The replacement string
 /// - `encoding` - The encoding to use when reading and writing the files
+/// - `files` - The paths of the files to process
 let RegexReplaceInFilesWithEncoding pattern (replacement:string) encoding files =
     files |> Seq.iter (RegexReplaceInFileWithEncoding pattern replacement encoding)
 

--- a/src/app/FakeLib/FileHelper.fs
+++ b/src/app/FakeLib/FileHelper.fs
@@ -422,6 +422,28 @@ let WriteConfigFile configFileName parameters =
 ///  - `files` - The files to process.
 let ReplaceInFiles replacements files = processTemplates replacements files
 
+/// Replace all occurences of the regex pattern with the given replacement in the specified file
+/// ## Parameters
+///
+/// - `file` - The path of the file to process
+/// - `pattern` - The string to search for a match
+/// - `replacement` - The replacement string
+/// - `encoding` - The encoding to use when reading and writing the file
+let RegexReplaceInFileWithEncoding pattern (replacement:string) encoding file =
+    let oldContent = File.ReadAllText(file, encoding)
+    let newContent = System.Text.RegularExpressions.Regex.Replace(oldContent, pattern, replacement)
+    File.WriteAllText(file, newContent, encoding)
+
+/// Replace all occurences of the regex pattern with the given replacement in the specified files
+/// ## Parameters
+///
+/// - `file` - The path of the file to process
+/// - `pattern` - The string to search for a match
+/// - `replacement` - The replacement string
+/// - `encoding` - The encoding to use when reading and writing the files
+let RegexReplaceInFilesWithEncoding pattern (replacement:string) encoding files =
+    files |> Seq.iter (RegexReplaceInFileWithEncoding pattern replacement encoding)
+
 /// Get the version a file.
 /// ## Parameters
 ///


### PR DESCRIPTION
This is my attempt at addressing #622 - Replacements in ReplaceInFiles should access regex patterns. 

This implementation requires that the caller specify the encoding for the files that they are processing. I attempted a solution whereby I did not specify the encoding in the ReadAlltext and WriteAlltext methods but I found that .NET was not always guessing the encoding correctly. As a result this process modified the files from their original encoding (ANSI) to UTF-8. As far as I know there isn't a simple way to detect file encoding so in this implementation I put the responsibility on the caller to specify the encoding.