### PR TITLE
Add basic support for CMake configuration and build

### DIFF
--- a/Samples/CMakeSupport/Advanced/Communicator/CMakeLists.txt
+++ b/Samples/CMakeSupport/Advanced/Communicator/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 2.6)
+
+project (Communicator CXX)
+
+include_directories ("${PROJECT_SOURCE_DIR}")
+add_library (Communicator Communicator.cxx)
+
+install (TARGETS Communicator
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    COMPONENT library
+)
+install (FILES Communicator.h DESTINATION include)

--- a/Samples/CMakeSupport/Advanced/Communicator/Communicator.cxx
+++ b/Samples/CMakeSupport/Advanced/Communicator/Communicator.cxx
@@ -1,0 +1,13 @@
+#include "Communicator.h"
+
+using namespace std;
+
+Communicator::Communicator(const string & interlocutorName) :
+  _interlocutorName(interlocutorName)
+{
+}
+
+string Communicator::hello() const
+{
+  return "Hello " + _interlocutorName + "!";
+}

--- a/Samples/CMakeSupport/Advanced/Communicator/Communicator.h
+++ b/Samples/CMakeSupport/Advanced/Communicator/Communicator.h
@@ -1,0 +1,17 @@
+#ifndef COMMUNICATE_H
+#define COMMUNICATE_H
+
+#include <string>
+
+// Provides helpers for communicating with an end-user.
+class Communicator
+{
+  private:
+    std::string _interlocutorName;
+
+  public:
+    explicit Communicator(const std::string & interlocutorName);
+    std::string hello() const;
+};
+
+#endif // COMMUNICATE_H

--- a/Samples/CMakeSupport/Advanced/Hello/CMakeLists.txt
+++ b/Samples/CMakeSupport/Advanced/Hello/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 2.6)
+
+project (Hello CXX)
+
+# Not using FindLibrary to keep the example simple.
+if (NOT DEFINED COMMUNICATOR_INCLUDE_DIR OR NOT DEFINED COMMUNICATOR_LIBRARY)
+  message (FATAL_ERROR "Please define both COMMUNICATOR_INCLUDE_DIR and COMMUNICATOR_LIBRARY.")
+endif ()
+
+include_directories ("${COMMUNICATOR_INCLUDE_DIR}")
+
+add_executable (hello main.cxx)
+
+target_link_libraries (hello "${COMMUNICATOR_LIBRARY}")

--- a/Samples/CMakeSupport/Advanced/Hello/main.cxx
+++ b/Samples/CMakeSupport/Advanced/Hello/main.cxx
@@ -1,0 +1,20 @@
+#include <cstdlib>
+#include <iostream>
+#include <Communicator.h>
+
+using namespace std;
+
+int main(int argc, char ** argv)
+{
+    if (argc < 2)
+    {
+        cerr << "ERROR: Please provide at least one name as argument." << endl;
+        return EXIT_FAILURE;
+    }
+    for (int i = 1; i < argc; i++)
+    {
+        Communicator communicator(argv[i]);
+        cout << communicator.hello() << endl;
+    }
+    return EXIT_SUCCESS;
+}

