### PR TITLE
Look for MSTest in VS2015 location

### DIFF
--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -6,7 +6,8 @@ open System.Text
 
 /// [omit]
 let mstestPaths = 
-    [| @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE";
+    [| @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE";
        @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE";
        @"[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]
 


### PR DESCRIPTION
I noticed while attempting to use the MSTest that it wouldn't find it if I was using VS 2015. The proposed fix adds the VS 2015 path, in the order demonstrated by the existing array, which has newer versions of VS closer to the beginning. 

I got a very cryptic error with this issue, not fixed with this PR: 

    System.Exception: Start of process  failed. Cannot start process because a file name has not been provided.

I also noticed that if FAKE can't find MSTest with a value from the `mstestPaths` array it supplies a path of "". Is that because it hopes to luck-out and find MSTest on the `%PATH%`? 

While we are on the subject of paths to VS assets, would it be a better idea if all path computations regarding the VS location were done in one place so we don't have to (presumably) fix this in each case where we create a `mstestPaths` analog? Say for something like `gacutil` (just thinking off the top of my head). 

Thanks, 

Brody  