### PR TITLE
Adjust Xamarin.iOS archive helper params.

### DIFF
--- a/src/app/FakeLib/XamarinHelper.fs
+++ b/src/app/FakeLib/XamarinHelper.fs
@@ -165,8 +165,9 @@ let AndroidSignAndAlign setParams apkFile =
 
 /// The iOS archive paramater type
 type iOSArchiveParams = {
-    /// Path to desired project or solution file. If not provided, mdtool finds the first solution in the current directory.
-    ProjectOrSolutionPath: string
+    /// Path to desired solution file. If not provided, mdtool finds the first solution in the current directory.
+    /// Although mdtool can take a project file, the archiving seems to fail to work without a solution.
+    SolutionPath: string
     /// Project name within a solution file
     ProjectName: string
     /// Build configuration, defaults to 'Debug|iPhoneSimulator'
@@ -177,7 +178,7 @@ type iOSArchiveParams = {
 
 /// The default iOS archive parameters
 let iOSArchiveDefaults = {
-    ProjectOrSolutionPath = ""
+    SolutionPath = ""
     ProjectName = ""
     Configuration = "Debug|iPhoneSimulator"
     MDToolPath = "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool"
@@ -189,7 +190,7 @@ let iOSArchiveDefaults = {
 let iOSArchive setParams =
     let archiveProject param =
         let projectNameArg = if param.ProjectName <> "" then String.Format("-p:{0} ", param.ProjectName) else ""
-        let args = String.Format(@"-v archive ""-c:{0}"" {1}{2}", param.Configuration, projectNameArg, param.ProjectOrSolutionPath)
+        let args = String.Format(@"-v archive ""-c:{0}"" {1}{2}", param.Configuration, projectNameArg, param.SolutionPath)
         executeCommand param.MDToolPath args
 
     iOSArchiveDefaults

--- a/src/app/FakeLib/XamarinHelper.fs
+++ b/src/app/FakeLib/XamarinHelper.fs
@@ -165,8 +165,10 @@ let AndroidSignAndAlign setParams apkFile =
 
 /// The iOS archive paramater type
 type iOSArchiveParams = {
-    /// (Required) Path to project file
-    ProjectPath: string
+    /// Path to desired project or solution file. If not provided, mdtool finds the first solution in the current directory.
+    ProjectOrSolutionPath: string
+    /// Project name within a solution file
+    ProjectName: string
     /// Build configuration, defaults to 'Debug|iPhoneSimulator'
     Configuration: string
     /// Path to mdtool, defaults to Xamarin Studio's usual path
@@ -175,7 +177,8 @@ type iOSArchiveParams = {
 
 /// The default iOS archive parameters
 let iOSArchiveDefaults = {
-    ProjectPath = ""
+    ProjectOrSolutionPath = ""
+    ProjectName = ""
     Configuration = "Debug|iPhoneSimulator"
     MDToolPath = "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool"
 }
@@ -184,16 +187,11 @@ let iOSArchiveDefaults = {
 /// ## Parameters
 ///  - `setParams` - Function used to override the default archive parameters
 let iOSArchive setParams =
-    let validateParams param =
-        if param.ProjectPath = "" then failwith "You must specify a project to archive"
-
-        param
-
     let archiveProject param =
-        let args = String.Format(@"-v archive ""-c:{0}"" -p:{1}", param.Configuration, param.ProjectPath)
+        let projectNameArg = if param.ProjectName <> "" then String.Format("-p:{0} ", param.ProjectName) else ""
+        let args = String.Format(@"-v archive ""-c:{0}"" {1}{2}", param.Configuration, projectNameArg, param.ProjectOrSolutionPath)
         executeCommand param.MDToolPath args
 
     iOSArchiveDefaults
         |> setParams
-        |> validateParams
         |> archiveProject


### PR DESCRIPTION
## Issue

When converting a Xamarin project from RAKE to FAKE, I was having issues using the XamarinHelper `iOSArchive` method. If I sent a project filename or fully-qualified path into the `ProjectPath` parameter, it would instead grab the nearest solution file and try to find that "path" as a project name. It turns out [that parameter is used to name a project within a solution rather than a path](http://manpages.ubuntu.com/manpages/natty/man1/mdtool.1.html).

## Solution

Since mdtool can take both a project/solution file parameter and a project name parameter, I adjusted it to accept both.

1. I [renamed the old `ProjectPath` parameter to `ProjectName`](https://github.com/fsharp/FAKE/compare/fsharp:master...patridge:XamarinHelper-ArchiveFix?expand=1#diff-1dfafe474456fc10563da24da095778bR171) to better reflect its purpose as a project name to find in a given (or fallback) solution.
2. Since this name parameter isn't actually required by mdtool, the [validation was no longer needed](https://github.com/fsharp/FAKE/compare/fsharp:master...patridge:XamarinHelper-ArchiveFix?expand=1#diff-1dfafe474456fc10563da24da095778bL187) to require it be provided.
3. I [added a parameter for the project/solution path](https://github.com/fsharp/FAKE/compare/fsharp:master...patridge:XamarinHelper-ArchiveFix?expand=1#diff-1dfafe474456fc10563da24da095778bR169). Since this parameter is also not required by mdtool, it was configured to be optional (leaving [mdtool to "pull  the  first solution it can find in the current directory"](http://manpages.ubuntu.com/manpages/natty/man1/mdtool.1.html).
4. [Restructured the mdtool calls](https://github.com/fsharp/FAKE/compare/fsharp:master...patridge:XamarinHelper-ArchiveFix?expand=1#diff-1dfafe474456fc10563da24da095778bR192) to handle the new parameters

## Tested

Here are some versions I was able to get to work with a simple Xamarin.Forms project I created with a solution at the same level as the build.fsx file being processed.

    iOSArchive (fun defaults ->
        {defaults with
            SolutionPath = "SomeSolution.sln"
            ProjectName = "SomeProject.iOS"
            Configuration = "AppStore|iPhone"
        })
    // => mdtool -v archive "-c:AppStore|iPhone" -p:SomeProject.iOS SomeSolution.sln

    iOSArchive (fun defaults ->
        {defaults with
            ProjectName = "SomeProject.iOS"
            Configuration = "AppStore|iPhone"
        })
    // Grabs local SomeSolution.sln and finds SomeProject.iOS within it
    // => mdtool -v archive "-c:AppStore|iPhone" -p:SomeProject.iOS
    
    iOSArchive (fun defaults ->
        {defaults with
            Configuration = "AppStore|iPhone"
        })
    // Grabs local SomeSolution.sln which is configured to build SomeProject.iOS for this configuration.
    // => mdtool -v archive "-c:AppStore|iPhone"

## Potential Problems

- Could be useful to output a debug message when no solution path is provided and mdtool will end up grabbing the first solution file it finds.
- Although mdtool can build from a project file directly, I was getting errors trying to archive from one. So, while SolutionPath could potentially take a project path, the archive step appears to fail.

    ERROR: Failed to archive project. Argument cannot be null.
    Parameter name: inSolution
    Running build failed.

- I'm still fairly new to F#, so my [conditional logic to create an optional mdtool argument](https://github.com/fsharp/FAKE/compare/fsharp:master...patridge:XamarinHelper-ArchiveFix?expand=1#diff-1dfafe474456fc10563da24da095778bR191) may not be ideal.