### PR TITLE
Fixed wrong visibility of FillInWiXScript function

### DIFF
--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -622,7 +622,7 @@ let generateWiXScript fileName =
 ///                                CustomActions = action1.ToString() + action2.ToString()
 ///                                ActionSequences = actionExecution1.ToString() + actionExecution2.ToString()
 ///                            })
-let internal FillInWixScript wiXPath setParams =
+let FillInWixScript wiXPath setParams =
     let parameters = WiXScriptDefaults |> setParams
     let wixScript = !!("*.wxs" @@ wiXPath)
     let replacements = [


### PR DESCRIPTION
I just saw that the FillInWiXScript function is defined as "internal" and thus not usable at the moment.
I'm sorry for the inconvenience, I fixed the visibility.