### PR TITLE
Add BuildConfig/TemplateFile options to PaketHelper's Pack command

### DIFF
--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -12,6 +12,8 @@ type PaketPackParams =
       TimeOut : TimeSpan
       Version : string
       ReleaseNotes : string
+      BuildConfig : string
+      TemplateFile : string
       WorkingDir : string
       OutputPath : string }
 
@@ -21,6 +23,8 @@ let PaketPackDefaults() : PaketPackParams =
       TimeOut = TimeSpan.FromMinutes 5.
       Version = null
       ReleaseNotes = null
+      BuildConfig = null
+      TemplateFile = null
       WorkingDir = "."
       OutputPath = "./temp" }
 
@@ -58,12 +62,14 @@ let Pack setParams =
 
     let version = if String.IsNullOrWhiteSpace parameters.Version then "" else " version " + toParam parameters.Version
     let releaseNotes = if String.IsNullOrWhiteSpace parameters.ReleaseNotes then "" else " releaseNotes " + toParam (xmlEncode parameters.ReleaseNotes)
+    let buildConfig = if String.IsNullOrWhiteSpace parameters.BuildConfig then "" else " buildconfig " + toParam parameters.BuildConfig
+    let templateFile = if String.IsNullOrWhiteSpace parameters.TemplateFile then "" else " templatefile " + toParam parameters.TemplateFile
       
     let packResult = 
         ExecProcess 
             (fun info -> 
             info.FileName <- parameters.ToolPath
-            info.Arguments <- sprintf "pack output %s%s%s" parameters.OutputPath version releaseNotes) parameters.TimeOut
+            info.Arguments <- sprintf "pack output %s%s%s%s%s" parameters.OutputPath version releaseNotes buildConfig templateFile) parameters.TimeOut
     
     if packResult <> 0 then failwithf "Error during packing %s." parameters.WorkingDir
     traceEndTask "PaketPack" parameters.WorkingDir


### PR DESCRIPTION
The `MSBuildHelper` module allows building configurations other than Release, and the `NuGetHelper` module allows consuming them by specifying a build configuration in the `NuGetParams.Properties` field. Since the `PaketHelper` module currently doesn't offer any way to make this work, I've added paket's `pack buildconfig` option in as a new field on `PaketPackParams`. Added paket's `pack templatefile` option in as well, since I'm already under-the-hood and it may help someone else.