### PR TITLE
Retrieve the ProgramFilesX86 value by exclusively relying on System.Environment

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -69,18 +69,12 @@ let inline getBuildParam name = getBuildParamOrDefault name String.Empty
 /// The path of the "Program Files" folder - might be x64 on x64 machine
 let ProgramFiles = Environment.GetFolderPath Environment.SpecialFolder.ProgramFiles
 
-/// The path of Program Files (x86)
-/// It seems this covers all cases where PROCESSOR\_ARCHITECTURE may misreport and the case where the other variable 
-/// PROCESSOR\_ARCHITEW6432 can be null
-let ProgramFilesX86 = 
-    let wow64 = environVar "PROCESSOR_ARCHITEW6432"
-    let globalArch = environVar "PROCESSOR_ARCHITECTURE"
-    match wow64, globalArch with
-    | "AMD64", "AMD64" 
-    | null, "AMD64" 
-    | "x86", "AMD64" -> environVar "ProgramFiles(x86)"
-    | _ -> environVar "ProgramFiles"
-    |> fun detected -> if detected = null then @"C:\Program Files (x86)\" else detected
+/// The path of Program Files for x86 (32-bit) executables.
+let ProgramFilesX86 =
+  if Environment.Is64BitOperatingSystem then
+    Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86
+  else
+    Environment.GetFolderPath Environment.SpecialFolder.ProgramFiles
 
 /// The system root environment variable. Typically "C:\Windows"
 let SystemRoot = environVar "SystemRoot"


### PR DESCRIPTION
#### Related documentation
- https://msdn.microsoft.com/en-us/library/system.environment.specialfolder.aspx
- http://stackoverflow.com/a/4514110
#### :warning: Warning

As I am a newcomer on FAKE, please note that I did not tested the code more than that:
- I build it only on a 64-bit Windows using both `build.cmd` and `FAKE.sln`
- I only ran it to build my own (and private) source code.

IMHO, it might be careful to test this PR on every platform targeted by FAKE.
