### PR TITLE
Simplify FCS interaction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ release.cmd
 Samples/typescript/out/
 help/RELEASE_NOTES.md
 paket.exe
+paket-files/
 
 # Ignore the Vagrant local directories
 .vagrant/*

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -36,3 +36,5 @@ nuget xunit.extensions
 nuget Newtonsoft.Json
 nuget Microsoft.AspNet.Razor 2.0.30506
 nuget Microsoft.AspNet.WebPages 2.0.30506
+
+github matthid/Yaaf.FSharp.Scripting src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs

--- a/paket.lock
+++ b/paket.lock
@@ -80,3 +80,7 @@ NUGET
     xunit.extensions (1.9.2)
       xunit (1.9.2)
     xunit.runners (1.9.2)
+GITHUB
+  remote: matthid/Yaaf.FSharp.Scripting
+  specs:
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (063fecd982243e91132c69bdbf27c46e8853877f)

--- a/paket.lock
+++ b/paket.lock
@@ -83,4 +83,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (bc8589d3f19a75ee480fa588a956db382d096893)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (253b322f7da2922c01685a02db45b3f3923d627e)

--- a/paket.lock
+++ b/paket.lock
@@ -83,4 +83,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (063fecd982243e91132c69bdbf27c46e8853877f)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (bc8589d3f19a75ee480fa588a956db382d096893)

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -7,6 +7,7 @@ open System
 open System.IO
 open System.Diagnostics
 open System.Threading
+open Yaaf.FSharp.Scripting
 
 let private FSIPath = @".\tools\FSharp\;.\lib\FSharp\;[ProgramFilesX86]\Microsoft SDKs\F#\3.1\Framework\v4.0;[ProgramFilesX86]\Microsoft SDKs\F#\3.0\Framework\v4.0;[ProgramFiles]\Microsoft F#\v4.0\;[ProgramFilesX86]\Microsoft F#\v4.0\;[ProgramFiles]\FSharp-2.0.0.0\bin\;[ProgramFilesX86]\FSharp-2.0.0.0\bin\;[ProgramFiles]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\FSharp-1.9.9.9\bin\"
 
@@ -85,8 +86,6 @@ let executeFSIWithScriptArgsAndReturnMessages script (scriptArgs: string[]) =
     Thread.Sleep 1000
     (result, messages)
 
-open Microsoft.FSharp.Compiler.Interactive.Shell
-
 /// Run the given FAKE script with fsi.exe at the given working directory. Provides full access to Fsi options and args. Redirect output and error messages.
 let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(fsiOptions, script, scriptArgs)) args onErrMsg onOutMsg =
     if printDetails then traceFAKE "Running Buildscript: %s" script
@@ -98,43 +97,32 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
     // Create an env var that only contains the build script args part from the --fsiargs (or "").
     Environment.SetEnvironmentVariable("fsiargs-buildscriptargs", String.Join(" ", scriptArgs))
 
-    let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration()
-
     let commonOptions =
         [ "fsi.exe"; "--noninteractive" ] @ fsiOptions
-        |> List.toArray
+        |> FsiOptions.ofArgs
 
-    let sbOut = Text.StringBuilder()
-    let sbErr = Text.StringBuilder()
-    let handleMessages() =
-        let handleMessagesFrom (sb:Text.StringBuilder) onMsg =
-            let s = sb.ToString()
-            if not <| String.IsNullOrEmpty s
-                then onMsg s
-        handleMessagesFrom sbOut onOutMsg
-        handleMessagesFrom sbErr onErrMsg
+    let handleMessages { Output = out; Error = err } =
+        let handleMessagesFrom msg onMsg =
+            if String.IsNullOrEmpty msg then
+              onMsg msg
+        handleMessagesFrom out onOutMsg
+        handleMessagesFrom err onErrMsg
 
-    use outStream = new StringWriter(sbOut)
-    use errStream = new StringWriter(sbErr)
-    use stdin = new StreamReader(Stream.Null)
+    let session =
+        try ScriptHost.Create(commonOptions)
+        with :? FsiEvaluationException as e ->
+            traceError "FsiEvaluationSession could not be created."
+            traceError e.Result.Error
+            reraise ()
 
-    try
-        let session = FsiEvaluationSession.Create(fsiConfig, commonOptions, stdin, outStream, errStream)
-
-        try
-            session.EvalScript script
-            // TODO: Reactivate when FCS don't show output any more 
-            // handleMessages()
-            true
-        with
-        | _ ->
-            handleMessages()
-            false
-    with
-    | exn ->
-        traceError "FsiEvaluationSession could not be created."
-        traceError <| sbErr.ToString()
-        raise exn
+    try session.EvalScript script
+        // TODO: Reactivate when FCS don't show output any more
+        // let msgs = session.EvalScriptWithOutput script
+        // handleMessages msgs
+        true
+    with :? FsiEvaluationException as eval ->
+        handleMessages eval.Result
+        false
 
 /// Run the given buildscript with fsi.exe and allows for extra arguments to the script. Returns output.
 let executeBuildScriptWithArgsAndReturnMessages script (scriptArgs: string[]) =

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -36,6 +36,10 @@
     <DocumentationFile>..\..\..\build\FakeLib.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\paket-files\matthid\Yaaf.FSharp.Scripting\src\source\Yaaf.FSharp.Scripting\YaafFSharpScripting.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YaafFSharpScripting.fs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="CSharpHelper.fs" />
     <Compile Include="EnvironmentHelper.fs" />

--- a/src/app/FakeLib/paket.references
+++ b/src/app/FakeLib/paket.references
@@ -1,3 +1,4 @@
+File: YaafFSharpScripting.fs
 FSharp.Core
 FSharp.Compiler.Service
 Mono.Web.Xdt


### PR DESCRIPTION
See @tpetricek's comment for details: https://github.com/tpetricek/FSharp.Formatting/pull/305#issuecomment-96007223
This should add a "fsi" object as expected, without the need to reference `F.C.I.S.dll`.

I'm not sure about the `TODO` can we remove that?