### PR TITLE
copy build.sh from ProjectScaffold.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,38 @@
 #!/bin/bash
+if test "$OS" = "Windows_NT"
+then
+  # use .Net
 
-mono .paket/paket.bootstrapper.exe
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-	exit $exit_code
+  .paket/paket.bootstrapper.exe
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+  	exit $exit_code
+  fi
+
+  .paket/paket.exe restore
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+  	exit $exit_code
+  fi
+  
+  [ ! -e build.fsx ] && .paket/paket.exe update
+  [ ! -e build.fsx ] && packages/FAKE/tools/FAKE.exe init.fsx
+  packages/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
+else
+  # use mono
+  mono .paket/paket.bootstrapper.exe
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+  	exit $exit_code
+  fi
+
+  mono .paket/paket.exe restore
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+  	exit $exit_code
+  fi
+
+  [ ! -e build.fsx ] && mono .paket/paket.exe update
+  [ ! -e build.fsx ] && mono packages/FAKE/tools/FAKE.exe init.fsx
+  mono packages/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
 fi
-
-mono .paket/paket.exe restore
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-	exit $exit_code
-fi
-
-mono packages/FAKE/tools/FAKE.exe "build.fsx"  $@


### PR DESCRIPTION
This makes `./build.sh` from the git bash working, without mono installed.