### PR TITLE
Allow test nUnit test assemblies containing SetupFixture attributes be compatible with NUnitParallel

### DIFF
--- a/src/app/FakeLib/UnitTest/NUnit/Xml.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Xml.fs
@@ -20,7 +20,10 @@ let inline private elem name = XElement(imp name : XName)
 /// [omit]
 let GetTestAssemblies(xDoc : XDocument) = 
     xDoc.Descendants()
-    |> Seq.filter (fun el -> el.Name = (imp "test-suite") && el.Attribute(imp "type").Value = "Assembly")
+    |> Seq.filter 
+        (fun el -> 
+                el.Name = (imp "test-suite") && 
+                (el.Attribute(imp "type").Value = "Assembly" || el.Attribute(imp "type").Value = "SetUpFixture"))
     |> Seq.toList
 
 /// Returns whether all tests in the given test result have succeeded


### PR DESCRIPTION
nUnit unit test assemblies that contain a SetupFixture attribute will be flagged in the test report as a "SetUpFixture" test-suite type. e.g.

&lt; test-suite type="SetUpFixture" name="assembly_name_here" executed="True" result="Success" success="True" time="1.00" asserts="0" &gt;

This change will update the NUnitParallel test report merging so that "SetUpFixture" types will be included in the merged test report xml.