### PR TITLE
Re-added internal class generated for AssemblyInfo.vb

### DIFF
--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -181,7 +181,14 @@ let CreateVisualBasicAssemblyInfoWithConfig outputFileName attributes (config : 
              |> Seq.toList
              |> List.map (fun (attr : Attribute) -> sprintf "<assembly: %sAttribute(%s)>" attr.Name attr.Value))
 
-    attributeLines 
+    let sourceLines =
+        if generateClass then
+            [ "Friend NotInheritable Class AssemblyVersionInformation"
+              sprintf "    Friend Const Version As String = %s" (getAssemblyVersionInfo attributes)
+              "End Class" ]
+        else []
+
+    attributeLines @ sourceLines
     |> writeToFile outputFileName
     traceEndTask "AssemblyInfo" outputFileName
 


### PR DESCRIPTION
Was removed in 63185e7cded200f73e75dedcf5e0afe21f20b953 for #673 due to errors building. Contrary to the prior report, classes _can_ be added to `AssemblyInfo.vb`.

Two issues resolved here are:

1. In a VB.NET project named `TestApp`, using `Namespace System` in user-code results in a namespace named `TestApp.System` being created, which causes the System namespace to be hidden. Removed the namespace declaration around the class to resolve this.

2. As pointed out in #673, the class definition had no name. Added the name used in the C#/F# code.