### PR TITLE
NUnit documentation improvements

### DIFF
--- a/help/gettingstarted.md
+++ b/help/gettingstarted.md
@@ -257,7 +257,7 @@ Now all our projects will be compiled and we can use FAKE's NUnit task in order 
 	// start build
 	RunTargetOrDefault "Default"
 
-Our new *Test* target scans the test directory for test assemblies and runs them with the NUnit runner. FAKE automatically tries to locate the runner in one of your subfolders. See the [NUnit task documentation](apidocs/fake-nunitparallel.html) if you need to specify the tool path explicitly.
+Our new *Test* target scans the test directory for test assemblies and runs them with the NUnit runner. FAKE automatically tries to locate the runner in one of your subfolders. See the [NUnit task documentation](apidocs/fake-nunitsequential.html) if you need to specify the tool path explicitly.
 
 The mysterious part **(fun p -> ...)** simply overrides the default parameters of the NUnit task and allows to specify concrete parameters.
 

--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -40,24 +40,44 @@ type NUnitDomainModel =
 ///
 /// For reference, see: [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
 type NUnitParams = 
-    { IncludeCategory : string
+    { 
+      /// Default: ""
+      IncludeCategory : string
+      /// Default: ""
       ExcludeCategory : string
+      /// Default FAKE will try to locate nunit-console.exe in any subfolder of the current directory.
       ToolPath : string
+      /// Default:"nunit-console.exe"
       ToolName : string
+      /// Default: false
       DontTestInNewThread : bool
+      /// Default: false
       StopOnError : bool
+      /// Default: ".\TestResult.xml"
       OutputFile : string
+      /// Default: ""
       Out : string
+      /// Default: ""
       ErrorOutputFile : string
+      /// Default: ""
       Framework : string
+      /// Default: [NUnitProcessModel](fake-nunitcommon-nunitprocessmodel.html).DefaultProcessModel
       ProcessModel : NUnitProcessModel
+      /// Default: true
       ShowLabels : bool
+      /// Default: ""
       WorkingDir : string
+      /// Default: ""
       XsltTransformFile : string
+      /// Default: 5 minutes
       TimeOut : TimeSpan
+      /// Default: false
       DisableShadowCopy : bool
+      /// Default: [NUnitDomainModel](fake-nunitcommon-nunitdomainmodel.html).DefaultDomainModel
       Domain : NUnitDomainModel
+      /// Default: [TestRunnerErrorLevel](fake-unittestcommon-testrunnererrorlevel.html).Error
       ErrorLevel : NUnitErrorLevel 
+      /// Default: ""
       Fixture: string}
 
 /// The [NUnit](http://www.nunit.org/) default parameters. FAKE tries to locate nunit-console.exe in any subfolder.

--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -9,7 +9,7 @@ open System.Text
 /// Option which allows to specify if a NUnit error should break the build.
 type NUnitErrorLevel = TestRunnerErrorLevel // a type alias to keep backwards compatibility
 
-/// Process model for nunit to use, see http://www.nunit.org/index.php?p=projectEditor&r=2.5
+/// Process model for nunit to use, see [Project Editor](http://www.nunit.org/index.php?p=projectEditor&r=2.6.4)
 type NUnitProcessModel = 
     | DefaultProcessModel
     | SingleProcessModel
@@ -21,7 +21,7 @@ type NUnitProcessModel =
         | SingleProcessModel -> "Single"
         | SeparateProcessModel -> "Separate" 
         | MultipleProcessModel -> "Multiple"
-/// The /domain option controls of the creation of AppDomains for running tests. See http://www.nunit.org/index.php?p=consoleCommandLine&r=2.4.6
+/// The /domain option controls of the creation of AppDomains for running tests. See [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
 type NUnitDomainModel = 
     /// No domain is created - the tests are run in the primary domain. This normally requires copying the NUnit assemblies into the same directory as your tests.
     | DefaultDomainModel
@@ -34,7 +34,11 @@ type NUnitDomainModel =
         | DefaultDomainModel -> ""
         | SingleDomainModel -> "Single"
         | MultipleDomainModel -> "Multiple"
-/// Parameter type for NUnit.
+
+/// The [NUnit](http://www.nunit.org/) Console Parameters type.
+/// FAKE will use [NUnitDefaults](fake-nunitcommon.html) for values not provided.
+///
+/// For reference, see: [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
 type NUnitParams = 
     { IncludeCategory : string
       ExcludeCategory : string
@@ -56,7 +60,7 @@ type NUnitParams =
       ErrorLevel : NUnitErrorLevel 
       Fixture: string}
 
-/// NUnit default parameters. FAKE tries to locate nunit-console.exe in any subfolder.
+/// The [NUnit](http://www.nunit.org/) default parameters. FAKE tries to locate nunit-console.exe in any subfolder.
 let NUnitDefaults = 
     let toolname = "nunit-console.exe"
     { IncludeCategory = ""

--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -41,46 +41,83 @@ type NUnitDomainModel =
 /// For reference, see: [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
 type NUnitParams = 
     { 
-      /// Default: ""
+      /// The [Categories](http://www.nunit.org/index.php?p=category&r=2.6.4) to be included in a test run. Multiple categories may be specified on either option, by using commas to separate them.
       IncludeCategory : string
-      /// Default: ""
+
+      /// The [Categories](http://www.nunit.org/index.php?p=category&r=2.6.4) to be excluded in a test run. Multiple categories may be specified on either option, by using commas to separate them.
       ExcludeCategory : string
-      /// Default FAKE will try to locate nunit-console.exe in any subfolder of the current directory.
+
+      /// The path to the NUnit console runner: `nunit-console.exe`
       ToolPath : string
-      /// Default:"nunit-console.exe"
+
+      /// NUnit console runner name. ( `nunit-console.exe`)
       ToolName : string
-      /// Default: false
+
+      /// Suppresses use of a separate thread for running the tests and uses the main thread instead.
       DontTestInNewThread : bool
-      /// Default: false
+
+      /// Causes execution of the test run to terminate immediately on the first test failure or error.
       StopOnError : bool
-      /// Default: ".\TestResult.xml"
+
+      /// The output path of the nUnit XML report.
       OutputFile : string
-      /// Default: ""
+
+      /// Redirects output created by the tests from standard output (console) to the file specified as value.
       Out : string
-      /// Default: ""
+
+      /// Redirects error output created by the tests from standard error output (console) to the file specified as value.
       ErrorOutputFile : string
-      /// Default: ""
+
+      /// Allows you to specify the version of the runtime to be used in executing tests.
       Framework : string
-      /// Default: [NUnitProcessModel](fake-nunitcommon-nunitprocessmodel.html).DefaultProcessModel
+
+      /// Controls how NUnit loads tests in processes. See: [NUnitProcessModel](fake-nunitcommon-nunitprocessmodel.html).
       ProcessModel : NUnitProcessModel
-      /// Default: true
+
+      /// Causes an identifying label to be displayed at the start of each test case.
       ShowLabels : bool
-      /// Default: ""
+
+      /// The working directory.
       WorkingDir : string
-      /// Default: ""
+
+      /// The path to a custom XSLT transform file to be used to process the XML report.
       XsltTransformFile : string
-      /// Default: 5 minutes
+
+      /// The default timeout to be used for test cases. If any test exceeds the timeout value, it is cancelled and reported as an error.
       TimeOut : TimeSpan
-      /// Default: false
+
+      /// Disables shadow copying of the assembly in order to provide improved performance.
       DisableShadowCopy : bool
-      /// Default: [NUnitDomainModel](fake-nunitcommon-nunitdomainmodel.html).DefaultDomainModel
+
+      /// See [NUnitDomainModel](fake-nunitcommon-nunitdomainmodel.html).
       Domain : NUnitDomainModel
       /// Default: [TestRunnerErrorLevel](fake-unittestcommon-testrunnererrorlevel.html).Error
       ErrorLevel : NUnitErrorLevel 
       /// Default: ""
       Fixture: string}
 
-/// The [NUnit](http://www.nunit.org/) default parameters. FAKE tries to locate nunit-console.exe in any subfolder.
+/// The [NUnitParams](fake-nunitcommon-nunitparams.html) default parameters. 
+///
+/// ## Defaults
+/// - `IncludeCategory` - `""`
+/// - `ExcludeCategory` - `""`
+/// - `ToolPath` - `""`
+/// - `ToolName` - `"nunit-console.exe"`
+/// - `DontTestInNewThread`- `false`
+/// - `StopOnError` - `false`
+/// - `OutputFile` - The `nunit-console.exe` path if it exists in a subdirectory of the current directory.
+/// - `Out` - `""`
+/// - `ErrorOutputFile` - `""`
+/// - `WorkingDir` - `""`
+/// - `Framework` - `""`
+/// - `ProcessModel` - `DefaultProcessModel`
+/// - `ShowLabels` - `true`
+/// - `XsltTransformFile` - `""`
+/// - `TimeOut` - 5 minutes
+/// - `DisableShadowCopy` - `false`
+/// - `Domain` - `DefaultDomainModel`
+/// - `ErrorLevel` - `Error`
+/// - `Fixture` - `""`
 let NUnitDefaults = 
     let toolname = "nunit-console.exe"
     { IncludeCategory = ""

--- a/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
@@ -25,7 +25,7 @@ type private AggFailedResult =
 /// Runs NUnit in parallel on a group of assemblies.
 /// ## Parameters
 /// 
-///  - `setParams` - Function used to manipulate the default NUnitParams value.
+///  - `setParams` - Function used to manipulate the default [NUnitParams](fake-nunitcommon-nunitparams.html) value.
 ///  - `assemblies` - Sequence of one or more assemblies containing NUnit unit tests.
 /// 
 /// ## Sample usage

--- a/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
@@ -5,7 +5,7 @@ module Fake.NUnitSequential
 /// Runs NUnit on a group of assemblies.
 /// ## Parameters
 /// 
-///  - `setParams` - Function used to manipulate the default NUnitParams value.
+///  - `setParams` - Function used to manipulate the default [NUnitParams](fake-nunitcommon-nunitparams.html) value.
 ///  - `assemblies` - Sequence of one or more assemblies containing NUnit unit tests.
 /// 
 /// ## Sample usage


### PR DESCRIPTION
This PR contains small improvements to documentation related to NUnit.

- Fixed link to `NUnitSequential` task on getting started page. Both links on getting started were pointing to `NUnitParallel` documentation.

- Linked `NUnitParams` apidoc on `NUnitSequential` and `NUnitParallel` documentation. I am not sure if this is the correct way to add a link to another file in the API docs.

- Unified NUnit documentation links to documentation for NUnit v2.6.4 (current stable version).

- Documented default values for `NUnitParams` in `NUnitDefaults` docs.

- Added docs for the `NUnitParams` record fields with text from NUnit documentation.