### PR TITLE
Fix SpecFlow MSTest integration

### DIFF
--- a/src/app/FakeLib/SpecFlowHelper.fs
+++ b/src/app/FakeLib/SpecFlowHelper.fs
@@ -51,13 +51,16 @@ let SpecFlow setParams =
 
     let tool = parameters.ToolPath @@ parameters.ToolName
 
+    let isMsTest = toLower >> ((=) "mstestexecutionreport")
+
     let commandLineBuilder = 
         new StringBuilder()
         |> append           parameters.SubCommand
         |> append           parameters.ProjectFile
         |> appendIfNotNull  parameters.BinFolder "/binFolder:"
         |> appendIfNotNull  parameters.OutputFile "/out:"
-        |> appendIfNotNull  parameters.XmlTestResultFile "/xmlTestResult:"
+        |> appendIfNotNull  parameters.XmlTestResultFile 
+                                (if isMsTest parameters.SubCommand then "/testResult:" else "/xmlTestResult:")
         |> appendIfNotNull  parameters.TestOutputFile "/testOutput:"
         |> appendIfTrue     parameters.Verbose "/verbose"
         |> appendIfTrue     parameters.ForceRegeneration "/force"


### PR DESCRIPTION
SpecFlow uses different parameters for MSTest than it does for NUnit
(see "specflow help mstestexecutionreport").