### PR TITLE
Parallel Builds

### DIFF
--- a/help/parallelbuild.md
+++ b/help/parallelbuild.md
@@ -1,0 +1,25 @@
+# Using FAKE's parallel option
+
+Since multithreading is beneficial (especially for large projects) FAKE allows to specify the
+number of threads used for traversing the dependency tree.
+This option of course only affects independent targets whereas dependent targets will
+still be exectued in order.
+
+
+## Setting the number of threads
+The number of threads used can be set using the environment variable ``fake-parallel-jobs``.
+This can be achieved in various ways where the easiest one is to use FAKE's built-in support for 
+setting environment variables:
+
+* FAKE.exe *YourBuildScript* "fake-parallel-jobs=8"
+
+Note that the dependency tree will be traversed as usual whenever setting ``fake-parallel-jobs`` to a value <= 1
+
+
+## Issues
+Running targets in parallel is of course only possible when the target-functions themselves are thread-safe.
+
+Parallel execution may also cause races on stdout and build-logs may therefore be quite obfuscated.
+
+
+

--- a/help/parallelbuild.md
+++ b/help/parallelbuild.md
@@ -7,13 +7,13 @@ still be exectued in order.
 
 
 ## Setting the number of threads
-The number of threads used can be set using the environment variable ``fake-parallel-jobs``.
+The number of threads used can be set using the environment variable ``parallel-jobs``.
 This can be achieved in various ways where the easiest one is to use FAKE's built-in support for 
 setting environment variables:
 
-``FAKE.exe *YourBuildScript* "fake-parallel-jobs=8"``
+``FAKE.exe *YourBuildScript* "parallel-jobs=8"``
 
-Note that the dependency tree will be traversed as usual whenever setting ``fake-parallel-jobs`` to a value ``<= 1`` or omiting it entirely.
+Note that the dependency tree will be traversed as usual whenever setting ``parallel-jobs`` to a value ``<= 1`` or omiting it entirely.
 
 ## Issues
 * Running targets in parallel is of course only possible when the target-functions themselves are thread-safe.

--- a/help/parallelbuild.md
+++ b/help/parallelbuild.md
@@ -11,15 +11,14 @@ The number of threads used can be set using the environment variable ``fake-para
 This can be achieved in various ways where the easiest one is to use FAKE's built-in support for 
 setting environment variables:
 
-* FAKE.exe *YourBuildScript* "fake-parallel-jobs=8"
+``FAKE.exe *YourBuildScript* "fake-parallel-jobs=8"``
 
-Note that the dependency tree will be traversed as usual whenever setting ``fake-parallel-jobs`` to a value <= 1
-
+Note that the dependency tree will be traversed as usual whenever setting ``fake-parallel-jobs`` to a value ``<= 1`` or omiting it entirely.
 
 ## Issues
-Running targets in parallel is of course only possible when the target-functions themselves are thread-safe.
+* Running targets in parallel is of course only possible when the target-functions themselves are thread-safe.
+* Parallel execution may also cause races on stdout and build-logs may therefore be quite obfuscated.
+* Error detection may suffer since it's not possible to determine a first error when targets are running in parallel
 
-Parallel execution may also cause races on stdout and build-logs may therefore be quite obfuscated.
-
-
-
+Due to these limitations it is recommended to use the standard sequential build whenever checking for errors (CI, etc.)
+However when a fast build is desired (and the project is e.g. known to build successfully) the parallel option might be helpful

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -402,7 +402,7 @@ let run targetName =
     watch.Start()        
     try
         tracefn "Building project with version: %s" buildVersion
-        let parallelJobs = environVarOrDefault "fake-parallel-jobs" "1" |> int
+        let parallelJobs = environVarOrDefault "parallel-jobs" "1" |> int
       
 
         if parallelJobs > 1 then

--- a/src/test/FsCheck.Fake/FsCheck.Fake.fsproj
+++ b/src/test/FsCheck.Fake/FsCheck.Fake.fsproj
@@ -59,6 +59,7 @@
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="TestStringHelper.fs" />
+    <Compile Include="TestParallelBuildOrder.fs" />
     <None Include="app.config" />
     <None Include="paket.references" />
   </ItemGroup>

