### PR TITLE
WIP Improve the contributing help file and add an help/vagrant.md file

### DIFF
--- a/help/contributing.md
+++ b/help/contributing.md
@@ -17,32 +17,67 @@ It turns `*.md` (Markdown with embedded code snippets) and `*.fsx` files (F# scr
 
  * The code for all the documents can be found in the `help` directory [on GitHub](https://github.com/fsharp/FAKE/tree/master/help). If you find a bug or add a new feature, make sure you document it!
 
- * If you want to build the documentation, simply run the build script [GitHub link](https://github.com/fsharp/FAKE/blob/master/build.fsx)) which builds the documentation.
+ * If you want to build the documentation, simply run the build script ([GitHub link](https://github.com/fsharp/FAKE/blob/master/build.fsx)) which builds the documentation.
  
 ## Creating pull requests
 
-* fork the [FAKE repo on GitHub](https://github.com/fsharp/FAKE)
-* add a new git remote in order to retrieve upstream changes
-    git remote add upstream https://github.com/fsharp/FAKE.git   
-* checkout the `master` branch
-* run the build in order to check if everything works
-  * on Mono run *build.sh*
-  * on Windows run *build.cmd*
-* create a new feature branch
-    git checkout -b myfeature
-* implement your bugfix/feature
-* add a bit of documentation (see above)
-* commit and push to your fork
-* use GitHub's UI to create a pull request
-    write "WIP" into the pull request description if it's not completely ready
-* if you need to rebase you can do:
-    git fetch upstream
-    git rebase upstream/master
-    git push origin myfeature -f
-* the pull request will be updated automatically
+### Prerequisites
 
-## Code style
+#### Git / GitHub
 
-* Read the [F# component design guidelines](http://fsharp.org/specs/component-design-guidelines/)
+* Fork the [FAKE repo on GitHub](https://github.com/fsharp/FAKE).
+
+* Clone your personal fork locally.
+
+* Add a new git remote in order to retrieve upstream changes.
+
+        git remote add upstream https://github.com/fsharp/FAKE.git
+
+#### Build tools
+
+* Windows users can install Visual Studio 2013 (the [Community Edition](https://www.visualstudio.com/products/visual-studio-community-vs)
+is freely available for open-source projects).
+
+* Linux and Mac users can read "[Guide - Cross-Platform Development with F#](http://fsharp.org/guides/mac-linux-cross-platform/)"
+to find out the required tools.
+
+* Alternately, you can use [Vagrant](https://www.vagrantup.com/) in-pair with [VirtualBox](https://www.virtualbox.org/)
+to automatically deploy a preconfigured virtual machine. See the `help/vagrant.md` file to get in
+touch with the tool.
+
+### Programming
+
+* Checkout the `master` branch.
+
+* Run the build in order to check if everything works.
+  * On Mono run `build.sh`
+  * On Windows run `build.cmd`
+
+* Create a new feature branch.
+
+        git checkout -b myfeature
+
+* Implement your bugfix/feature.
+
+* Add a bit of documentation (see above).
+
+* Commit and push to your fork.
+
+* Use GitHub's UI to create a pull request.
+    Write "WIP" into the pull request description if it's not completely ready
+
+* If you need to rebase you can do:
+
+        git fetch upstream
+        git rebase upstream/master
+        git push origin myfeature -f
+
+* The pull request will be updated automatically.
+
+#### Text editor / Code style
+
 * Install the [EditorConfig](http://editorconfig.org/) extension in your text editor(s). List available [here](http://editorconfig.org/#download).
+
 * Visual Studio users can also install the [CodeMaid](http://www.codemaid.net/) extension.
+
+* Read the [F# component design guidelines](http://fsharp.org/specs/component-design-guidelines/).

--- a/help/vagrant.md
+++ b/help/vagrant.md
@@ -1,0 +1,56 @@
+# How to use Vagrant and quickly setup a reproducible development environment for FAKE
+
+Since [#711](https://github.com/fsharp/FAKE/pull/711), it is possible to deploy an fresh Ubuntu
+Linux virtual machine with one simple command thanks to [Vagrant](https://www.vagrantup.com/). Here
+is how to proceed...
+
+# Install the system-wide prerequisites
+
+## VirtualBox and its Extension Pack
+
+> VirtualBox is a powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as
+> home use. Not only is VirtualBox an extremely feature rich, high performance product for
+> enterprise customers, it is also the only professional solution that is freely available as Open
+> Source Software under the terms of the GNU General Public License (GPL) version 2.
+
+You can install VirtualBox and the VirtualBox Extension Pack from [www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
+or with your package manager.
+
+## Vagrant
+
+> Vagrant is a tool for building complete development environments. With an easy-to-use workflow
+> and focus on automation, Vagrant lowers development environment setup time, increases
+> development/production parity, and makes the "works on my machine" excuse a relic of the past.
+
+You can install Vagrant from [www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)
+or with your package manager.
+
+# Start a new VM
+
+Simply `cd` to the root directory of the FAKE source code and run `vagrant up`.
+
+The VM will be automatically downloaded, imported into VirtualBox, configured and started. The FAKE
+source directory is automatically shared with the VM under the `/vagrant` directory.
+
+Run `vagrant ssh` to directly connect via SSH to the VM and start working.
+
+Alternately, you can directly execute any command with `vagrant ssh -c "<command>"`.
+As example, you can directly invoke the `build.sh` script with the
+`vagrant ssh -c "cd /vagrant && bash ./build.sh"` command.
+
+Once you have finished, you can either:
+
+* Run `vagrant suspend` to pause the VM.
+* Run `vagrant halt` to shutdown the VM.
+* Run `vagrant destroy` to delete the imported VM.
+* Run `vagrant box remove ubuntu/trusty64` to remove the base box from your computer.
+* Re-run `vagrant up` to reload the VM.
+
+The full command line documentation is available at [docs.vagrantup.com](https://docs.vagrantup.com/).
+
+# Further information
+
+* [Vagrant Documentation](https://docs.vagrantup.com/v2/)
+* [Vagrant on GitHub](https://github.com/mitchellh/vagrant)
+* [What is Vagrant and why should I care](http://24ways.org/2014/what-is-vagrant-and-why-should-i-care/)
+* [Packer](https://www.packer.io/) (used to create base boxes).


### PR DESCRIPTION
As promised in #711, here is a refresh of the help regarding contributions and development environments.

I marked this as WIP because I did not found a proper way to insert a link in `help/contributing.md` pointing to `help/vagrant.md` and working in both GitHub and FSharp.Formatter.

Previews of the GitHub parsing can be seen here:
* [`help/contributing.md`](https://github.com/bbenoist/FAKE/blob/feature/contributing-doc/help/contributing.md)
* [`help/vagrant.md`](https://github.com/bbenoist/FAKE/blob/feature/contributing-doc/help/vagrant.md)