--- a/Samples/CMakeSupport/Advanced/build.fsx
+++ b/Samples/CMakeSupport/Advanced/build.fsx
@@ -1,0 +1,95 @@
+#r "../../../build/FakeLib.dll"
+open Fake
+
+// Out of source build: CMake separates the source code from what's being generated.
+
+let communicatorSourceDir = currentDirectory @@ "Communicator"
+let communicatorBinaryDir = communicatorSourceDir + "-build"
+let communicatorInstallDir = communicatorSourceDir + "-install"
+let helloSourceDir = currentDirectory @@ "Hello"
+let helloBinaryDir = helloSourceDir + "-build"
+
+// As both CMake projects will use the same compilers, we define the common parameters only once.
+
+let commonGenerateParams (parameters:CMakeGenerateParams) = {
+    parameters with
+        Generator = if isUnix then "Unix Makefiles" else "Visual Studio 12 2013"
+        Variables =
+            if not isUnix then parameters.Variables else
+            [{Name = "CMAKE_BUILD_TYPE"; Value = CMakeString("Release")}]
+}
+
+let commonBuildParams (parameters:CMakeBuildParams) = {
+    parameters with
+        Config = if isUnix then parameters.Config else "Release"
+}
+
+// Clean both build directories to ensure a reproducible output between each run.
+Target "Clean" (fun _ ->
+    CleanDirs [ communicatorBinaryDir; communicatorInstallDir; helloBinaryDir ]
+)
+
+Target "Configure-Communicator" (fun _ ->
+    ensureDirectory communicatorBinaryDir
+    CMake.Generate (fun p ->
+        { commonGenerateParams p with
+            SourceDirectory = communicatorSourceDir
+            BinaryDirectory = communicatorBinaryDir
+            InstallDirectory = communicatorInstallDir
+        }
+    )
+)
+
+Target "Build-Communicator" (fun _ ->
+    CMake.Build (fun p ->
+        { commonBuildParams p with
+            BinaryDirectory = communicatorBinaryDir
+        }
+    )
+)
+
+Target "Install-Communicator" (fun _ ->
+    CMake.Build (fun p ->
+        { commonBuildParams p with
+            BinaryDirectory = communicatorBinaryDir
+            Target = if isUnix then "install" else "INSTALL"
+        }
+    )
+)
+
+Target "Configure-Hello" (fun _ ->
+    ensureDirectory helloBinaryDir
+    CMake.Generate (fun p ->
+        { commonGenerateParams p with
+            SourceDirectory = helloSourceDir
+            BinaryDirectory = helloBinaryDir
+            Variables =
+                [
+                    {Name = "COMMUNICATOR_INCLUDE_DIR";
+                     Value = CMakeDirPath(communicatorInstallDir @@ "include")}
+                    {Name = "COMMUNICATOR_LIBRARY";
+                     Value = CMakeFilePath(communicatorInstallDir @@ "lib" @@ "Communicator.lib")}
+                ]
+        }
+    )
+)
+
+Target "Build-Hello" (fun _ ->
+    CMake.Build (fun p ->
+        { commonBuildParams p with
+            BinaryDirectory = helloBinaryDir
+        }
+    )
+)
+
+Target "All" (fun _ -> ())
+
+"Clean"
+    ==> "Configure-Communicator"
+    ==> "Build-Communicator"
+    ==> "Install-Communicator"
+    ==> "Configure-Hello"
+    ==> "Build-Hello"
+"Build-Hello" ==> "All"
+
+RunTargetOrDefault "All"

--- a/Samples/CMakeSupport/Simple/CMakeLists.txt
+++ b/Samples/CMakeSupport/Simple/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required (VERSION 2.6)
+
+project (Hello CXX)
+
+add_executable (hello main.cxx)

--- a/Samples/CMakeSupport/Simple/build.fsx
+++ b/Samples/CMakeSupport/Simple/build.fsx
@@ -1,0 +1,34 @@
+#r "../../../build/FakeLib.dll"
+open Fake
+
+// Out of source build: CMake separates the source code from what's being generated.
+let binaryDir = "./build"
+
+// Clean both build directories to ensure a reproducible output between each run.
+Target "Clean" (fun _ -> CleanDir binaryDir)
+
+// Generate the platform-specific Makefiles.
+Target "Configure" (fun _ ->
+    ensureDirectory binaryDir
+    CMake.Generate (fun p ->
+        { p with
+            Generator = if isUnix then "Unix Makefiles" else "Visual Studio 12 2013"
+            Variables =
+                if not isUnix then p.Variables else
+                [{Name = "CMAKE_BUILD_TYPE"; Value = CMakeString("Release")}]
+        }
+    )
+)
+
+// Build the binaries by calling the `cmake --build` wrapper.
+Target "Build" (fun _ ->
+    CMake.Build (fun p ->
+        { p with 
+            Config = if isUnix then p.Config else "Release"
+        }
+    )
+)
+
+"Clean" ==> "Configure" ==> "Build"
+
+RunTargetOrDefault "Build"

--- a/Samples/CMakeSupport/Simple/main.cxx
+++ b/Samples/CMakeSupport/Simple/main.cxx
@@ -1,0 +1,14 @@
+#include <cstdlib>
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+    if (argc < 2)
+    {
+        std::cerr << "ERROR: Please provide at least one name as argument." << std::endl;
+        return EXIT_FAILURE;
+    }
+    for (int i = 1; i < argc; i++)
+        std::cout << "Hello " << argv[i] << "!" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/Samples/CMakeSupport/build.cmd
+++ b/Samples/CMakeSupport/build.cmd
@@ -1,0 +1,21 @@
+:: Builds the CMake support examples on Windows.
+@echo off
+
+set "currentDir=%CD%"
+set "baseDir=%~dp0"
+set "fake=..\..\..\build\FAKE.exe"
+
+cd "%baseDir%"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cd Simple
+"%fake%" .\build.fsx
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cd ..
+
+cd Advanced
+"%fake%" .\build.fsx
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cd "%currentDir%"

