### PR TITLE
Fixes #634, added option for MergeByHash

### DIFF
--- a/src/test/Test.FAKECore/OpenCoverHelperSpecs.cs
+++ b/src/test/Test.FAKECore/OpenCoverHelperSpecs.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Fake;
+using Machine.Specifications;
+
+namespace Test.FAKECore
+{
+    public class OpenCoverHelperSpecs
+    {
+        It args_should_include_mergebyhash = () => BuildOpenCoverArgs(true).ShouldContain(" -mergebyhash");
+        It args_should_not_include_mergebyhash = () => BuildOpenCoverArgs(false).ShouldNotContain(" -mergebyhash");
+        It args_should_include_target_args = () => BuildOpenCoverArgs(false).ShouldContain(" -targetargs:\"Tests\\test.dll\"");
+        It args_should_include_target = () => 
+            BuildOpenCoverArgs(false).ShouldContain(string.Format("-target:\"{0}\" ", FileSystemHelper.FullName("TestRunnerPath.exe")));
+        It args_should_include_RegisterUser = () => BuildOpenCoverArgs(false).ShouldContain(" -register:user");
+        It args_should_include_filter = () => BuildOpenCoverArgs(false).ShouldContain(" -filter:\"[*Tests]*\"");
+        It args_should_include_optionalArguments = () => BuildOpenCoverArgs(false, "-enableperformancecounters").ShouldContain("-enableperformancecounters");
+
+        private static string BuildOpenCoverArgs(bool mergebyhash, string optionalArguments = "")
+        {
+            return OpenCoverHelper.buildOpenCoverArgs(
+                new OpenCoverHelper.OpenCoverParams("Exepath.exe", "TestRunnerPath.exe", "output",
+                    OpenCoverHelper.RegisterType.RegisterUser, "[*Tests]*", new TimeSpan(10), "WorkingDir", mergebyhash, optionalArguments), 
+                    "Tests\\test.dll");
+        }
+    }
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Globbing\TestSample5\AbsoluteDirGlobbingSpecs.cs" />
     <Compile Include="NAVFiles\NAVSplitObjectSpecs.cs" />
     <Compile Include="NAVFiles\NavTestResultSpecs.cs" />
+    <Compile Include="OpenCoverHelperSpecs.cs" />
     <Compile Include="PackageMgt\PackagesConfigSpecs.cs" />
     <Compile Include="SemVerHelperSpecs.cs" />
     <Compile Include="ProjectSystemSpecs.cs" />


### PR DESCRIPTION
Also added option to add any additional parameters so that it is possible to use all available commands for OpenCover without re-compiling.