### PR TITLE
Add a lib directory reference for doc generation

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -117,7 +117,7 @@ Target "GenerateDocs" (fun _ ->
           -- "./build/**/Fake.IIS.dll"                      
           -- "./build/**/Fake.Deploy.Lib.dll"
 
-    CreateDocsForDlls apidocsDir templatesDir projInfo (githubLink + "/blob/master") dllFiles
+    CreateDocsForDlls apidocsDir templatesDir (projInfo @ ["--libDirs", "./build"]) (githubLink + "/blob/master") dllFiles
 
     WriteStringToFile false "./docs/.nojekyll" ""
 


### PR DESCRIPTION
When building #727, the `GenerateDocs` target fails because it is trying to understand the `ICSharpCode.SharpZipLib` assembly reference, but can't find it. This adds a reference to the `lib` directory.

fixes #719