### PR TITLE
xUnit use relative path for output dir

### DIFF
--- a/src/app/FakeLib/UnitTest/XUnitHelper.fs
+++ b/src/app/FakeLib/UnitTest/XUnitHelper.fs
@@ -61,11 +61,12 @@ let XUnitDefaults =
 let buildXUnitArgs parameters assembly = 
     let fi = fileInfo assembly
     let name = fi.Name
-    
-    let dir = 
+
+    let dir =
         if isNullOrEmpty parameters.OutputDir then String.Empty
         else Path.GetFullPath parameters.OutputDir
-    
+        |> replace currentDirectory "."
+
     let traits includeExclude (name, values : string) = 
         values.Split([| ',' |], System.StringSplitOptions.RemoveEmptyEntries)
         |> Seq.collect (fun value -> 


### PR DESCRIPTION
A rooted *nix path (beginning with /) is interpreted by the xUnit runner as a command line directive. This causes the xUnit runner to fail when report directories are specified when building on Mono.
