### PR TITLE
Get package version from nuspec file

### DIFF
--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -116,10 +116,10 @@ let GetPackageVersion deploymentsDir package =
             if index < folder.Length then
                 folder.Substring index
             else
-                let files = Directory.GetFiles(folder, sprintf "%s.*.nupkg" package)
-                let file = (Seq.head files).Replace(".nupkg","")
-                let index = file.LastIndexOf package + package.Length + 1
-                file.Substring index
+                let nuspec = Directory.GetFiles(folder, sprintf "%s.nuspec" package) |> Seq.head
+                let doc = System.Xml.Linq.XDocument.Load(nuspec)
+                let vers = doc.Descendants(XName.Get("version", doc.Root.Name.NamespaceName))
+                (Seq.head vers).Value
                
         logfn "Version %s found for package %s" version package
         version


### PR DESCRIPTION
I was using `GetPackageVersion` in FsLab. When we use Paket to get FsLab dependencies, it downloads the package `Google.DataTable.Net.Wrapper` and puts it in a file called `Google.DataTable.Net.Wrapper.3.1.2.nupkg`. However, the `nuspec` file says that the version is actually `3.1.2.0` and if you add the reference using NuGet, it places it in a directory with `3.1.2.0` in the name (and also includes the additional `.0` in the  `nupkg` file name).

I'm not sure if this is a bug in Paket (uses wrong file name) or if it is just NuGet giving us inconsistent information. I suspect the latter, so I'm sending a PR. But perhaps this is better handled in Paket.. not sure!

(Based on code I added to the FsLab build script: https://github.com/fslaborg/FsLab/commit/2475145d2181d9e588ddd43cf8ecbd932c6c8a1c)