### PR TITLE
Use Environment.SystemDirectory to retrieve the system's root directory

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -83,7 +83,7 @@ let ProgramFilesX86 =
     |> fun detected -> if detected = null then @"C:\Program Files (x86)\" else detected
 
 /// The system root environment variable. Typically "C:\Windows"
-let SystemRoot = environVar "SystemRoot"
+let SystemRoot = Environment.SystemDirectory
 
 /// Determines if the current system is an Unix system
 let isUnix = Environment.OSVersion.Platform = PlatformID.Unix


### PR DESCRIPTION
Thus, does not exclusively works on Windows.