### PR TITLE
Adding ability to control type library export (/tlb flag) of RegAsm.

### DIFF
--- a/src/app/FakeLib/RegAsmHelper.fs
+++ b/src/app/FakeLib/RegAsmHelper.fs
@@ -8,13 +8,15 @@ open System
 type RegAsmParams = 
     { ToolPath : string
       WorkingDir : string
-      TimeOut : TimeSpan }
+      TimeOut : TimeSpan
+      ExportTypeLibrary : bool }
 
 /// RegAsm default params
 let RegAsmDefaults = 
     { ToolPath = @"C:\Windows\Microsoft.NET\Framework\v2.0.50727\regasm.exe"
       WorkingDir = "."
-      TimeOut = TimeSpan.FromMinutes 5. }
+      TimeOut = TimeSpan.FromMinutes 5.
+      ExportTypeLibrary = true }
 
 /// Runs regasm on the given lib
 /// ## Parameters
@@ -24,7 +26,10 @@ let RegAsmDefaults =
 let RegAsm setParams lib = 
     traceStartTask "RegAsm" lib
     let parameters = setParams RegAsmDefaults
-    let args = sprintf "%s /tlb:%s" lib (replace ".dll" ".tlb" lib)
+    let args = if parameters.ExportTypeLibrary then
+                    sprintf "\"%s\" /tlb:\"%s\"" lib (replace ".dll" ".tlb" lib)
+                else
+                    sprintf "\"%s\"" lib
     if 0 <> ExecProcess (fun info -> 
                 info.FileName <- parameters.ToolPath
                 info.WorkingDirectory <- parameters.WorkingDir


### PR DESCRIPTION
The previous implementation of RegAsm always exports a type library (by using the /tlb flag). We had a use case, were only registration of the assembly was possible, but no export of a type library (C++ COM+ wrapper).
This fix allows to specify whether to run RegAsm with type library export or not (default: with type library export).

Also escaping assembly paths in command line calls.