### PR TITLE
Typed exception when nunit tests fail will not reported to teamcity anymore

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -150,7 +150,10 @@ try
             |> traceError
             printUsage()
 
-        sendTeamCityError exn.Message
+        let isFailedTestsException = exn :? UnitTestCommon.FailedTestsException
+        if not isFailedTestsException  then
+            sendTeamCityError exn.Message
+
         Environment.ExitCode <- 1
 
     if buildServer = BuildServer.TeamCity then

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -196,8 +196,11 @@ let targetError targetName (exn:System.Exception) =
     let msg = sprintf "%s%s" (error exn) (if exn.InnerException <> null then "\n" + (exn.InnerException |> error) else "")
             
     traceError <| sprintf "Running build failed.\nError:\n%s" msg
-    sendTeamCityError <| error exn
- 
+
+    let isFailedTestsException = exn :? UnitTestCommon.FailedTestsException
+    if not isFailedTestsException  then
+        sendTeamCityError <| error exn
+
 let addExecutedTarget target time =
     ExecutedTargets.Add (toLower target) |> ignore
     ExecutedTargetTimes.Add(toLower target,time) |> ignore

--- a/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
@@ -96,12 +96,12 @@ let NUnitParallel (setParams : NUnitParams -> NUnitParams) (assemblies : string 
             List.fold (fun acc x -> 
                 { acc with WorseReturnCode = min acc.WorseReturnCode x.ReturnCode
                            Messages = acc.Messages @ formatErrorMessages x }) AggFailedResult.Empty failedResults
-        
+
         let fail() = 
             List.iter traceError aggResult.Messages
-            failwithf "NUnitParallel test runs failed (%d of %d assemblies are failed)." (List.length failedResults) 
-                (List.length testRunResults)
-        
+            raise (FailedTestsException (sprintf "NUnitParallel test runs failed (%d of %d assemblies are failed)." 
+                    (List.length failedResults) (List.length testRunResults)))
+
         match parameters.ErrorLevel with
         | DontFailBuild -> 
             match aggResult.WorseReturnCode with

--- a/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
@@ -14,7 +14,7 @@ module Fake.NUnitSequential
 ///         !! (testDir + @"\Test.*.dll") 
 ///           |> NUnit (fun p -> { p with ErrorLevel = DontFailBuild })
 ///     )
-let NUnit (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) = 
+let NUnit (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) =
     let details = assemblies |> separated ", "
     traceStartTask "NUnit" details
     let parameters = NUnitDefaults |> setParams
@@ -38,8 +38,8 @@ let NUnit (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) =
     | DontFailBuild -> 
         match result with
         | OK | TestsFailed -> traceEndTask "NUnit" details
-        | _ -> failwith (errorDescription result)
+        | _ -> raise (FailedTestsException(errorDescription result))
     | Error | FailOnFirstError -> 
         match result with
         | OK -> traceEndTask "NUnit" details
-        | _ -> failwith (errorDescription result)
+        | _ -> raise (FailedTestsException(errorDescription result))

--- a/src/app/FakeLib/UnitTest/UnitTestCommon.fs
+++ b/src/app/FakeLib/UnitTest/UnitTestCommon.fs
@@ -12,3 +12,6 @@ type TestRunnerErrorLevel =
     | FailOnFirstError
     /// With this option set, no exception is thrown if a test is broken.
     | DontFailBuild
+
+type FailedTestsException(msg) =
+    inherit System.Exception(msg)


### PR DESCRIPTION
I am a f# newbie. So please tell me if this is the way you would do it.

I think it would be better if the exception is analysed in sendTeamCityError but there the exception was not availlable.