### PR TITLE
Fix WatchChanges on Mac, fix Dispose, improve Timer usage

### DIFF
--- a/src/app/FakeLib/ChangeWatcher.fs
+++ b/src/app/FakeLib/ChangeWatcher.fs
@@ -47,19 +47,20 @@ let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileInclude
                            dirsToWatch
                            |> Seq.exists (fun p -> p.StartsWith d && p <> d)
                            |> not)
-    
+    tracefn "dirs to watch: %A" dirsToWatch
+ 
+    // we collect changes in a mutable ref cell and wait for a few milliseconds to 
+    // receive all notifications when the system sends them repetedly or sends multiple
+    // updates related to the same file; then we call 'onChange' with all cahnges
     let unNotifiedChanges = ref List.empty<FileChange>
-    
-    let acumChanges (fileChange : FileChange) = 
-        if fileIncludes.IsMatch fileChange.FullPath then 
-            lock unNotifiedChanges (fun () -> unNotifiedChanges := [ fileChange ] @ !unNotifiedChanges)
-    
-    let timer = new System.Timers.Timer(5.0)
+    // when running 'onChange' we ignore all notifications to avoid infinite loops
+    let runningHandlers = ref false
+
+    let timer = new System.Timers.Timer(50.0)
+    timer.AutoReset <- false
     timer.Elapsed.Add(fun _ -> 
         lock unNotifiedChanges (fun () -> 
-            if !unNotifiedChanges
-               |> Seq.length
-               > 0 then 
+            if not (Seq.isEmpty !unNotifiedChanges) then
                 let changes = 
                     !unNotifiedChanges
                     |> Seq.groupBy (fun c -> c.FullPath)
@@ -67,13 +68,25 @@ let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileInclude
                            changes
                            |> Seq.sortBy (fun c -> c.Status)
                            |> Seq.head)
-                unNotifiedChanges := List.empty<FileChange>
-                onChange changes))
+                unNotifiedChanges := []
+                try 
+                    runningHandlers := true
+                    onChange changes
+                finally
+                    runningHandlers := false ))
 
-    tracefn "dirs to watch: %A" dirsToWatch
+    let acumChanges (fileChange : FileChange) = 
+        // only record the changes if we are not currently running 'onChange' handler
+        if not !runningHandlers && fileIncludes.IsMatch fileChange.FullPath then 
+            lock unNotifiedChanges (fun () -> 
+              unNotifiedChanges := fileChange :: !unNotifiedChanges
+              // start the timer (ignores repeated calls) to trigger events in 50ms
+              (timer:System.Timers.Timer).Start() )
+    
     let watchers = 
-        dirsToWatch |> Seq.map (fun dir -> 
+        dirsToWatch |> List.ofSeq |> List.map (fun dir -> 
                            tracefn "watching dir: %s" dir
+
                            let watcher = new FileSystemWatcher(FullName dir, "*.*")
                            watcher.EnableRaisingEvents <- true
                            watcher.IncludeSubdirectories <- true
@@ -88,11 +101,6 @@ let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileInclude
                                              Name = e.Name
                                              Status = Created })
                            watcher)
-    watchers
-    |> Seq.length
-    |> ignore //force iteration
-
-    timer.Start()
 
     { new System.IDisposable with
           member this.Dispose() = 


### PR DESCRIPTION
This does a couple of improvements to the watcher:

 - Make it work on Mac/Unix (if you specified full path before, the `getRoot` function would drop the `/` from the beginning and treat the path as not rooted - and you'd end up with wrong path)
 - Make it possible to specify just file names without `*` pattern (e.g. `!! "app.fsx"` if I want to watch for just a single file)
 - Rather than running the timer all the time, we now only start it when something happens. I also increased the delay a bit (to give the system a bit more time to collect all events related to one action)
 - Also, it now ignores events that happen when the user is reacting to another event (if the user-specified function touches the file - we do not want to get into an infinite loop).

This is mostly triggered by the Suave Dojo (using WatchChanges to live-reload web server), but I think all the changes are useful for the other scenarios I'm aware of.