### PR TITLE
WIP: Implement file system change watching.

### DIFF
--- a/src/app/FAKE/FAKE.fsproj
+++ b/src/app/FAKE/FAKE.fsproj
@@ -24,8 +24,8 @@
     <WarningLevel>3</WarningLevel>
     <StartAction>Project</StartAction>
     <StartProgram>C:\sources\FAKE\tools\FAKE\FAKE.exe</StartProgram>
-    <StartWorkingDirectory>d:\Code\Paket</StartWorkingDirectory>
-    <StartArguments>GenerateHelp -st</StartArguments>
+    <StartWorkingDirectory>C:\Projects\FAKE\src\test\testscripts</StartWorkingDirectory>
+    <StartArguments>test1.fsx</StartArguments>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/app/FakeLib/ChangeWatcher.fs
+++ b/src/app/FakeLib/ChangeWatcher.fs
@@ -1,0 +1,101 @@
+﻿[<AutoOpen>]
+/// This module contains helper function to create and extract zip archives.
+module Fake.ChangeWatcher
+open System.IO
+
+type FileStatus =
+| Deleted
+| Created
+| Changed
+
+type FileChange = {
+    FullPath : string
+    Name : string
+    Status : FileStatus
+}
+
+let private handleWatcherEvents (status : FileStatus) (onChange : FileChange -> unit) (e:FileSystemEventArgs) =
+    onChange (
+        {
+            FullPath = e.FullPath
+            Name = e.Name
+            Status = status
+        }
+    )
+
+/// Watches the for changes matching fileIncludes.
+/// ## Parameters
+///  - `onChange` - function to call when a change is detected.
+///  - `fileIncludes` - The glob pattern for files to watch for changes.
+let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileIncludes) =
+
+    let dirsToWatch = 
+        fileIncludes.Includes 
+        |> Seq.map (fun file ->
+            Globbing.getRoot fileIncludes.BaseDirectory (file)
+        )
+
+    // remove children directoryss from watch list so that we dont get duplicate file watchers running
+    let dirsToWatch = dirsToWatch |> Seq.filter(fun d -> 
+        dirsToWatch |> Seq.exists(fun p -> 
+            p.StartsWith d && p <> d
+        ) |> not
+    )
+
+    let unNotifiedChanges = ref List.empty<FileChange>
+    let acumChanges (fileChange : FileChange) = 
+        if fileIncludes.IsMatch fileChange.FullPath then
+            lock unNotifiedChanges ( fun () ->
+                unNotifiedChanges := [fileChange] @ !unNotifiedChanges
+            )
+
+    let timer = new System.Timers.Timer(5.0)
+    timer.Elapsed.Add (fun _ -> 
+        lock unNotifiedChanges ( fun () ->
+            if !unNotifiedChanges |> Seq.length > 0 then
+                let changes = 
+                    !unNotifiedChanges
+                    |> Seq.groupBy(fun c -> c.FullPath)
+                    |> Seq.map(fun (name,changes) -> 
+                        changes |> Seq.sortBy(fun c -> c.Status) |> Seq.head
+                    )
+                unNotifiedChanges := List.empty<FileChange>
+                onChange changes
+        )
+    )
+
+    printfn "dirs to watch: %A" dirsToWatch
+    let watchers = dirsToWatch |> Seq.map(fun dir ->
+        printfn "watching dir: %s" dir
+        
+        let watcher = new FileSystemWatcher(FullName dir,"*.*")
+        watcher.EnableRaisingEvents <- true
+        watcher.IncludeSubdirectories <- true    
+
+        watcher.Changed.Add(handleWatcherEvents Changed acumChanges)
+        watcher.Created.Add(handleWatcherEvents Created acumChanges)
+        watcher.Deleted.Add(handleWatcherEvents Deleted acumChanges)
+        watcher.Renamed.Add(fun (e:RenamedEventArgs) ->
+            acumChanges {
+                FullPath = e.OldFullPath
+                Name = e.OldName
+                Status = Deleted
+            }
+            acumChanges {
+                FullPath = e.FullPath
+                Name = e.Name
+                Status = Created
+            }
+        )
+
+        watcher
+    ) 
+    watchers |> Seq.length |> ignore //force iteration
+
+    timer.Start()
+
+    fun () -> 
+        for watcher in watchers do 
+            watcher.EnableRaisingEvents <- false
+            watcher.Dispose()
+        timer.Dispose()

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -155,6 +155,7 @@
     <Compile Include="Sxshelper.fs" />
     <Compile Include="Vb6helper.fs" />
     <Compile Include="AndroidPublisher.fs" />
+    <Compile Include="ChangeWatcher.fs" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/app/FakeLib/Globbing/FileSystem.fs
+++ b/src/app/FakeLib/Globbing/FileSystem.fs
@@ -22,6 +22,21 @@ type FileIncludes =
     /// Sets a directory as BaseDirectory.
     member this.SetBaseDirectory(dir : string) = { this with BaseDirectory = dir.TrimEnd(Path.DirectorySeparatorChar) }
     
+    /// Checks if a particular file is matched
+    member this.IsMatch (path : string) =
+        let included = 
+            this.Includes
+            |> Seq.exists(fun fileInclude ->
+                Globbing.isMatch fileInclude path
+            )
+        let excluded = 
+            this.Excludes
+            |> Seq.exists(fun fileInclude ->
+                Globbing.isMatch fileInclude path
+            )
+
+        included && not excluded
+
     interface IEnumerable<string> with
         
         member this.GetEnumerator() = 

