### PR TITLE
combinePaths with no trimming operations

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -19,9 +19,11 @@ let environVar name = Environment.GetEnvironmentVariable name
 
 /// Combines two path strings using Path.Combine
 let inline combinePaths path1 (path2 : string) = Path.Combine(path1, path2.TrimStart [| '\\'; '/' |])
+let inline combinePathsNoTrim path1 path2 = Path.Combine(path1, path2)
 
 /// Combines two path strings using Path.Combine
 let inline (@@) path1 path2 = combinePaths path1 path2
+let inline (</>) path1 path2 = combinePathsNoTrim path1 path2
 
 /// Retrieves all environment variables from the given target
 let environVars target = 

--- a/src/test/Test.FAKECore/EnvironmentHelperSpecs.cs
+++ b/src/test/Test.FAKECore/EnvironmentHelperSpecs.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Fake;
+using Machine.Specifications;
+
+namespace Test.FAKECore
+{
+    public class when_combining_paths
+    {
+        It should_strip_leading_slashes_when_using_combinePaths =
+            () => 
+            {
+                var testValues = new List<string[]> {
+                    new[]{"/test/path", "/of/the/thing", "/test/path" + Path.DirectorySeparatorChar + "of/the/thing"},
+                    new[]{"/test/path", "of/the/thing", "/test/path" + Path.DirectorySeparatorChar + "of/the/thing"},
+                };
+
+                if (Path.VolumeSeparatorChar != Path.DirectorySeparatorChar)
+                {
+                    var path2 = "X" + Path.VolumeSeparatorChar + "/test";
+                    testValues.Add(new[]{"/test/path", path2, path2});
+                }
+
+                foreach (var item in testValues)
+                {
+                    EnvironmentHelper.combinePaths(item[0], item[1]).ShouldEqual(item[2]);
+                }
+            };
+
+        It should_work_like_path_dot_combine_when_using_combinePathsNoTrim =
+            () => 
+            {
+                var testValues = new List<string[]> {
+                    new[]{"/test/path", "/of/the/thing", "/of/the/thing"},
+                    new[]{"/test/path", "of/the/thing", "/test/path" + Path.DirectorySeparatorChar + "of/the/thing"},
+                };
+
+                if (Path.VolumeSeparatorChar != Path.DirectorySeparatorChar)
+                {
+                    var path2 = "X" + Path.VolumeSeparatorChar + "/test";
+                    testValues.Add(new[]{"/test/path", path2, path2});
+                }
+
+                foreach (var item in testValues)
+                {
+                    EnvironmentHelper.combinePathsNoTrim(item[0], item[1]).ShouldEqual(item[2]);
+                }
+            };
+    }
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -108,6 +108,7 @@
     <Compile Include="SideBySideSpecification\ReferencesScanningSpecs.cs" />
     <Compile Include="SideBySideSpecification\SpecsRemovementSpecs.cs" />
     <Compile Include="StringHelperSpecs.cs" />
+    <Compile Include="EnvironmentHelperSpecs.cs" />
     <Compile Include="MessageFiles\MessageFileSpecs.cs" />
     <Compile Include="ConfigFiles\ConfigSpecs.cs" />
     <Compile Include="AssemblyInfoSpecs.cs" />


### PR DESCRIPTION
Previous versions of combinePath stripped of leading slashes from path2, which caused behaviors to be different between linux and windows.  This new version of combinePaths doesn't trim the leading slashes, allowing the underlying Path.Combine to behave the same on both windows and linux.  This fixes fsharp/FAKE#670

We discussed several options for the operators.  I managed to get just the plain / operator working using ideas mentioned [here](http://stackoverflow.com/questions/2812084/overload-operator-in-f) but in the end I decided to just use </> as the operator to do non trimmed path.combines.