### PR TITLE
Remvoved internal class generated in AssemblyInfo.Vb

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -181,16 +181,7 @@ let CreateVisualBasicAssemblyInfoWithConfig outputFileName attributes (config : 
              |> Seq.toList
              |> List.map (fun (attr : Attribute) -> sprintf "<assembly: %sAttribute(%s)>" attr.Name attr.Value))
 
-    let sourceLines =
-        if generateClass then
-            [ sprintf "Namespace %s" useNamespace
-              "    Friend NotInheritable Class"
-              sprintf "        Friend Const Version As String = %s" (getAssemblyVersionInfo attributes)
-              "    End Class"
-              "End Namespace" ]
-        else []
-
-    attributeLines @ sourceLines
+    attributeLines 
     |> writeToFile outputFileName
     traceEndTask "AssemblyInfo" outputFileName
 


### PR DESCRIPTION
Working on adding vb.net support in ProjectScaffold, and trying to run the assemblyinfo generate task caused build of vb.net project to fail.

Removing the generated class fixed the problem.

(I know the generated class actually had a syntax error, missing the class name, but even fixing this failed the build.)

It seems adding classes to AssemblyInfo.vb may not be supported, though I could not find any info on it.

Suggesting to remove the generated class from AssemblyInfo.vb for now, until more info is found.

(Also I might look into this part of the build process as part of figuring out what to do with fsprojects/ProjectScaffold#107 )