--- a/src/test/Test.FAKECore/Globbing/GlobbingSpecs.cs
+++ b/src/test/Test.FAKECore/Globbing/GlobbingSpecs.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using Fake;
+using Machine.Specifications;
+using Test.FAKECore.FileHandling;
+
+namespace Test.FAKECore.Globbing
+{
+    public class when_matching_files_to_patterns : BaseFunctions
+    {
+        static void IsMatch(string pattern, string[] files)
+        {
+            foreach (var file in files)
+            {
+                Fake.Globbing.isMatch(pattern, file).ShouldBeTrue();
+            }
+        }
+
+        static void IsNotMatch(string pattern, string[] files)
+        {
+            foreach (var file in files)
+            {
+                Fake.Globbing.isMatch(pattern, file).ShouldBeFalse();
+            }
+        }
+
+        private It should_exact_match =
+            () => IsMatch("foo.bar", new[] { "foo.bar" });
+
+        It should_not_match =
+            () => IsNotMatch("foo.bar", new[] { "baz.bar", "baz/foo.bar" });
+
+        It should_match_any_in_root =
+            () => IsMatch("*.*", new[] { "foo.bar", "foo.baz" });
+
+        It should_not_match_in_sub_dir =
+            () => IsNotMatch("*.*", new[] { "foo/bar/baz.bill", "foo/bar.baz" });
+
+        It should_match_filename =
+            () => IsMatch("*.bar", new[] { "foo.bar", "baz.bar" });
+
+        It should_not_match_filename =
+            () => IsNotMatch("*.bar", new[] { "foo.baz", "baz.foo" });
+
+        It should_match_subdir =
+            () => IsMatch("foo/*.bar", new[] { "foo/baz.bar", "foo/foo.bar" });
+
+        It should_not_match_different_subdir =
+            () => IsNotMatch("foo/*.bar", new[] { "baz/foo.bar", "foo/bar/baz.bar" });
+
+        It should_match_any =
+            () => IsMatch("**/*.*", new[] {
+                "foo", 
+                "foo.bar", 
+                "foo/baz", 
+                "foo/baz.bill", 
+                "foo/baz/x.bill"
+            });
+
+        It should_match_any_with_extension =
+            () => IsMatch("**/*.bar", new[] {
+                "foo.bar", 
+                "foo/baz.bar", 
+                "foo/bar/bill.bar"
+            });
+
+        It should_not_match_any_with_wrong_extension =
+            () => IsNotMatch("**/*.bar", new[] {
+                "foo.baz", 
+                "foo/baz.baz", 
+                "foo/bar/bill.baz"
+            });
+
+        It should_match_any_subdir_with_extension =
+            () => IsMatch("foo/**/*.bar", new[] {
+                "foo/baz.bar", 
+                "foo/baz/bill.bar", 
+            });
+
+        It should_not_match_any_in_wrong_subdir_with_extension =
+            () => IsNotMatch("foo/**/*.bar", new[] {
+                "bill/baz.bar", 
+                "baz/foo/bill.bar", 
+            });
+
+        It should_match_particular_subdir =
+            () => IsMatch("**/subdir/more/*.bar", new[] {
+                "subdir/more/foo.bar",
+                "root/subdir/more/foo.bar",
+                "root/another/subdir/more/foo.bar"
+            });
+
+        It should_not_match_particular_subdir =
+            () => IsNotMatch("**/subdir/more/*.bar", new[] {
+                "wrong/foo.bar",
+                "foo.bar",
+                "subdir/more/wrong/foo.bar"
+            });
+
+        It should_match_particular_subdir_then_recursive =
+            () => IsMatch("**/subdir/more/**/*.bar", new[] {
+                "root/subdir/more/foo.bar",
+                "root/subdir/more/another/foo.bar",
+                "root/another/subdir/more/foo.bar"
+            });
+    }
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -71,6 +71,7 @@
     <Compile Include="FileHandling\CopyFileSpecs.cs" />
     <Compile Include="FixProjectFileSpecs.cs" />
     <Compile Include="CompareProjectFilesSpecs.cs" />
+    <Compile Include="Globbing\GlobbingSpecs.cs" />
     <Compile Include="Globbing\SampeWithParens\SampleWithParensSpecs.cs" />
     <Compile Include="Globbing\TestSample7\CountersRegressionSpecs.cs" />
     <Compile Include="Globbing\TestSample6\CurlRegressionSpecs.cs" />


### PR DESCRIPTION
Created a wrapper around `FileSystemWatcher` that makes it easy to watch the disk for changes. Uses a glob pattern to filter the changes to a subset of the files. I had to reimplement globbing using a regex, the current implementation requires walking the file system every time, the regex can do a simple compare to see if a path is matched.

Example :
```f#
Target "Watch" (fun _ ->
    let stop = !! "c:/projects/watchDir/*.txt" |> WatchChanges (fun changes -> 
        RunTarget "Tests"
    )

    System.Console.ReadLine() |> ignore

    stop() //if you need to cleanup the watches.
)
```

There are two reasons I marked this as WIP. 

First, is I dont know if the documentation I added is sufficient. This seems to be cool enough to justify its own article in the docs, but I wanted to check before writing that.

Second, if you dont do something to keep FAKE from exiting, it will exit immediately after setting up the watcher. Hence the `ReadLine` at the end of the function. Personally I dont find this to be pleasant. To make this not required we would have to keep track of all running `WatchChanges` and prevent FAKE from exiting while they are running. What are others thoughts on this?