### PR TITLE
Add a Vagrant file to automatically deploy an Ubuntu 14.04 development VM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,9 @@
 *.fsproj merge=union
 *.dbproj merge=union
 
+# Custom for Vagrant
+*.sh diff=bash text=auto eol=lf
+
 # Standard to msysgit
 *.doc diff=astextplain
 *.DOC diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ release.cmd
 Samples/typescript/out/
 help/RELEASE_NOTES.md
 paket.exe
+
+# Ignore the Vagrant local directories
+.vagrant/*
+*/.vagrant/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.provider "virtualbox" do |vb|
+        vb.gui = false
+        vb.memory = 4096
+        vb.cpus = 4
+    end
+    config.vm.provision "shell", inline: <<-SHELL
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+        apt-get update
+        apt-get -y upgrade
+        apt-get -y install mono-complete
+        apt-get -y install mono-tools-devel
+        apt-get -y install referenceassemblies-pcl
+        apt-get -y install fsharp
+        apt-get -y autoremove
+        mozroots --import --sync
+    SHELL
+end


### PR DESCRIPTION
Mostly inspired from the existing Vagrantfile in [Math.Net Numerics](http://numerics.mathdotnet.com/).

See https://www.vagrantup.com/ for more information about the Vagrant software.