### PR TITLE
FCS simplification.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ release.cmd
 Samples/typescript/out/
 help/RELEASE_NOTES.md
 paket.exe
+paket-files/
 
 # Ignore the Vagrant local directories
 .vagrant/*

--- a/build.fsx
+++ b/build.fsx
@@ -9,6 +9,7 @@ open System.IO
 open SourceLink
 open Fake.ReleaseNotesHelper
 
+
 // properties
 let projectName = "FAKE"
 let projectSummary = "FAKE - F# Make - Get rid of the noise in your build scripts."
@@ -142,6 +143,16 @@ Target "Test" (fun _ ->
     |>  xUnit (fun p -> p)
 )
 
+Target "Bootstrap" (fun _ ->
+    // Check if we can build ourself with the new binaries.
+    let result = 
+        ExecProcess (fun info -> 
+            info.FileName <- "build/FAKE.exe"
+            info.WorkingDirectory <- "."
+            info.Arguments <- "build.fsx DoNothing") (System.TimeSpan.FromMinutes 3.0)
+    if result <> 0 then failwith "Bootstrapping failed"
+)
+
 Target "SourceLink" (fun _ ->
     use repo = new GitRepo(__SOURCE_DIRECTORY__)
     !! "src/app/**/*.fsproj" 
@@ -256,13 +267,15 @@ Target "Release" (fun _ ->
     Branches.pushTag "" "origin" release.NugetVersion
 )
 
+Target "DoNothing" DoNothing
 Target "Default" DoNothing
 
 // Dependencies
 "Clean"
     ==> "SetAssemblyInfo"
     ==> "BuildSolution"
-    ==> "Test"    
+    ==> "Test"  
+    ==> "Bootstrap"  
     ==> "Default"
     ==> "CopyLicense"
     =?> ("GenerateDocs", isLocalBuild && not isLinux)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -36,3 +36,5 @@ nuget xunit.extensions
 nuget Newtonsoft.Json
 nuget Microsoft.AspNet.Razor 2.0.30506
 nuget Microsoft.AspNet.WebPages 2.0.30506
+
+github matthid/Yaaf.FSharp.Scripting src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs

--- a/paket.lock
+++ b/paket.lock
@@ -80,3 +80,7 @@ NUGET
     xunit.extensions (1.9.2)
       xunit (1.9.2)
     xunit.runners (1.9.2)
+GITHUB
+  remote: matthid/Yaaf.FSharp.Scripting
+  specs:
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (253b322f7da2922c01685a02db45b3f3923d627e)

--- a/paket.lock
+++ b/paket.lock
@@ -83,4 +83,4 @@ NUGET
 GITHUB
   remote: matthid/Yaaf.FSharp.Scripting
   specs:
-    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (253b322f7da2922c01685a02db45b3f3923d627e)
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (d2412f60c253d84b4a9c07ce53ac24da31e38645)

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -101,8 +101,9 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
         (FsiOptions.Default.AsArgs |> Array.toList) @ fsiOptions
         |> FsiOptions.ofArgs
 
-    // onErrMsg expects finished lines, disposing ensures we print unfinished lines.
-    use forwarder = ScriptHost.CreateForwardWriter(onErrMsg, removeNewLines = true)
+    // onErrMsg and onOutMsg expect finished lines, disposing ensures we print unfinished lines.
+    // We don't use onErrMsg because it makes AppVeyor build fail: https://github.com/fsharp/FAKE/pull/773
+    use forwarder = ScriptHost.CreateForwardWriter(onOutMsg, removeNewLines = true)
     let session =
         try ScriptHost.Create
               (commonOptions,

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -102,8 +102,7 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
         |> FsiOptions.ofArgs
 
     // onErrMsg and onOutMsg expect finished lines, disposing ensures we print unfinished lines.
-    // We don't use onErrMsg because it makes AppVeyor build fail: https://github.com/fsharp/FAKE/pull/773
-    use forwarder = ScriptHost.CreateForwardWriter(trace, removeNewLines = true)
+    use forwarder = ScriptHost.CreateForwardWriter(onErrMsg, removeNewLines = true)
     let session =
         try ScriptHost.Create
               (commonOptions,

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -103,7 +103,7 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
 
     // onErrMsg and onOutMsg expect finished lines, disposing ensures we print unfinished lines.
     // We don't use onErrMsg because it makes AppVeyor build fail: https://github.com/fsharp/FAKE/pull/773
-    use forwarder = ScriptHost.CreateForwardWriter(onOutMsg, removeNewLines = true)
+    use forwarder = ScriptHost.CreateForwardWriter(trace, removeNewLines = true)
     let session =
         try ScriptHost.Create
               (commonOptions,

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -36,6 +36,10 @@
     <DocumentationFile>..\..\..\build\FakeLib.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\paket-files\matthid\Yaaf.FSharp.Scripting\src\source\Yaaf.FSharp.Scripting\YaafFSharpScripting.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YaafFSharpScripting.fs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="CSharpHelper.fs" />
     <Compile Include="EnvironmentHelper.fs" />

--- a/src/app/FakeLib/TraceListener.fs
+++ b/src/app/FakeLib/TraceListener.fs
@@ -58,7 +58,9 @@ type ConsoleTraceListener(importantMessagesToStdErr, colorMap) =
             | FinishedMessage -> ()
 
 /// The default TraceListener for Console.
-let defaultConsoleTraceListener = ConsoleTraceListener(buildServer <> CCNet, colorMap)
+let defaultConsoleTraceListener =
+  // If we write the stderr on those build servers the build will fail.
+  ConsoleTraceListener(buildServer <> CCNet && buildServer <> AppVeyor, colorMap)
 
 /// Specifies if the XmlWriter should close tags automatically
 let mutable AutoCloseXmlWriter = false

--- a/src/app/FakeLib/paket.references
+++ b/src/app/FakeLib/paket.references
@@ -1,3 +1,4 @@
+File: YaafFSharpScripting.fs
 FSharp.Core
 FSharp.Compiler.Service
 Mono.Web.Xdt


### PR DESCRIPTION
Continuation of #771.

Hm, after fixing the Stackoverflow I noticed that we can not really forward the script output anyway (because we would loose coloring)

This PR changes the following:

 * First add a bootstrap step (which detects the stackoverflow). (build fails)
 * Fix the error
 * Change the behavior to not redirect the script output, but print the errors/warnings of FCS.
   NOTE: This is a new feature, now we can see compiler warnings from build scripts.
   Actually I was always wondering why FAKE would not show them.
