### PR TITLE
Add test adapter path to vs test params

### DIFF
--- a/src/app/FakeLib/UnitTest/VSTest.fs
+++ b/src/app/FakeLib/UnitTest/VSTest.fs
@@ -54,7 +54,9 @@ type VSTestParams =
       /// A timeout for the test runner (optional).
       TimeOut : TimeSpan
       /// Error level for controlling how VSTest failures should break the build (optional).
-      ErrorLevel : ErrorLevel }
+      ErrorLevel : ErrorLevel 
+      /// Path to test adapter e.g. xUnit (optional)
+      TestAdapterPath: string}
 
 /// VSTest default parameters.
 let VSTestDefaults = 
@@ -78,7 +80,8 @@ let VSTestDefaults =
           | None -> ""
       WorkingDir = null
       TimeOut = TimeSpan.MaxValue
-      ErrorLevel = ErrorLevel.Error }
+      ErrorLevel = ErrorLevel.Error
+      TestAdapterPath = null }
 
 /// Builds the command line arguments from the given parameter record and the given assemblies.
 /// [omit]
@@ -103,6 +106,7 @@ let buildVSTestArgs (parameters : VSTestParams) assembly =
     |> appendIfTrue parameters.ListExecutors "/ListExecutors"
     |> appendIfTrue parameters.ListLoggers "/ListLoggers"
     |> appendIfTrue parameters.ListSettingsProviders "/ListSettingsProviders"
+    |> appendIfNotNull parameters.TestAdapterPath "/TestAdapterPath:"
     |> toText
 
 /// Runs VSTest command line tool (VSTest.Console.exe) on a group of assemblies.


### PR DESCRIPTION
It would be nice to be able to use the vstest console runner to run tests that are written with other testing frameworks such as xUnit - this would allow developers to make use of the vstest coverage and trx logger - for instance when used in conjunction with SonarQube
This pull request adds the optional TestAdapterPath to the vstest params type
