### PR TITLE
Treat non csproj files as nuspec files

### DIFF
--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -233,9 +233,9 @@ let private createNuSpecFromTemplate parameters (templateNuSpec:FileInfo) =
 
 let private createNuSpecFromTemplateIfNuSpecFile parameters nuSpecOrProjFile = 
     let nuSpecOrProjFileInfo = fileInfo nuSpecOrProjFile
-    match nuSpecOrProjFileInfo.Extension.ToLower() = ".nuspec" with
-    | true -> Some (createNuSpecFromTemplate parameters nuSpecOrProjFileInfo)
-    | false -> None
+    match nuSpecOrProjFileInfo.Extension.ToLower() = ".csproj" with
+    | true -> None
+    | false -> Some (createNuSpecFromTemplate parameters nuSpecOrProjFileInfo)
     
 
 let private propertiesParam = function 

--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -231,7 +231,7 @@ let private createNuSpecFromTemplate parameters (templateNuSpec:FileInfo) =
     tracefn "Created nuspec file %s" specFile
     specFile
 
-let private createNuSpecFromTemplateIfNuSpecFile parameters nuSpecOrProjFile = 
+let private createNuSpecFromTemplateIfNotCsprojFile parameters nuSpecOrProjFile = 
     let nuSpecOrProjFileInfo = fileInfo nuSpecOrProjFile
     match nuSpecOrProjFileInfo.Extension.ToLower() = ".csproj" with
     | true -> None
@@ -361,7 +361,7 @@ let NuGetPack setParams nuspecOrProjectFile =
     traceStartTask "NuGetPack" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try
-        match (createNuSpecFromTemplateIfNuSpecFile parameters nuspecOrProjectFile) with
+        match (createNuSpecFromTemplateIfNotCsprojFile parameters nuspecOrProjectFile) with
         | Some nuspecTemplateFile -> 
             pack parameters nuspecTemplateFile
             DeleteFile nuspecTemplateFile
@@ -392,7 +392,7 @@ let NuGet setParams nuspecOrProjectFile =
     traceStartTask "NuGet" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try 
-        match (createNuSpecFromTemplateIfNuSpecFile parameters nuspecOrProjectFile) with
+        match (createNuSpecFromTemplateIfNotCsprojFile parameters nuspecOrProjectFile) with
         | Some nuspecTemplateFile -> 
             pack parameters nuspecTemplateFile
             DeleteFile nuspecTemplateFile

--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -231,9 +231,9 @@ let private createNuSpecFromTemplate parameters (templateNuSpec:FileInfo) =
     tracefn "Created nuspec file %s" specFile
     specFile
 
-let private createNuSpecFromTemplateIfNotCsprojFile parameters nuSpecOrProjFile = 
+let private createNuSpecFromTemplateIfNotProjFile parameters nuSpecOrProjFile = 
     let nuSpecOrProjFileInfo = fileInfo nuSpecOrProjFile
-    match nuSpecOrProjFileInfo.Extension.ToLower() = ".csproj" with
+    match nuSpecOrProjFileInfo.Extension.ToLower().EndsWith("proj") with
     | true -> None
     | false -> Some (createNuSpecFromTemplate parameters nuSpecOrProjFileInfo)
     
@@ -361,7 +361,7 @@ let NuGetPack setParams nuspecOrProjectFile =
     traceStartTask "NuGetPack" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try
-        match (createNuSpecFromTemplateIfNotCsprojFile parameters nuspecOrProjectFile) with
+        match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
         | Some nuspecTemplateFile -> 
             pack parameters nuspecTemplateFile
             DeleteFile nuspecTemplateFile
@@ -392,7 +392,7 @@ let NuGet setParams nuspecOrProjectFile =
     traceStartTask "NuGet" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try 
-        match (createNuSpecFromTemplateIfNotCsprojFile parameters nuspecOrProjectFile) with
+        match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
         | Some nuspecTemplateFile -> 
             pack parameters nuspecTemplateFile
             DeleteFile nuspecTemplateFile


### PR DESCRIPTION
Currently nuspec files must have a .nuspec file extension to be treated as valid nuspec templates. We have nuspec files without this extension which no longer work with up to date versions. The only reason why this distinction exists, is to cover .csproj files. So our suggestion is to just look for the .csproj file extension.