### PR TITLE
Find NuGet.exe in current folder (and sub-folders) first, then look in PATH

### DIFF
--- a/src/app/FakeLib/RestorePackageHelper.fs
+++ b/src/app/FakeLib/RestorePackageHelper.fs
@@ -5,30 +5,39 @@ module Fake.RestorePackageHelper
 
 open System
 
-/// Looks for a tool in all subfolders - returns the tool file name.
+/// Looks for NuGet.exe in [1] the specified defaultPath, [2] a list of standard tool folders, [3] any subfolder in the current directory, [4] the PATH - returns the first path where NuGet.exe was found.
 let findNuget defaultPath = 
     try
         let priorityList = 
-            [currentDirectory @@ "tools" @@ "NuGet"
+            [defaultPath
+             currentDirectory @@ "tools" @@ "NuGet"
              currentDirectory @@ ".nuget"             
              currentDirectory @@ "packages" @@ "NuGet.Commandline" @@ "tools"
              currentDirectory @@ "packages" @@ "Nuget.Commandline" @@ "tools"]
-            |> Seq.append pathDirectories
-
+            
         let exeNames = ["nuget.exe"; "NuGet.exe"; "Nuget.exe"]
 
-        let priorityPaths =
-            seq { for path in priorityList do
+        let findInFolders folders =
+            seq { for path in folders do
                     for name in exeNames do
                       let fi = fileInfo(path @@ name)
                       if fi.Exists then yield fi.FullName }
+
+        // Find in defaultPath or priorityFolders
+        let priorityPaths = findInFolders priorityList
         if not <| Seq.isEmpty priorityPaths then Seq.head priorityPaths else
 
+        // Find in ANY subfolder
         let tools = !! ("./**/" @@ "nuget.exe")
-        if Seq.isEmpty tools then 
-            let tools = !! ("./**/" @@ "NuGet.exe")
-            if Seq.isEmpty tools then defaultPath @@ "NuGet.exe" else Seq.head tools
-        else Seq.head tools
+                    ++ ("./**/" @@ "NuGet.exe")
+                    ++ ("./**/" @@ "Nuget.exe")
+        if not <| Seq.isEmpty tools then Seq.head tools else
+
+        // Find in PATH
+        let nugetInPATH = findInFolders pathDirectories
+        if not <| Seq.isEmpty nugetInPATH then Seq.head nugetInPATH else
+
+        defaultPath @@ "NuGet.exe"
     with
     | _ -> defaultPath @@ "NuGet.exe"
 


### PR DESCRIPTION
Fixes #717. Also bumped priority of the "defaultPath" parameter - treating it as the "default" path (to look in) now, rather than merely as a fall-back.