### PR TITLE
Generalize archive helpers

### DIFF
--- a/src/app/FakeLib/ArchiveHelper.fs
+++ b/src/app/FakeLib/ArchiveHelper.fs
@@ -1,0 +1,234 @@
+﻿/// Provides utility tasks for storing and compressing files in archives.
+module Fake.ArchiveHelper
+
+open System
+open System.IO
+open ICSharpCode.SharpZipLib.Core
+open ICSharpCode.SharpZipLib.BZip2
+open ICSharpCode.SharpZipLib.GZip
+open ICSharpCode.SharpZipLib.Tar
+open ICSharpCode.SharpZipLib.Zip
+
+[<Literal>]
+let private DefaultBufferSize = 32768
+
+/// A description of a file to be added to an archive.
+type ArchiveFileSpec = { InputFilePath : string; ArchiveFilePath : string }
+
+let private copyFileBuffered bufferSize (outStream : #Stream) (inStream : #Stream) =
+    let rec doCopy buffer (outStream : #Stream) (inStream : #Stream) length =
+        if length > 0L then
+            let count = inStream.Read(buffer, 0, buffer.Length)
+            outStream.Write(buffer, 0, count)
+            doCopy buffer outStream inStream (length - int64 count)
+
+    let length = inStream.Length
+    inStream.Seek(0L, SeekOrigin.Begin) |> ignore
+    let buffer = Array.zeroCreate<byte> bufferSize
+    doCopy buffer outStream inStream length
+
+let private addEntry prepareEntry afterEntry (outStream : #Stream) fileSpec =
+    let info = fileInfo fileSpec.InputFilePath
+    use inStream = info.OpenRead()
+    let entryName = prepareEntry info fileSpec.ArchiveFilePath
+    logfn "Compressed %s => %s" fileSpec.InputFilePath entryName
+    copyFileBuffered DefaultBufferSize outStream inStream
+    afterEntry outStream
+
+let private createArchiveStream (streamCreator : Stream -> #Stream) fileName =
+    File.Create(fileName) :> Stream
+    |> streamCreator
+
+let private createArchive streamCreator addEntry archiveName items =
+    use stream = streamCreator archiveName
+    Seq.iter (addEntry stream) items
+    tracefn "Archive successfully created %s" archiveName
+
+/// Constructs a file specification which will archive the file at the root.
+let archiveFileSpec filePath =
+    { InputFilePath = Path.GetFullPath(filePath)
+      ArchiveFilePath = Path.GetFileName(filePath) }
+
+/// Constructs a file specification which will archive the file with a path relative to the `baseDir`.
+let archiveFileSpecWithBaseDir baseDir filePath =
+    let baseDir = 
+        let dir = directoryInfo baseDir
+        if not dir.Exists then failwithf "Directory not found: %s" dir.FullName
+        dir.FullName
+
+    let fullFilePath = Path.GetFullPath(filePath)
+    { InputFilePath = fullFilePath
+      ArchiveFilePath = if isNotNullOrEmpty baseDir && fullFilePath.StartsWith(baseDir, true, Globalization.CultureInfo.InvariantCulture) then
+                            fullFilePath.[(baseDir.Length + 1)..]
+                        else
+                            failwithf "File to be included (%s) was not in base directory: %s" fullFilePath baseDir }
+
+module CompressionLevel =
+    type T = CompressionLevel of int
+
+    let private clipLevel = max 0 >> min 9
+
+    let Default = CompressionLevel 7
+
+    let create level = CompressionLevel (clipLevel level)
+
+    let value (CompressionLevel l) = l
+
+module Zip =
+    type ZipCompressionParams = { Comment : string option; Level : CompressionLevel.T }
+
+    let ZipCompressionDefaults = { Comment = None; Level = CompressionLevel.Default }
+
+    let private addEntry (outStream : ZipOutputStream) =
+        let prepareEntry (fileInfo : FileInfo) itemSpec =
+            let entry = new ZipEntry(ZipEntry.CleanName itemSpec)
+            entry.DateTime <- fileInfo.LastWriteTime
+            entry.Size <- fileInfo.Length
+            outStream.PutNextEntry(entry)
+            entry.Name
+        let afterEntry (outStream : ZipOutputStream) =
+            outStream.CloseEntry()
+        addEntry prepareEntry afterEntry outStream
+
+    let stream { Level = level; Comment = comment } inner =
+        let zipStream = new ZipOutputStream(inner)
+        zipStream.SetLevel <| CompressionLevel.value level
+        match comment with | Some c -> zipStream.SetComment <| c | _ -> ()
+        zipStream
+
+    let createFile zipParams fileName =
+        tracefn "Creating zip archive: %s (%A)" fileName zipParams.Level
+        createArchiveStream (stream zipParams) fileName
+
+    let compress zipParams =
+        createArchive (createFile zipParams) addEntry
+
+module GZip =
+    type GZipCompressionParams = { Level : CompressionLevel.T }
+
+    let GZipCompressionDefaults = { Level = CompressionLevel.Default }
+
+    let stream { Level = level } inner =
+        let gzipStream = new GZipOutputStream(inner)
+        gzipStream.SetLevel <| CompressionLevel.value level
+        gzipStream
+
+    let createFile gzipParams fileName =
+        tracefn "Creating gz archive: %s (%A)" fileName gzipParams.Level
+        createArchiveStream (stream gzipParams) fileName
+
+    let compressFile level outFile fileName =
+        use inStream = (fileInfo fileName).OpenRead()
+        createArchive (createFile level) (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
+
+module BZip2 =
+    let stream inner = new BZip2OutputStream(inner)
+
+    let createFile fileName =
+        tracefn "Creating bz2 archive: %s" fileName
+        createArchiveStream stream fileName
+
+    let compressFile level outFile fileName =
+        use inStream = (fileInfo fileName).OpenRead()
+        createArchive createFile (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
+
+module Tar =
+    let private addEntry (outStream : TarOutputStream) =
+        let prepareEntry (fileInfo : FileInfo) itemSpec =
+            let entry = TarEntry.CreateTarEntry itemSpec
+            entry.ModTime <- fileInfo.LastWriteTime
+            entry.Size <- fileInfo.Length
+            outStream.PutNextEntry(entry)
+            entry.Name
+        let afterEntry (outStream : TarOutputStream) =
+            outStream.CloseEntry()
+        addEntry prepareEntry afterEntry outStream
+
+    let stream inner = new TarOutputStream(inner)
+
+    let createFile fileName =
+        tracefn "Creating tar archive: %s" fileName
+        createArchiveStream stream fileName
+
+    let compress fileName items =
+        createArchive createFile addEntry fileName items
+
+    module GZip =
+        let stream gzipParams = GZip.stream gzipParams >> stream
+
+        let createFile (gzipParams : GZip.GZipCompressionParams) fileName =
+            tracefn "Creating tar.gz archive: %s (%A)" fileName gzipParams.Level
+            createArchiveStream (stream gzipParams) fileName
+    
+        let compress gzipParam =
+            createArchive (createFile gzipParam) addEntry
+
+    module BZip2 =
+        let stream = BZip2.stream >> stream
+
+        let createFile fileName =
+            tracefn "Creating tar.bz2 archive: %s" fileName
+            createArchiveStream stream fileName
+
+        let compress fileName items =
+            createArchive createFile addEntry fileName items
+
+let private doCompression compressor archivePath fileSpecGenerator =
+    Seq.map fileSpecGenerator
+    >> compressor archivePath
+
+let private buildFileSpec flatten baseDir =
+    (if flatten then archiveFileSpec else archiveFileSpecWithBaseDir baseDir)
+
+/// Creates a zip archive with the given files.
+/// ## Parameters
+///  - `zipParams` - The compression parameters.
+///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let CreateZip zipParams flatten baseDir archivePath files =
+    doCompression (Zip.compress zipParams) archivePath (buildFileSpec flatten baseDir) files
+
+/// Creates a zip archive with the given files with default parameters.
+/// ## Parameters
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let Zip baseDir archivePath files =
+    doCompression (Zip.compress Zip.ZipCompressionDefaults) archivePath (buildFileSpec false baseDir) files
+
+/// Creates a tar.gz archive with the given files.
+/// ## Parameters
+///  - `gzipParams` - The compression parameters.
+///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let CreateTarGZip gzipParams flatten baseDir archivePath files =
+    doCompression (Tar.GZip.compress gzipParams) archivePath (buildFileSpec flatten baseDir) files
+
+/// Creates a tar.gz archive with the given files with default parameters.
+/// ## Parameters
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let TarGZip baseDir archivePath files =
+    doCompression (Tar.GZip.compress GZip.GZipCompressionDefaults) archivePath (buildFileSpec false baseDir) files
+
+/// Creates a tar.bz2 archive with the given files.
+/// ## Parameters
+///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let CreateTarBZip2 flatten baseDir archivePath files =
+    doCompression Tar.BZip2.compress archivePath (buildFileSpec flatten baseDir) files
+
+/// Creates a tar.gz archive with the given files with default parameters.
+/// ## Parameters
+///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
+///  - `archivePath` - The fileName of the resulting archive.
+///  - `files` - A sequence with files to compress.
+let TarBZip2 baseDir archivePath files =
+    doCompression Tar.BZip2.compress archivePath (buildFileSpec false baseDir) files

--- a/src/app/FakeLib/ArchiveHelper.fs
+++ b/src/app/FakeLib/ArchiveHelper.fs
@@ -4,64 +4,82 @@ module Fake.ArchiveHelper
 open System
 open System.IO
 open ICSharpCode.SharpZipLib.Core
-open ICSharpCode.SharpZipLib.BZip2
-open ICSharpCode.SharpZipLib.GZip
-open ICSharpCode.SharpZipLib.Tar
-open ICSharpCode.SharpZipLib.Zip
 
 [<Literal>]
 let private DefaultBufferSize = 32768
 
 /// A description of a file to be added to an archive.
-type ArchiveFileSpec = { InputFilePath : string; ArchiveFilePath : string }
+type ArchiveFileSpec = { InputFile : FileInfo; ArchiveEntryPath : string }
 
-let private copyFileBuffered bufferSize (outStream : #Stream) (inStream : #Stream) =
+type private ExtractEntrySpec = { OutputFile : FileInfo; ArchiveEntryPath : string; EntrySize : int64 }
+
+let private copyStreamBuffered bufferSize (outStream : #Stream) (inStream : #Stream) length =
     let rec doCopy buffer (outStream : #Stream) (inStream : #Stream) length =
         if length > 0L then
             let count = inStream.Read(buffer, 0, buffer.Length)
             outStream.Write(buffer, 0, count)
             doCopy buffer outStream inStream (length - int64 count)
 
-    let length = inStream.Length
-    inStream.Seek(0L, SeekOrigin.Begin) |> ignore
     let buffer = Array.zeroCreate<byte> bufferSize
     doCopy buffer outStream inStream length
 
-let private addEntry prepareEntry afterEntry (outStream : #Stream) fileSpec =
-    let info = fileInfo fileSpec.InputFilePath
-    use inStream = info.OpenRead()
-    let entryName = prepareEntry info fileSpec.ArchiveFilePath
-    logfn "Compressed %s => %s" fileSpec.InputFilePath entryName
+let private copyFileBuffered bufferSize (outStream : #Stream) (inStream : #Stream) =
+    inStream.Seek(0L, SeekOrigin.Begin) |> ignore
+    copyStreamBuffered bufferSize outStream inStream inStream.Length
+    
+let private addEntry prepareEntry afterEntry (outStream : #Stream) { InputFile = inFile; ArchiveEntryPath = entryPath } =
+    use inStream = inFile.OpenRead()
+    let entryName = prepareEntry inFile entryPath
     copyFileBuffered DefaultBufferSize outStream inStream
+    logfn "Compressed %s => %s" inFile.FullName entryName
     afterEntry outStream
 
-let private createArchiveStream (streamCreator : Stream -> #Stream) fileName =
-    File.Create(fileName) :> Stream
+let private extractEntry (inStream : #Stream) entry =
+    entry.OutputFile.Directory |> ensureDirExists
+    use outStream = entry.OutputFile.Create()
+    copyStreamBuffered DefaultBufferSize outStream inStream entry.EntrySize
+    logfn "Extracted %s => %s" entry.ArchiveEntryPath entry.OutputFile.FullName
+
+let private createArchiveStream (streamCreator : Stream -> #Stream) (archiveFile : FileInfo) =
+    archiveFile.Create() :> Stream
     |> streamCreator
 
-let private createArchive streamCreator addEntry archiveName items =
-    use stream = streamCreator archiveName
+let private openArchiveStream (streamCreator : Stream -> #Stream) (archiveFile : FileInfo) =
+    archiveFile.OpenRead() :> Stream
+    |> streamCreator
+
+let private createArchive streamCreator addEntry (archiveFile : FileInfo) items =
+    use stream = streamCreator archiveFile
     Seq.iter (addEntry stream) items
-    tracefn "Archive successfully created %s" archiveName
+    tracefn "Archive successfully created %s" archiveFile.FullName
+
+let rec private extractEntries getNextEntry (inStream : #Stream) =
+    match getNextEntry inStream with
+    | Some entry -> 
+        extractEntry inStream entry
+        extractEntries getNextEntry inStream
+    | None -> ()
 
 /// Constructs a file specification which will archive the file at the root.
-let archiveFileSpec filePath =
-    { InputFilePath = Path.GetFullPath(filePath)
-      ArchiveFilePath = Path.GetFileName(filePath) }
+let archiveFileSpec (file : FileInfo) =
+    { InputFile = file; ArchiveEntryPath = file.Name }
 
 /// Constructs a file specification which will archive the file with a path relative to the `baseDir`.
-let archiveFileSpecWithBaseDir baseDir filePath =
-    let baseDir = 
-        let dir = directoryInfo baseDir
-        if not dir.Exists then failwithf "Directory not found: %s" dir.FullName
-        dir.FullName
+let archiveFileSpecWithBaseDir (baseDir : DirectoryInfo) (file : FileInfo) =
+    if not baseDir.Exists then failwithf "Directory not found: %s" baseDir.FullName
+    if not <| isInFolder baseDir file then failwithf "File not in base directory: (BaseDir: %s, File: %s)" baseDir.FullName file.FullName
+    { InputFile = file; ArchiveEntryPath = replace (baseDir.FullName + directorySeparator) "" file.FullName }
 
-    let fullFilePath = Path.GetFullPath(filePath)
-    { InputFilePath = fullFilePath
-      ArchiveFilePath = if isNotNullOrEmpty baseDir && fullFilePath.StartsWith(baseDir, true, Globalization.CultureInfo.InvariantCulture) then
-                            fullFilePath.[(baseDir.Length + 1)..]
-                        else
-                            failwithf "File to be included (%s) was not in base directory: %s" fullFilePath baseDir }
+let private doCompression compressor archivePath fileSpecGenerator =
+    Seq.map fileSpecGenerator
+    >> compressor archivePath
+
+let private buildFileSpec flatten baseDir =
+    (if flatten then archiveFileSpec else archiveFileSpecWithBaseDir baseDir)
+
+let private allFilesInDirectory (baseDir : DirectoryInfo) =
+    !! (baseDir.FullName @@ "**" @@ "*")
+    |> Seq.map fileInfo
 
 module CompressionLevel =
     type T = CompressionLevel of int
@@ -75,11 +93,13 @@ module CompressionLevel =
     let value (CompressionLevel l) = l
 
 module Zip =
+    open ICSharpCode.SharpZipLib.Zip
+    
     type ZipCompressionParams = { Comment : string option; Level : CompressionLevel.T }
 
     let ZipCompressionDefaults = { Comment = None; Level = CompressionLevel.Default }
 
-    let private addEntry (outStream : ZipOutputStream) =
+    let addZipEntry (outStream : ZipOutputStream) =
         let prepareEntry (fileInfo : FileInfo) itemSpec =
             let entry = new ZipEntry(ZipEntry.CleanName itemSpec)
             entry.DateTime <- fileInfo.LastWriteTime
@@ -90,50 +110,158 @@ module Zip =
             outStream.CloseEntry()
         addEntry prepareEntry afterEntry outStream
 
-    let stream { Level = level; Comment = comment } inner =
+    let compressStream { Level = level; Comment = comment } inner =
         let zipStream = new ZipOutputStream(inner)
         zipStream.SetLevel <| CompressionLevel.value level
         match comment with | Some c -> zipStream.SetComment <| c | _ -> ()
         zipStream
 
-    let createFile zipParams fileName =
-        tracefn "Creating zip archive: %s (%A)" fileName zipParams.Level
-        createArchiveStream (stream zipParams) fileName
+    let extractStream inner = new ZipInputStream(inner)
+
+    let createFile zipParams (file : FileInfo) =
+        tracefn "Creating zip archive: %s (%A)" file.FullName zipParams.Level
+        createArchiveStream (compressStream zipParams) file
 
     let compress zipParams =
-        createArchive (createFile zipParams) addEntry
+        createArchive (createFile zipParams) addZipEntry
+
+    let extract (extractDir : DirectoryInfo) (archiveFile : FileInfo) =
+        let rec getNextEntry (stream : ZipInputStream) =
+            let entry = stream.GetNextEntry()
+            match entry with
+            | null -> None
+            | _ when not entry.IsFile -> getNextEntry stream
+            | _ ->
+                let outFile = extractDir.FullName @@ entry.Name |> fileInfo
+                Some { OutputFile = outFile; ArchiveEntryPath = entry.Name; EntrySize = entry.Size }
+
+        openArchiveStream extractStream archiveFile
+        |> extractEntries getNextEntry 
+        logfn "Extracted %s" archiveFile.FullName
+
+    /// Extracts a zip archive to a given directory.
+    /// ## Parameters
+    ///  - `targetDir` - The directory into which the archived files will be extracted.
+    ///  - `archivePath` - The archive to be extracted.
+    let Extract targetDir archivePath =
+        extract targetDir archivePath
+
+    /// Creates a zip archive with the given files.
+    /// ## Parameters
+    ///  - `setParams` - A function which modifies the default compression parameters.
+    ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+    ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `files` - A sequence of files to compress.
+    let Compress setParams flatten baseDir archiveFile files =
+        doCompression (setParams ZipCompressionDefaults |> compress) archiveFile (buildFileSpec flatten baseDir) files
+
+    /// Creates a zip archive with the given archive file specifications.
+    /// ## Parameters
+    ///  - `setParams` - A function which modifies the default compression parameters.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `fileSpecs` - A sequence of archive file specifications.
+    let CompressSpecs setParams archiveFile fileSpecs =
+        doCompression (setParams ZipCompressionDefaults |> compress) archiveFile id fileSpecs
+
+    /// Creates a zip archive with the given files with default parameters.
+    /// ## Parameters
+    ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `files` - A sequence of files to compress.
+    let CompressWithDefaults baseDir archiveFile files =
+        Compress id false baseDir archiveFile files
+
+    /// Creates a zip archive containing all the files in a directory.
+    /// ## Parameters
+    ///  - `setParams` - A function which modifies the default compression parameters.
+    ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+    ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    let CompressDir setParams flatten (baseDir : DirectoryInfo) archiveFile =
+        allFilesInDirectory baseDir |> Compress setParams flatten baseDir archiveFile
+
+    /// Creates a zip archive containing all the files in a directory.
+    /// ## Parameters
+    ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    let CompressDirWithDefaults (baseDir : DirectoryInfo) archiveFile =
+        allFilesInDirectory baseDir |> CompressWithDefaults baseDir archiveFile
 
 module GZip =
+    open ICSharpCode.SharpZipLib.GZip
+
     type GZipCompressionParams = { Level : CompressionLevel.T }
 
     let GZipCompressionDefaults = { Level = CompressionLevel.Default }
 
-    let stream { Level = level } inner =
+    let compressStream { Level = level } inner =
         let gzipStream = new GZipOutputStream(inner)
         gzipStream.SetLevel <| CompressionLevel.value level
         gzipStream
 
-    let createFile gzipParams fileName =
-        tracefn "Creating gz archive: %s (%A)" fileName gzipParams.Level
-        createArchiveStream (stream gzipParams) fileName
+    let extractStream inner = new GZipInputStream(inner)
 
-    let compressFile level outFile fileName =
-        use inStream = (fileInfo fileName).OpenRead()
-        createArchive (createFile level) (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
+    let createFile gzipParams (file : FileInfo) =
+        tracefn "Creating gz archive: %s (%A)" file.FullName gzipParams.Level
+        createArchiveStream (compressStream gzipParams) file
+
+    /// Extracts a file compressed with gzip.
+    /// ## Parameters
+    ///  - `outFile` - The extracted output file. If existing, will be overwritten.
+    ///  - `file` - The compressed file.
+    let ExtractFile outFile (file : FileInfo) =
+        use inStream = openArchiveStream extractStream file
+        extractEntry inStream { OutputFile = outFile; ArchiveEntryPath = file.FullName; EntrySize = inStream.Length }
+
+    /// Compresses a file using gzip.
+    /// ## Parameters
+    ///  - `setParams` - A function which modifies the default compression parameters.
+    ///  - `outFile` - The compressed output file. If existing, will be overwritten.
+    ///  - `file` - The file to be compressed.
+    let CompressFile setParams outFile (file : FileInfo) =
+        use inStream = file.OpenRead()
+        createArchive (setParams GZipCompressionDefaults |> createFile) (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
+
+    /// Compresses a file using gzip.
+    /// ## Parameters
+    ///  - `outFile` - The compressed output file. If existing, will be overwritten.
+    ///  - `file` - The file to be compressed.
+    let CompressFileWithDefaults outFile (file : FileInfo) =
+        use inStream = file.OpenRead()
+        createArchive (createFile GZipCompressionDefaults) (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
 
 module BZip2 =
-    let stream inner = new BZip2OutputStream(inner)
+    open ICSharpCode.SharpZipLib.BZip2
 
-    let createFile fileName =
-        tracefn "Creating bz2 archive: %s" fileName
-        createArchiveStream stream fileName
+    let compressStream inner = new BZip2OutputStream(inner)
 
-    let compressFile level outFile fileName =
-        use inStream = (fileInfo fileName).OpenRead()
+    let extractStream inner = new BZip2InputStream(inner)
+
+    let createFile (file : FileInfo) =
+        tracefn "Creating bz2 archive: %s" file.FullName
+        createArchiveStream compressStream file
+
+    /// Extracts a file compressed with bzip2.
+    /// ## Parameters
+    ///  - `outFile` - The extracted output file. If existing, will be overwritten.
+    ///  - `file` - The compressed file.
+    let ExtractFile outFile (file : FileInfo) =
+        use inStream = openArchiveStream extractStream file
+        extractEntry inStream { OutputFile = outFile; ArchiveEntryPath = file.FullName; EntrySize = inStream.Length }
+
+    /// Compresses a file using bzip2.
+    /// ## Parameters
+    ///  - `outFile` - The compressed output file. If existing, will be overwritten.
+    ///  - `file` - The file to be compressed.
+    let CompressFile outFile (file : FileInfo) =
+        use inStream = file.OpenRead()
         createArchive createFile (copyFileBuffered DefaultBufferSize) outFile (Seq.singleton inStream)
 
 module Tar =
-    let private addEntry (outStream : TarOutputStream) =
+    open ICSharpCode.SharpZipLib.Tar
+
+    let addEntry (outStream : TarOutputStream) =
         let prepareEntry (fileInfo : FileInfo) itemSpec =
             let entry = TarEntry.CreateTarEntry itemSpec
             entry.ModTime <- fileInfo.LastWriteTime
@@ -144,91 +272,202 @@ module Tar =
             outStream.CloseEntry()
         addEntry prepareEntry afterEntry outStream
 
-    let stream inner = new TarOutputStream(inner)
+    let compressStream inner = new TarOutputStream(inner)
 
-    let createFile fileName =
-        tracefn "Creating tar archive: %s" fileName
-        createArchiveStream stream fileName
+    let extractStream inner = new TarInputStream(inner)
 
-    let compress fileName items =
-        createArchive createFile addEntry fileName items
+    let createFile (file : FileInfo) =
+        tracefn "Creating tar archive: %s" file.FullName
+        createArchiveStream compressStream file
+
+    let compress file items =
+        createArchive createFile addEntry file items
+
+    let rec private getNextEntry (extractDir : DirectoryInfo) (stream : TarInputStream) =
+        let entry = stream.GetNextEntry()
+        match entry with
+        | null -> None
+        | _ when entry.IsDirectory -> getNextEntry extractDir stream
+        | _ ->
+            let outFile = extractDir.FullName @@ entry.Name |> fileInfo
+            Some { OutputFile = outFile; ArchiveEntryPath = entry.Name; EntrySize = entry.Size }
+
+    let extract (extractDir : DirectoryInfo) (archiveFile : FileInfo) =
+        openArchiveStream extractStream archiveFile
+        |> extractEntries (getNextEntry extractDir)
+        logfn "Extracted %s" archiveFile.FullName
+
+    /// Extracts a tar archive to a given directory.
+    /// ## Parameters
+    ///  - `targetDir` - The directory into which the archived files will be extracted.
+    ///  - `archivePath` - The archive to be extracted.
+    let Extract targetDir archivePath =
+        extract targetDir archivePath
+
+    /// Creates a tar archive with the given files.
+    /// ## Parameters
+    ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+    ///  - `baseDir` - The relative directory of the files to be archived. Use this parameter to influence directory structure within the archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `files` - A sequence of files to store.
+    let Store flatten baseDir archiveFile files =
+        doCompression compress archiveFile (buildFileSpec flatten baseDir) files
+
+    /// Creates a tar archive with the given archive file specifications.
+    /// ## Parameters
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `fileSpecs` - A sequence of archive file specifications.
+    let StoreSpecs archiveFile fileSpecs =
+        doCompression compress archiveFile id fileSpecs
+
+    /// Creates a tar archive with the given files with default parameters.
+    /// ## Parameters
+    ///  - `baseDir` - The relative directory of the files to be archived. Use this parameter to influence directory structure within the archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    ///  - `files` - A sequence of files to store.
+    let StoreWithDefaults baseDir archiveFile files =
+        Store false baseDir archiveFile files
+
+    /// Creates a tar archive containing all the files in a directory.
+    /// ## Parameters
+    ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+    ///  - `baseDir` - The base directory to be archived. This directory will be the root of the resulting archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    let CompressDir flatten (baseDir : DirectoryInfo) archiveFile =
+        allFilesInDirectory baseDir |> Store flatten baseDir archiveFile
+
+    /// Creates a tar.gz archive containing all the files in a directory.
+    /// ## Parameters
+    ///  - `baseDir` - The base directory to be archived. This directory will be the root of the resulting archive.
+    ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+    let CompressDirWithDefaults (baseDir : DirectoryInfo) archiveFile =
+        allFilesInDirectory baseDir |> StoreWithDefaults baseDir archiveFile
 
     module GZip =
-        let stream gzipParams = GZip.stream gzipParams >> stream
+        let compressStream gzipParams = GZip.compressStream gzipParams >> compressStream
 
-        let createFile (gzipParams : GZip.GZipCompressionParams) fileName =
-            tracefn "Creating tar.gz archive: %s (%A)" fileName gzipParams.Level
-            createArchiveStream (stream gzipParams) fileName
+        let extractStream = GZip.extractStream >> extractStream
+
+        let createFile (gzipParams : GZip.GZipCompressionParams) (file : FileInfo) =
+            tracefn "Creating tar.gz archive: %s (%A)" file.FullName gzipParams.Level
+            createArchiveStream (compressStream gzipParams) file
     
         let compress gzipParam =
             createArchive (createFile gzipParam) addEntry
 
+        let extract extractDir archiveFile =
+            openArchiveStream extractStream archiveFile
+            |> extractEntries (getNextEntry extractDir)
+            logfn "Extracted %s" archiveFile.FullName
+
+        /// Extracts a tar.gz archive to a given directory.
+        /// ## Parameters
+        ///  - `targetDir` - The directory into which the archived files will be extracted.
+        ///  - `archivePath` - The archive to be extracted.
+        let Extract targetDir archivePath =
+            extract targetDir archivePath
+
+        /// Creates a tar.gz archive with the given files.
+        /// ## Parameters
+        ///  - `setParams` - A function which modifies the default compression parameters.
+        ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+        ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `files` - A sequence of files to compress.
+        let Compress setParams flatten baseDir archiveFile files =
+            doCompression (setParams GZip.GZipCompressionDefaults |> compress) archiveFile (buildFileSpec flatten baseDir) files
+
+        /// Creates a tar.gz archive with the given archive file specifications.
+        /// ## Parameters
+        ///  - `setParams` - A function which modifies the default compression parameters.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `fileSpecs` - A sequence of archive file specifications.
+        let CompressSpecs setParams archiveFile fileSpecs =
+            doCompression (setParams GZip.GZipCompressionDefaults |> compress) archiveFile id fileSpecs
+
+        /// Creates a tar.gz archive with the given files with default parameters.
+        /// ## Parameters
+        ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `files` - A sequence of files to compress.
+        let CompressWithDefaults baseDir archiveFile files =
+            Compress id false baseDir archiveFile files
+
+        /// Creates a tar.gz archive containing all the files in a directory.
+        /// ## Parameters
+        ///  - `setParams` - A function which modifies the default compression parameters.
+        ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+        ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        let CompressDir setParams flatten (baseDir : DirectoryInfo) archiveFile =
+            allFilesInDirectory baseDir |> Compress setParams flatten baseDir archiveFile
+
+        /// Creates a tar.gz archive containing all the files in a directory.
+        /// ## Parameters
+        ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        let CompressDirWithDefaults (baseDir : DirectoryInfo) archiveFile =
+            allFilesInDirectory baseDir |> CompressWithDefaults baseDir archiveFile
+
     module BZip2 =
-        let stream = BZip2.stream >> stream
+        let compressStream = BZip2.compressStream >> compressStream
 
-        let createFile fileName =
-            tracefn "Creating tar.bz2 archive: %s" fileName
-            createArchiveStream stream fileName
+        let extractStream = BZip2.extractStream >> extractStream
 
-        let compress fileName items =
-            createArchive createFile addEntry fileName items
+        let createFile (file : FileInfo) =
+            tracefn "Creating tar.bz2 archive: %s" file.FullName
+            createArchiveStream compressStream file
 
-let private doCompression compressor archivePath fileSpecGenerator =
-    Seq.map fileSpecGenerator
-    >> compressor archivePath
+        let compress =
+            createArchive createFile addEntry
 
-let private buildFileSpec flatten baseDir =
-    (if flatten then archiveFileSpec else archiveFileSpecWithBaseDir baseDir)
+        let extract extractDir archiveFile =
+            openArchiveStream extractStream archiveFile
+            |> extractEntries (getNextEntry extractDir)
+            logfn "Extracted %s" archiveFile.FullName
 
-/// Creates a zip archive with the given files.
-/// ## Parameters
-///  - `zipParams` - The compression parameters.
-///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let CreateZip zipParams flatten baseDir archivePath files =
-    doCompression (Zip.compress zipParams) archivePath (buildFileSpec flatten baseDir) files
+        /// Extracts a tar.bz2 archive to a given directory.
+        /// ## Parameters
+        ///  - `targetDir` - The directory into which the archived files will be extracted.
+        ///  - `archivePath` - The archive to be extracted.
+        let Extract targetDir archivePath =
+            extract targetDir archivePath
 
-/// Creates a zip archive with the given files with default parameters.
-/// ## Parameters
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let Zip baseDir archivePath files =
-    doCompression (Zip.compress Zip.ZipCompressionDefaults) archivePath (buildFileSpec false baseDir) files
+        /// Creates a tar.bz2 archive with the given files.
+        /// ## Parameters
+        ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+        ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `files` - A sequence of files to compress.
+        let Compress flatten baseDir archiveFile files =
+            doCompression compress archiveFile (buildFileSpec flatten baseDir) files
 
-/// Creates a tar.gz archive with the given files.
-/// ## Parameters
-///  - `gzipParams` - The compression parameters.
-///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let CreateTarGZip gzipParams flatten baseDir archivePath files =
-    doCompression (Tar.GZip.compress gzipParams) archivePath (buildFileSpec flatten baseDir) files
+        /// Creates a tar.bz2 archive with the given archive file specifications.
+        /// ## Parameters
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `fileSpecs` - A sequence of archive file specifications.
+        let CompressSpecs archiveFile fileSpecs =
+            doCompression compress archiveFile id fileSpecs
 
-/// Creates a tar.gz archive with the given files with default parameters.
-/// ## Parameters
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let TarGZip baseDir archivePath files =
-    doCompression (Tar.GZip.compress GZip.GZipCompressionDefaults) archivePath (buildFileSpec false baseDir) files
+        /// Creates a tar.bz2 archive with the given files with default parameters.
+        /// ## Parameters
+        ///  - `baseDir` - The relative directory of the files to be compressed. Use this parameter to influence directory structure within the archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        ///  - `files` - A sequence of files to compress.
+        let CompressWithDefaults baseDir archiveFile files =
+            Compress false baseDir archiveFile files
 
-/// Creates a tar.bz2 archive with the given files.
-/// ## Parameters
-///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let CreateTarBZip2 flatten baseDir archivePath files =
-    doCompression Tar.BZip2.compress archivePath (buildFileSpec flatten baseDir) files
+        /// Creates a tar.bz2 archive containing all the files in a directory.
+        /// ## Parameters
+        ///  - `flatten` - If set to true then all subfolders are merged into the root folder of the archive.
+        ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        let CompressDir flatten (baseDir : DirectoryInfo) archiveFile =
+            allFilesInDirectory baseDir |> Compress flatten baseDir archiveFile
 
-/// Creates a tar.gz archive with the given files with default parameters.
-/// ## Parameters
-///  - `baseDir` - The relative dir of the files to be compressed. Use this parameter to influence directory structure within the archive.
-///  - `archivePath` - The fileName of the resulting archive.
-///  - `files` - A sequence with files to compress.
-let TarBZip2 baseDir archivePath files =
-    doCompression Tar.BZip2.compress archivePath (buildFileSpec false baseDir) files
+        /// Creates a tar.bz2 archive containing all the files in a directory.
+        /// ## Parameters
+        ///  - `baseDir` - The base directory to be compressed. This directory will be the root of the resulting archive.
+        ///  - `archiveFile` - The output archive file. If existing, will be overwritten.
+        let CompressDirWithDefaults (baseDir : DirectoryInfo) archiveFile =
+            allFilesInDirectory baseDir |> CompressWithDefaults baseDir archiveFile

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -56,8 +56,8 @@
     <Compile Include="ProcessHelper.fs" />
     <Compile Include="AppVeyor.fs" />
     <Compile Include="TaskRunnerHelper.fs" />
-    <Compile Include="Globbing\Globbing.fs" />    
-    <Compile Include="Globbing\FileSystem.fs" />    
+    <Compile Include="Globbing\Globbing.fs" />
+    <Compile Include="Globbing\FileSystem.fs" />
     <Compile Include="UnitTest\UnitTestCommon.fs" />
     <Compile Include="UnitTest\UnitTestHelper.fs" />
     <Compile Include="UnitTest\NUnit\Xml.fs" />
@@ -79,6 +79,7 @@
     <Compile Include="MsBuildLogger.fs" />
     <Compile Include="FileHelper.fs" />
     <Compile Include="MSBuildHelper.fs" />
+    <Compile Include="ArchiveHelper.fs" />
     <Compile Include="ZipHelper.fs" />
     <Compile Include="StrongNamingHelper.fs" />
     <Compile Include="GACHelper.fs" />

--- a/src/app/FakeLib/ZipHelper.fs
+++ b/src/app/FakeLib/ZipHelper.fs
@@ -2,41 +2,15 @@
 /// This module contains helper function to create and extract zip archives.
 module Fake.ZipHelper
 
-open System.IO
-open ICSharpCode.SharpZipLib.Zip
-open ICSharpCode.SharpZipLib.Core
-open System
+open Fake.ArchiveHelper
 
 /// The default zip level
 let DefaultZipLevel = 7
 
-let private addZipEntry (stream : ZipOutputStream) (buffer : byte[]) (item : string) (itemSpec : string) =
-    let info = fileInfo item
-    let itemSpec = ZipEntry.CleanName itemSpec
-    logfn "Adding File %s" itemSpec
-    let entry = new ZipEntry(itemSpec)
-    entry.DateTime <- info.LastWriteTime
-    entry.Size <- info.Length
-    use stream2 = info.OpenRead()
-    stream.PutNextEntry(entry)
-    let length = ref stream2.Length
-    stream2.Seek(0L, SeekOrigin.Begin) |> ignore
-    while !length > 0L do
-        let count = stream2.Read(buffer, 0, buffer.Length)
-        stream.Write(buffer, 0, count)
-        length := !length - (int64 count)
-
-let private createZip fileName comment level (items : (string * string) seq) =
-    use stream = new ZipOutputStream(File.Create(fileName))
-    let zipLevel = min (max 0 level) 9
-    tracefn "Creating Zipfile: %s (Level: %d)" fileName zipLevel
-    stream.SetLevel zipLevel
-    if not (String.IsNullOrEmpty comment) then stream.SetComment comment
-    let buffer = Array.create 32768 0uy
-    for item, itemSpec in items do
-        addZipEntry stream buffer item itemSpec
-    stream.Finish()
-    tracefn "Zip successfully created %s" fileName
+let inline private setParams level comment p : Zip.ZipCompressionParams =
+    { p with
+            Comment = match comment with | null -> None | _ -> Some comment
+            Level = CompressionLevel.create level }
 
 /// Creates a zip file with the given files
 /// ## Parameters
@@ -47,60 +21,86 @@ let private createZip fileName comment level (items : (string * string) seq) =
 ///  - `flatten` - If set to true then all subfolders are merged into the root folder.
 ///  - `files` - A sequence with files to zip.
 let CreateZip workingDir fileName comment level flatten files =
-    let workingDir = 
-        let dir = directoryInfo workingDir
-        if not dir.Exists then failwithf "Directory not found: %s" dir.FullName
-        dir.FullName
+    files
+    |> Seq.map fileInfo
+    |> Zip.Compress (setParams level comment) flatten (directoryInfo workingDir) (fileInfo fileName)
 
-    let items = seq {
-        for item in files do
-            let info = fileInfo item
-            if info.Exists then 
-                let itemSpec = 
-                    if flatten then info.Name
-                    else if not (String.IsNullOrEmpty(workingDir)) 
-                            && info.FullName.StartsWith(workingDir, true, Globalization.CultureInfo.InvariantCulture) then 
-                        info.FullName.Remove(0, workingDir.Length)
-                    else info.FullName
-                yield item, itemSpec }
+/// Unzips a file with the given file name.
+/// ## Parameters
+///  - `target` - The target directory.
+///  - `fileName` - The file name of the zip file.
+let Unzip target (fileName : string) =
+    Zip.Extract (directoryInfo target) (fileInfo fileName)
 
-    createZip fileName comment level items
+/// Creates a zip file with the given file.
+/// ## Parameters
+///  - `fileName` - The file name of the resulting zip file.
+///  - `targetFileName` - The file to zip.
+let ZipFile fileName targetFileName =
+    let fi = fileInfo targetFileName
+
+    Seq.singleton fi
+    |> Zip.CompressWithDefaults fi.Directory (fileInfo fileName)
+
+let inline private toArchiveFileSpecs (archivePath, fileInclude) = seq {
+    for file in fileInclude do
+        let info = fileInfo file
+        yield archiveFileSpecWithAltBaseDir archivePath (directoryInfo fileInclude.BaseDirectory) info }
+
+/// Creates a zip file with the given files.
+/// ## Parameters
+///  - `fileName` - The file name of the resulting zip file.
+///  - `comment` - A comment for the resulting zip file.
+///  - `level` - The compression level.
+///  - `files` - A sequence of target folders and files to include relative to their base directory.
+let CreateZipOfIncludes fileName comment level files =
+    files
+    |> Seq.map toArchiveFileSpecs
+    |> Seq.concat
+    |> Zip.CompressSpecs (setParams comment level) (fileInfo fileName)
+
+/// Creates a zip file with the given files.
+/// ## Parameters
+///  - `fileName` - The file name of the resulting zip file.
+///  - `files` - A sequence of target folders and files to include relative to their base directory.
+///
+/// ## Sample
+///
+///     Target "Zip" (fun _ ->
+///         [   "", !! "MyWebApp/*.html"
+///                 ++ "MyWebApp/bin/**/*.dll"
+///                 ++ "MyWebApp/bin/**/*.pdb"
+///                 ++ "MyWebApp/fonts/**"
+///                 ++ "MyWebApp/img/**"
+///                 ++ "MyWebApp/js/**"
+///                 -- "MyWebApp/js/_references.js"
+///                 ++ "MyWebApp/web.config"
+///             @"app_data\jobs\continuous\MyWebJob", !! "MyWebJob/bin/Release/*.*"
+///         ]
+///         |> ZipOfIncludes (sprintf @"bin\MyWebApp.%s.zip" buildVersion)
+///     )
+///
+let ZipOfIncludes fileName files =
+    files
+    |> Seq.map toArchiveFileSpecs
+    |> Seq.concat
+    |> Zip.CompressSpecs id (fileInfo fileName)
 
 /// Creates a zip file with the given files.
 /// ## Parameters
 ///  - `workingDir` - The relative dir of the zip files. Use this parameter to influence directory structure within zip file.
 ///  - `fileName` - The file name of the resulting zip file.
 ///  - `files` - A sequence with files to zip.
-let Zip workingDir fileName files = CreateZip workingDir fileName "" DefaultZipLevel false files
+let Zip workingDir fileName files =
+    files
+    |> Seq.map fileInfo
+    |> Zip.CompressWithDefaults (directoryInfo workingDir) (fileInfo fileName)
 
-/// Creates a zip file with the given file.
-/// ## Parameters
-///  - `fileName` - The file name of the resulting zip file.
-///  - `targetFileName` - The file to zip.
-let ZipFile fileName targetFileName = 
-    let fi = fileInfo targetFileName
-    CreateZip (fi.Directory.FullName) fileName "" DefaultZipLevel false [ fi.FullName ]
+// The following functions do not have analogs in `ArchiveHelper`
 
-/// Unzips a file with the given file name.
-/// ## Parameters
-///  - `target` - The target directory.
-///  - `fileName` - The file name of the zip file.
-let Unzip target (fileName : string) = 
-    use zipFile = new ZipFile(fileName)
-    for entry in zipFile do
-        match entry with
-        | :? ZipEntry as zipEntry -> 
-            let unzipPath = Path.Combine(target, zipEntry.Name)
-            let directoryPath = Path.GetDirectoryName(unzipPath)
-            // create directory if needed
-            if directoryPath.Length > 0 then Directory.CreateDirectory(directoryPath) |> ignore
-            // unzip the file
-            let zipStream = zipFile.GetInputStream(zipEntry)
-            let buffer = Array.create 32768 0uy
-            if unzipPath.EndsWith "/" |> not then 
-                use unzippedFileStream = File.Create(unzipPath)
-                StreamUtils.Copy(zipStream, unzippedFileStream, buffer)
-        | _ -> ()
+open System
+open System.IO
+open ICSharpCode.SharpZipLib.Zip
 
 /// Unzips a single file from the archive with the given file name.
 /// ## Parameters
@@ -131,49 +131,3 @@ let UnzipFirstMatchingFileInMemory predicate (zipFileName : string) =
     use stream = zf.GetInputStream(ze)
     use reader = new StreamReader(stream)
     reader.ReadToEnd()
-
-/// Creates a zip file with the given files.
-/// ## Parameters
-///  - `fileName` - The file name of the resulting zip file.
-///  - `comment` - A comment for the resulting zip file.
-///  - `level` - The compression level.
-///  - `files` - A sequence of target folders and files to include relative to their base directory.
-let CreateZipOfIncludes fileName comment level (files : (string * FileIncludes) seq) =
-    let items = seq {
-        for path, incl in files do
-            for file in incl do
-                let info = fileInfo file
-                if info.Exists then
-                    let baseFull = (Path.GetFullPath incl.BaseDirectory).TrimEnd [|'/';'\\'|]
-                    let path =
-                        if String.IsNullOrEmpty path then ""
-                        else sprintf "%s%c" (path.TrimEnd [|'/';'\\'|]) Path.DirectorySeparatorChar
-                    let spec = sprintf "%s%s" path (info.FullName.Substring (baseFull.Length+1))
-                    yield file, spec }
-
-    createZip fileName comment level items
-
-/// Creates a zip file with the given files.
-/// ## Parameters
-///  - `fileName` - The file name of the resulting zip file.
-///  - `files` - A sequence of target folders and files to include relative to their base directory.
-///
-/// ## Sample
-///
-/// The following sample creates 4 targets using TargetTemplateWithDependencies and hooks them into the build pipeline.
-///
-///     Target "Zip" (fun _ ->
-///         [   "", !! "MyWebApp/*.html"
-///                 ++ "MyWebApp/bin/**/*.dll"
-///                 ++ "MyWebApp/bin/**/*.pdb"
-///                 ++ "MyWebApp/fonts/**"
-///                 ++ "MyWebApp/img/**"
-///                 ++ "MyWebApp/js/**"
-///                 -- "MyWebApp/js/_references.js"
-///                 ++ "MyWebApp/web.config"
-///             @"app_data\jobs\continuous\MyWebJob", !! "MyWebJob/bin/Release/*.*"
-///         ]
-///         |> ZipOfIncludes (sprintf @"bin\MyWebApp.%s.zip" buildVersion)
-///     )
-///
-let ZipOfIncludes fileName files = CreateZipOfIncludes fileName "" DefaultZipLevel files


### PR DESCRIPTION
Provide a more comprehensive suite of archive and compression helpers, including zip, gzip, bzip2, tar, and tar.gz/tar.bz2.

This module isn't `AutoOpen`, and should be considered as a general case replacement for the `ZipHelper` module (which is `AutoOpen`). The modules in `ArchiveHelper` could be expanded to support some of the use cases provided in `ZipHelper`, but this is a good base from which to start.

Note that this will fail to build documentation until #719 is resolved. (`.\build GenerateDocs` fails)