--- a/src/test/FsCheck.Fake/TestParallelBuildOrder.fs
+++ b/src/test/FsCheck.Fake/TestParallelBuildOrder.fs
@@ -1,0 +1,143 @@
+﻿module FsCheck.Fake.TestParallelBuildOrder
+
+open System
+open System.Collections.Generic
+open global.Xunit
+open Fake
+open FsCheck
+
+let inline (==>) a b = global.Fake.AdditionalSyntax.(==>) a b
+
+// checks whether the given order is consistent with all dependencies
+let validateBuildOrder (order : list<Target[]>) (rootTarget : string) =
+    let rootTarget = getTarget rootTarget
+
+    // store a "level" for all targets in order
+    let targetLevelMap = 
+        order |> List.mapi (fun i arr ->
+                arr |> Array.map (fun t -> t.Name, i)
+              )
+              |> Seq.concat
+              |> Map.ofSeq
+
+    // check whether the assigned level is smaller or equal to
+    // the given max level.
+    let checkLevel (target : Target) (maxLevel : int) =
+        match Map.tryFind target.Name targetLevelMap with
+            | Some level ->
+                if level > maxLevel then
+                    failwithf "found target on unexpected level %d (should be at most %d)" level maxLevel
+
+            | None ->
+                failwithf "target %A was not assigned a level but occurs in the dependency tree" target.Name
+    
+    // recursively validate the target levels
+    let rec validate (t : Target) (maxLevel : int) =
+        checkLevel t maxLevel
+        let realLevel = Map.find t.Name targetLevelMap
+
+        let deps = t.Dependencies |> List.map getTarget
+        for d in deps do
+            validate d (realLevel - 1)
+
+    // initially the max-level is unbounded
+    validate rootTarget Int32.MaxValue
+
+[<Fact>]
+let ``Independent targets are parallel``() =
+    TargetDict.Clear()
+
+    Target "a" DoNothing
+    Target "b" DoNothing
+    Target "c" DoNothing
+    
+    Target "dep" DoNothing
+
+    "a" ==> "dep" |> ignore
+    "b" ==> "dep" |> ignore
+    "c" ==> "dep" |> ignore
+
+    let order = determineBuildOrder "dep"
+
+    validateBuildOrder order "dep"
+
+    match order with
+        | [f; [|d|]] ->
+            
+            let set = f |> Seq.map (fun a -> a.Name) |> Set.ofSeq
+            let valid = set = Set.ofList ["a"; "b"; "c"]
+
+            if not valid then 
+                failwithf "unexpected build order: %A" order
+
+            if d.Name <> "dep" then
+                failwithf "unexpected build order: %A" order
+
+        | _ ->
+            failwithf "inconsitent order: %A" order
+
+
+    ()
+
+[<Fact>]
+let ``Ordering maintains dependencies``() =
+    let r = Random()
+
+    for iter in 1..10 do
+        TargetDict.Clear()
+        Target "final" DoNothing
+
+        let targetCount = r.Next 30 + 10
+        let dependencyCount = r.Next(3 * targetCount)
+
+        // define some targets and introduce a dependency
+        // to some final target.
+        for c in 0..targetCount-1 do
+            Target (string c) DoNothing
+            string c ==> "final" |> ignore
+
+        // add a number of dependencies between two
+        // random targets. By adding dependencies from
+        // the lower index to the higher one we ensure that
+        // the resulting graph remains acyclic
+        for i in 0..dependencyCount-1 do
+            let a = r.Next targetCount
+            let b = r.Next targetCount
+
+            if a <> b then
+                // determine l(ow) and h(igh) and add the dependency
+                let l,h = if a < b then a,b else b, a
+                string l ==> string h |> ignore
+
+
+
+        let order = determineBuildOrder "final"
+        validateBuildOrder order "final"
+
+[<Fact>]
+let ``Diamonds are resolved correctly``() =
+    TargetDict.Clear()
+    Target "a" DoNothing
+    Target "b" DoNothing
+    Target "c" DoNothing
+    Target "d" DoNothing
+
+    // create a diamond graph
+    "a" ==> "b" ==> "d" |> ignore
+    "a" ==> "c" ==> "d" |> ignore
+
+    let order = determineBuildOrder "d"
+    validateBuildOrder order "d"
+
+    match order with
+        | [[|a|];[|b;c|];[|d|]] ->
+            let bcNamesCorrect =
+                if b.Name = "b" then c.Name = "c"
+                elif c.Name = "b" then b.Name = "c"
+                else false
+
+            if a.Name <> "a" || d.Name <> "d" || not bcNamesCorrect then
+                failwithf "unexpected order: %A" order
+
+        | _ ->
+            failwithf "unexpected order: %A" order


### PR DESCRIPTION
Added support for parallel builds by using an environment-variable %fake-parallel-jobs%

Note that this of course only works when target-functions can be executed concurrently.
The feature can be enabled by passing for example "fake-parallel-jobs=4" to FAKE.exe

Since parallel build cause problems in TraceHelpers the current "stack" of opened tags is now thread-local.
