### PR TITLE
Change formatting of graph output

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -304,7 +304,7 @@ let PrintDependencyGraph verbose target =
             let addToOrder = not (printed.Contains (toLower act))
             printed.Add (toLower act) |> ignore
     
-            if addToOrder || verbose then log <| (sprintf "<== %s" act).PadLeft(3 * indent)
+            if addToOrder || verbose then log <| sprintf "%s<== %s" (String(' ', indent * 3)) act
             Seq.iter (printDependencies (indent+1)) target.Dependencies
             if addToOrder then order.Add act
         


### PR DESCRIPTION
Consider this build.fsx:
```fsharp
#r @"packages/FAKE/bin/Debug/FakeLib.dll"

open Fake

Target "BuildTests" (fun _ -> log "Building tests ...")
Target "RunTests" (fun _ -> log "Running tests ...")
Target "Test" DoNothing

Target "Build"  (fun _ -> log "Building the app ...")

Target "PaketPack" (fun _ -> log "Create packages ...")
Target "PaketPush" (fun _ -> log "Push packages to server ...")
Target "Paket" DoNothing

Target "Default" DoNothing

"BuildTests" ==> "Test"
"RunTests" ==> "Test"

"PaketPack" ==> "Paket"
"PaketPush" ==> "Paket"

"Test" ==> "Default"
"Build" ==> "Default"
"Paket" ==> "Default"

PrintDependencyGraph true "Default" 
```

Currently FAKE gives the following output:
```
DependencyGraph for Target Default:
<== Default
<== Test
<== BuildTests
<== RunTests
<== Build
<== Paket
<== PaketPack
<== PaketPush

The resulting target order is:
 - BuildTests
 - RunTests
 - Test
 - Build
 - PaketPack
 - PaketPush
 - Paket
 - Default
```

With this change, we get the following output:
```
DependencyGraph for Target Default:
<== Default
   <== Test
      <== BuildTests
      <== RunTests
   <== Build
   <== Paket
      <== PaketPack
      <== PaketPush

The resulting target order is:
 - BuildTests
 - RunTests
 - Test
 - Build
 - PaketPack
 - PaketPush
 - Paket
 - Default
```