### PR TITLE
looks in current nuspec for namespace

### DIFF
--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -442,6 +442,7 @@ let getNuspecProperties (nuspec : string) =
         [ "x", "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
           "y", "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" 
           "default", ""
+          "inDoc", doc.DocumentElement.NamespaceURI
           ]
     
     let getValue name = 

--- a/src/test/Test.Fake.Deploy/PackageMgt/GettingNuspecProperties.cs
+++ b/src/test/Test.Fake.Deploy/PackageMgt/GettingNuspecProperties.cs
@@ -1,0 +1,63 @@
+﻿using Fake;
+using Machine.Specifications;
+
+namespace Test.Fake.Deploy.PackageMgt
+{
+
+    public class when_reading_nuspec_values_with_new_nuspace_namespace
+    {
+        //static IEnumerable<NuGetHelper.NuSpecPackage> _releases;
+        private static NuGetHelper.NuSpecPackage _package = null;
+        const string Nuspec = @"<?xml version=""1.0""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd"">
+  <metadata>
+    <id>foo</id>
+    <version>0.0.1-alpha</version>
+    <authors>ashic</authors>
+    <owners>ashic</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>the foo thing</description>
+    <copyright>Copyright 2015</copyright>
+    <title>foo</title>
+    <tags>ci msdeploy</tags>
+  </metadata>
+  <files>
+    <file src=""G:\trash\foo\*.*"" target="".\"" />
+  </files>
+</package>";
+
+        Because of = () => _package = NuGetHelper.getNuspecProperties(Nuspec);
+
+        It should_should_read__the_version = () => _package.Version.ShouldEqual("0.0.1-alpha");
+        It should_should_read_the_id = () => _package.Id.ShouldEqual("foo");
+    }
+
+
+    public class when_reading_nuspec_values_with_no_nuspace_namespace
+    {
+        //static IEnumerable<NuGetHelper.NuSpecPackage> _releases;
+        private static NuGetHelper.NuSpecPackage _package = null;
+        const string Nuspec = @"<?xml version=""1.0""?>
+<package>
+  <metadata>
+    <id>foo</id>
+    <version>0.0.1-alpha</version>
+    <authors>ashic</authors>
+    <owners>ashic</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>the foo thing</description>
+    <copyright>Copyright 2015</copyright>
+    <title>foo</title>
+    <tags>ci msdeploy</tags>
+  </metadata>
+  <files>
+    <file src=""G:\trash\foo\*.*"" target="".\"" />
+  </files>
+</package>";
+
+        Because of = () => _package = NuGetHelper.getNuspecProperties(Nuspec);
+
+        It should_should_read__the_version = () => _package.Version.ShouldEqual("0.0.1-alpha");
+        It should_should_read_the_id = () => _package.Id.ShouldEqual("foo");
+    }
+}

--- a/src/test/Test.Fake.Deploy/Test.Fake.Deploy.csproj
+++ b/src/test/Test.Fake.Deploy/Test.Fake.Deploy.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\Test.FAKECore\Extensions.cs">
       <Link>Extensions.cs</Link>
     </Compile>
+    <Compile Include="PackageMgt\GettingNuspecProperties.cs" />
     <Compile Include="PackageMgt\ReleaseDiscoveringSpecs.cs" />
     <Compile Include="PackageMgt\RollbackSpecs.cs" />
     <Compile Include="PackageMgt\RoutingSpecs.cs" />


### PR DESCRIPTION
When Fake.Deploy is running a deployment, it looks up package details from the nuspec file. Currently, only a couple of namespaces are used, and depending on the version of nuget used, other namespaces may be in the nuspec file. For example, if the nuspec file used to generate a package doesn't have a namespace specified, any of the following may get used:

"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
"http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"
"http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd"
...

This pull request will try the (currently hardcoded) values, but will also use the document's namespace. This provides more robust handling of versions.