### PR TITLE
Modified combinePaths to work like Path.Combine to fix fsharp/FAKE#670

### DIFF
--- a/src/app/Fake.Deploy/DeploymentHelper.fs
+++ b/src/app/Fake.Deploy/DeploymentHelper.fs
@@ -29,7 +29,7 @@ let getActiveReleases dir = !!(dir @@ deploymentRootDir @@ "**/active/*.nupkg") 
 
 /// Retrieves the NuSpec information for the active release of the given app.
 let getActiveReleaseFor dir (app : string) = 
-    !!(dir @@ deploymentRootDir @@ app @@ "/active/*.nupkg")
+    !!(dir @@ deploymentRootDir @@ app @@ "active/*.nupkg")
     |> Seq.map GetMetaDataFromPackageFile
     |> Seq.head
 
@@ -38,7 +38,7 @@ let getAllReleases dir = !!(dir @@ deploymentRootDir @@ "**/*.nupkg") |> Seq.map
 
 /// Retrieves the NuSpec information for all releases of the given app.
 let getAllReleasesFor dir (app : string) = 
-    !!(dir @@ deploymentRootDir @@ app @@ "/**/*.nupkg") |> Seq.map GetMetaDataFromPackageFile
+    !!(dir @@ deploymentRootDir @@ app @@ "**/*.nupkg") |> Seq.map GetMetaDataFromPackageFile
 
 /// Returns statistics about the machine environment.
 let getStatistics() = getMachineEnvironment()
@@ -102,7 +102,7 @@ let runDeploymentFromPackageFile workDir packageFileName scriptArgs =
 /// Rolls the given app back to the specified version
 let rollback workDir (app : string) (version : string) = 
     try 
-        let currentPackageFileName = !!(workDir @@ deploymentRootDir @@ app @@ "/active/*.nupkg") |> Seq.head
+        let currentPackageFileName = !!(workDir @@ deploymentRootDir @@ app @@ "active/*.nupkg") |> Seq.head
         let backupPackageFileName = getBackupFor workDir app version
         if currentPackageFileName = backupPackageFileName then 
             Failure { Messages = Seq.empty
@@ -138,10 +138,10 @@ let getVersionFromNugetFileName (app : string) (fileName : string) =
 /// Returns the version no. of the latest backup of the given app
 let getPreviousPackageVersionFromBackup dir app versions = 
     let currentPackageFileName = 
-        !!(dir @@ deploymentRootDir @@ app @@ "/active/*.nupkg")
+        !!(dir @@ deploymentRootDir @@ app @@ "active/*.nupkg")
         |> Seq.head
         |> getVersionFromNugetFileName app
-    !!(dir @@ deploymentRootDir @@ app @@ "/backups/*.nupkg")
+    !!(dir @@ deploymentRootDir @@ app @@ "backups/*.nupkg")
     |> Seq.map (getVersionFromNugetFileName app)
     |> Seq.filter (fun x -> x < currentPackageFileName)
     |> Seq.toList

--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -18,7 +18,7 @@ type EnvironTarget = EnvironmentVariableTarget
 let environVar name = Environment.GetEnvironmentVariable name
 
 /// Combines two path strings using Path.Combine
-let inline combinePaths path1 (path2 : string) = Path.Combine(path1, path2.TrimStart [| '\\'; '/' |])
+let inline combinePaths path1 path2 = Path.Combine(path1, path2)
 
 /// Combines two path strings using Path.Combine
 let inline (@@) path1 path2 = combinePaths path1 path2

--- a/src/test/Test.FAKECore/EnvironmentHelperSpecs.cs
+++ b/src/test/Test.FAKECore/EnvironmentHelperSpecs.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Fake;
+using Machine.Specifications;
+
+namespace Test.FAKECore
+{
+    public class when_combining_paths
+    {
+        It should_act_as_path_combine =
+            () => {
+                var testValues  = new []{
+                    new []{"c:\\test", "dir\\asdf"},
+                    new []{"\\test", "dir\\asdf"},
+                    new []{"test", "dir\\asdf"},
+                    new []{"/test", "dir/asdf"},
+                    new []{"/test", "/dir/asdf"},
+                    new []{"c:\\test", "d:\\dir\\asdf"},
+                    new []{"/asdf/asdf/asdf/", "/asdf/asdf"},
+                    new []{"c:\\test", "\\\\dir\\asdf"},
+                    new []{"c:\\test", "/dir\\asdf"},
+                };
+
+                foreach(var item in testValues)
+                {
+                    EnvironmentHelper.combinePaths(item[0], item[1])
+                        .ShouldEqual(System.IO.Path.Combine(item[0], item[1]));
+                }
+            };
+    }
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -108,6 +108,7 @@
     <Compile Include="SideBySideSpecification\ReferencesScanningSpecs.cs" />
     <Compile Include="SideBySideSpecification\SpecsRemovementSpecs.cs" />
     <Compile Include="StringHelperSpecs.cs" />
+    <Compile Include="EnvironmentHelperSpecs.cs" />
     <Compile Include="MessageFiles\MessageFileSpecs.cs" />
     <Compile Include="ConfigFiles\ConfigSpecs.cs" />
     <Compile Include="AssemblyInfoSpecs.cs" />


### PR DESCRIPTION
The original combinePaths insisted on stripping leading characters off of the second path, causing it to not behave like Path.Combine.  /a/b/c joined with /d/e/f is supposed to come out as /d/e/f, but since the / was stripped on before we got /a/b/c/d/e/f, which caused certain operations to fail.  Since on windows roots like C:\ weren't being stripped, on windows the combinePaths worked like Path.Combine.  But on Linux it would result in different results.  This should cause combinePaths and @@ to work the same on both systems.

This only broke some deployment helper methods that used leading /'s, but those have been fixed.  Tests pass on Windows and Linux.  Just make sure not to use leading /'s in second paths if you expect those to join up like they used to.