--- a/Samples/CMakeSupport/build.sh
+++ b/Samples/CMakeSupport/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Builds the CMake support examples on Linux.
+#
+# To execute it on the Vagrant VM, simply execute the following steps:
+# 1. Install the `cmake` and `build-essential` packages:
+#    sudo apt-get -y install cmake build-essential
+# 2. Run this script from any directory:
+#    bash /vagrant/src/fake/Samples/CMakeSupport/build.sh
+
+# Exit the script on any error.
+set -e
+
+currentDir="$PWD"
+baseDir="$(dirname $0)"
+fake="../../../build/FAKE.exe"
+
+cd "$baseDir"
+
+cd Simple
+"$fake" ./build.fsx
+
+cd ..
+
+cd Advanced
+"$fake" ./build.fsx
+
+cd "$currentDir"

--- a/src/app/FakeLib/CMake.fs
+++ b/src/app/FakeLib/CMake.fs
@@ -1,0 +1,220 @@
+﻿namespace Fake
+
+open System
+open System.Diagnostics
+open System.IO
+
+/// The possible variable value types for CMake variables.
+type CMakeValue =
+    | CMakeBoolean of bool
+    | CMakeString of string
+    | CMakeFilePath of string
+    | CMakeDirPath of string
+
+/// A CMake variable.
+type CMakeVariable = {
+    /// The name of the variable.
+    /// It cannot contains spaces and special characters.
+    Name:string
+    /// The value of the variable.
+    /// Will be automatically converted to the CMake format when required.
+    Value:CMakeValue
+}
+
+/// The CMakeGenerate parameter type.
+type CMakeGenerateParams = {
+    /// The location of the CMake executable. Automatically found if null or empty.
+    ToolPath:string
+    /// The source directory which should include a `CMakeLists.txt` file.
+    SourceDirectory:string
+    /// The binary build directory where CMake will generate the files.
+    BinaryDirectory:string
+    /// An optional toolchain file to load.
+    /// Equivalent to the `-D CMAKE_TOOLCHAIN_FILE:FILEPATH="<toolchain-file>"` CMake option.
+    Toolchain:string
+    /// The native build system generator to use for writing the files.
+    /// See `cmake --help` for a list of the available entries.
+    /// *To avoid unpredictable generator usage, it is recommended to define it.*
+    /// Equivalent to the `-G <generator-name>` option.
+    Generator:string
+    /// An optional toolset (!= toolchain) to use.
+    /// Equivalent to the `-T <toolset-name>` option.
+    /// Not supported by every generator.
+    Toolset:string
+    /// An optional CMake platform.
+    /// Equivalent to the `-A <platform-name>` option.
+    /// Not supported by every generator.
+    Platform:string
+    /// A list of the optional CMake cache files to load.
+    /// Equivalent to the `-C <initial-cache>` options.
+    Caches:string list
+    /// The directory where CMake will install the generated files.
+    /// Equivalent to the `-D CMAKE_INSTALL_PREFIX:DIRPATH="<install-directory>"` CMake option.
+    InstallDirectory:string
+    /// A list of every variable to pass as a CMake argument.
+    /// Equivalent to the `-D <var>:<type>=<value>` options.
+    Variables:CMakeVariable list
+    /// Remove matching entries from CMake cache.
+    /// Equivalent to the `-U <globbing_expr>` options.
+    CacheEntriesToRemove:string list
+    /// The CMake execution timeout.
+    Timeout:TimeSpan
+    /// A character string containing additional arguments to give to CMake.
+    AdditionalArgs:string
+}
+
+/// The CMakeBuild parameter type.
+type CMakeBuildParams = {
+    /// The location of the CMake executable. Automatically found if null or empty.
+    ToolPath:string
+    /// The binary build directory where CMake will generate the files.
+    BinaryDirectory:string
+    /// The CMake target to build instead of the default one.
+    /// Equivalent to the `--target <target>` option.
+    Target:string
+    /// The build configuration to use (e.g. `Release`).
+    /// Equivalent to the `--config <cfg>` option.
+    /// Not supported by every generator.
+    Config:string
+    /// The CMake execution timeout.
+    Timeout:TimeSpan
+    /// A character string containing additional arguments to give to CMake.
+    AdditionalArgs:string
+}
+
+/// Contains tasks which allow to use CMake to build CMakeLists files.
+/// See `Samples/CMakeSupport` for usage examples.
+module CMake =
+    /// The default option set given to CMakeGenerate.
+    let CMakeGenerateDefaults = {
+        ToolPath = ""
+        SourceDirectory = currentDirectory
+        BinaryDirectory = currentDirectory @@ "build"
+        Toolchain = ""
+        Generator = ""
+        Toolset = ""
+        Platform = ""
+        Caches = []
+        InstallDirectory = currentDirectory @@ "install"
+        Variables = []
+        CacheEntriesToRemove = []
+        Timeout = TimeSpan.MaxValue
+        AdditionalArgs = ""
+    }
+
+    /// The default option set given to CMakeBuild.
+    let CMakeBuildDefaults = {
+        ToolPath = ""
+        BinaryDirectory = currentDirectory @@ "build"
+        Target = ""
+        Config = ""
+        Timeout = TimeSpan.MaxValue
+        AdditionalArgs = ""
+    }
+
+    /// [omit]
+    /// Tries to find the specified CMake executable:
+    ///
+    /// 1. Locally in `./<tools|packages>/<cmake.portable>|<cmake>/bin`
+    /// 3. In the `PATH` environment variable.
+    /// 4. In the `<ProgramFilesx86>\CMake\bin` directory.
+    /// ## Parameters
+    ///  - `exeName` - The name of the CMake executable (e.g. `cmake`, `ctest`, etc.) to find.
+    ///    The `.exe` suffix will be automatically appended on Windows.
+    let FindExe exeName =
+        let fullName = exeName + if isUnix then "" else ".exe"
+        [
+            Seq.singleton (currentDirectory @@ "tools" @@ "cmake.portable" @@ "tools" @@ "bin")
+            Seq.singleton (currentDirectory @@ "packages" @@ "cmake.portable" @@ "tools" @@ "bin")
+            Seq.singleton (currentDirectory @@ "tools" @@ "cmake" @@ "tools" @@ "bin")
+            Seq.singleton (currentDirectory @@ "packages" @@ "cmake" @@ "tools" @@ "bin")
+            pathDirectories
+        ]
+        |> (fun list -> if isUnix then list else List.append list [Seq.singleton (ProgramFilesX86 @@ "CMake" @@ "bin")])
+        |> Seq.concat
+        |> Seq.map (fun directory -> directory @@ fullName)
+        |> Seq.tryFind fileExists
+
+    /// [omit]
+    /// Converts a file path to a valid CMake format.
+    /// ## Parameters
+    ///  - `path` - The path to reformat.
+    let private FormatCMakePath (path:string) = path.Replace("\\", "/")
+
+    /// [omit]
+    /// Invokes the CMake executable with the specified arguments.
+    /// ## Parameters
+    ///  - `toolPath` - The location of the executable. Automatically found if null or empty.
+    ///  - `binaryDir` - The location of the binary directory.
+    ///  - `args` - The arguments given to the executable.
+    ///  - `timeout` - The CMake execution timeout
+    let private CallCMake toolPath binaryDir args timeout =
+        // CMake expects an existing binary directory.
+        // Not defaulted because it would prevent building multiple CMake projects in the same FAKE script.
+        if isNullOrEmpty binaryDir then failwith "The CMake binary directory is not set."
+        // Try to find the CMake executable if not specified by the user.
+        let cmakeExe =
+            if not <| isNullOrEmpty toolPath then toolPath else
+            let found = FindExe "cmake"
+            if found <> None then found.Value else failwith "Cannot find the CMake executable."
+        // CMake expects the binary directory to be passed as an argument.
+        let arguments = if (String.IsNullOrEmpty args) then "\"" + binaryDir + "\"" else args
+        let fullCommand = cmakeExe + " " + arguments
+        traceStartTask "CMake" fullCommand
+        let setInfo (info:ProcessStartInfo) =
+            info.FileName <- cmakeExe
+            info.WorkingDirectory <- binaryDir
+            info.Arguments <- arguments
+        let result = ExecProcess (setInfo) timeout
+        if result <> 0 then failwithf "CMake failed with exit code %i." result
+        traceEndTask "CMake" fullCommand
+
+    /// Calls `cmake` to generate a project.
+    /// ## Parameters
+    ///  - `setParams` - Function used to manipulate the default CMake parameters. See `CMakeGenerateParams`.
+    let Generate setParams =
+        let parameters = setParams CMakeGenerateDefaults
+        // CMake expects an existing source directory.
+        // Not defaulted because it would prevent building multiple CMake projects in the same FAKE script.
+        if isNullOrEmpty parameters.SourceDirectory then failwith "The CMake source directory is not set."
+        let argsIfNotEmpty format values =
+            List.filter (isNotNullOrEmpty) values
+            |> List.map (sprintf format)
+        let generator = argsIfNotEmpty "-G \"%s\"" [parameters.Generator]
+        let toolchain = argsIfNotEmpty "-D CMAKE_TOOLCHAIN_FILE:FILEPATH=\"%s\"" [FormatCMakePath parameters.Toolchain]
+        let toolset = argsIfNotEmpty "-T \"%s\"" [parameters.Toolset]
+        let platform = argsIfNotEmpty "-A \"%s\"" [parameters.Platform]
+        let caches = parameters.Caches |> List.map FormatCMakePath |> argsIfNotEmpty "-C \"%s\""
+        let installDir = argsIfNotEmpty "-D CMAKE_INSTALL_PREFIX:DIRPATH=\"%s\"" [FormatCMakePath parameters.InstallDirectory]
+        let variables =
+            parameters.Variables
+            |> List.map (fun option ->
+                "-D " + option.Name +
+                match option.Value with
+                | CMakeBoolean(value) -> ":BOOL=" + if value then "ON" else "OFF"
+                | CMakeString(value) -> ":STRING=\"" + value + "\""
+                | CMakeDirPath(value) -> FormatCMakePath value |> sprintf ":PATH=\"%s\""
+                | CMakeFilePath(value) -> FormatCMakePath value |> sprintf ":FILEPATH=\"%s\""
+            )
+        let cacheEntriesToRemove = argsIfNotEmpty "-U \"%s\"" parameters.CacheEntriesToRemove
+        let args =
+            [ generator; toolchain; toolset; platform; caches; installDir; variables; cacheEntriesToRemove
+              [parameters.AdditionalArgs; "\"" + parameters.SourceDirectory + "\""]
+            ] |> List.concat |> String.concat " "
+        CallCMake parameters.ToolPath parameters.BinaryDirectory args parameters.Timeout
+
+    /// Calls `cmake --build` to build a project.
+    /// ## Parameters
+    ///  - `setParams` - Function used to manipulate the default CMake parameters. See `CMakeBuildParams`.
+    let Build setParams =
+        let parameters = setParams CMakeBuildDefaults
+        let targetArgs =
+            if isNullOrEmpty parameters.Target then ""
+            else " --target \"" + parameters.Target + "\""
+        let configArgs =
+            if isNullOrEmpty parameters.Config then ""
+            else " --config \"" + parameters.Config + "\""
+        let args =
+            "--build \"" + parameters.BinaryDirectory + "\"" +
+            targetArgs + configArgs + parameters.AdditionalArgs
+        CallCMake parameters.ToolPath parameters.BinaryDirectory args parameters.Timeout

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -158,6 +158,7 @@
     <Compile Include="Vb6helper.fs" />
     <Compile Include="AndroidPublisher.fs" />
     <Compile Include="ChangeWatcher.fs" />
+    <Compile Include="CMake.fs" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Description of the wrapped tool:

> CMake, is a cross-platform, open-source build system. CMake is a family of tools designed to build, test and package software. CMake is used to control the software compilation process using simple platform and compiler independent configuration files. CMake generates native makefiles and workspaces that can be used in the compiler environment of your choice.

See the [official website](http://www.cmake.org/) for more information about CMake.

Features:
* Configure and build any CMake project with FakeLib's CMakeHelper.
* Supports the most used CMake option switches.
* Strong CMake variable declaration to avoid conversion issues.
* Executable search algorithm working on both Windows and Unix.
* Toolchain file support.
* Setting unwrapped CMake arguments manually remains possible.
* Setting CMake arguments manually remains possible.

It has been tested on both Windows (with VS 2012 and 2013) and the Ubuntu/Vagrant box (g++) using a simple C++ project.

