### PR TITLE
CMake support improvements

### DIFF
--- a/Samples/CMakeSupport/Advanced/build.fsx
+++ b/Samples/CMakeSupport/Advanced/build.fsx
@@ -1,5 +1,6 @@
 #r "../../../build/FakeLib.dll"
 open Fake
+open Fake.CMakeSupport
 
 // Out of source build: CMake separates the source code from what's being generated.
 

--- a/Samples/CMakeSupport/Simple/build.fsx
+++ b/Samples/CMakeSupport/Simple/build.fsx
@@ -1,5 +1,6 @@
 #r "../../../build/FakeLib.dll"
 open Fake
+open Fake.CMakeSupport
 
 // Out of source build: CMake separates the source code from what's being generated.
 let binaryDir = "./build"

--- a/src/app/FakeLib/CMake.fs
+++ b/src/app/FakeLib/CMake.fs
@@ -185,7 +185,7 @@ module CMake =
         let toolset = argsIfNotEmpty "-T \"%s\"" [parameters.Toolset]
         let platform = argsIfNotEmpty "-A \"%s\"" [parameters.Platform]
         let caches = parameters.Caches |> List.map FormatCMakePath |> argsIfNotEmpty "-C \"%s\""
-        let installDir = argsIfNotEmpty "-D CMAKE_INSTALL_PREFIX:DIRPATH=\"%s\"" [FormatCMakePath parameters.InstallDirectory]
+        let installDir = argsIfNotEmpty "-D CMAKE_INSTALL_PREFIX:PATH=\"%s\"" [FormatCMakePath parameters.InstallDirectory]
         let variables =
             parameters.Variables
             |> List.map (fun option ->

--- a/src/app/FakeLib/CMake.fs
+++ b/src/app/FakeLib/CMake.fs
@@ -1,5 +1,6 @@
-﻿namespace Fake
+﻿namespace Fake.CMakeSupport
 
+open Fake
 open System
 open System.Diagnostics
 open System.IO


### PR DESCRIPTION
Here are two new commits which includes improvements on the CMake support in FAKE:

* Commit f35c76d contains a fix for a typo I made.
* Commit b7193ed mostly aims to lower the CMake types in the HTML documentation. You can ignore it if you do not agree with the namespace changes.