### PR TITLE
Force build server output if the user wishes to

### DIFF
--- a/src/app/FakeLib/UnitTest/XUnit2Helper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit2Helper.fs
@@ -138,8 +138,8 @@ let buildXUnit2Args parameters assembly =
     |> append "-maxthreads"
     |> append (sprintf "%i" parameters.MaxThreads)
     |> appendIfFalse parameters.ShadowCopy "-noshadow"
-    |> appendIfTrue (buildServer = TeamCity) "-teamcity"
-    |> appendIfTrue (buildServer = AppVeyor) "-appveyor"
+    |> appendIfTrue (buildServer = TeamCity || parameters.Teamcity) "-teamcity"
+    |> appendIfTrue (buildServer = AppVeyor || parameters.Appveyor) "-appveyor"
     |> appendIfTrue parameters.Wait "-wait"
     |> appendIfTrue parameters.Silent "-silent"
     |> appendIfTrue parameters.XmlOutput (sprintf "-xml\" \"%s" (dir @@ (name + ".xml")))


### PR DESCRIPTION
The parameters have probably been ignored by accident, because the docs already say "forces [TeamCity|AppVeyor CI] mode (normally auto-detected)"