### PR TITLE
Added caching of compiled build scripts.

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -36,3 +36,4 @@ nuget xunit.extensions
 nuget Newtonsoft.Json
 nuget Microsoft.AspNet.Razor 2.0.30506
 nuget Microsoft.AspNet.WebPages 2.0.30506
+nuget HashLib

--- a/paket.lock
+++ b/paket.lock
@@ -20,6 +20,7 @@ NUGET
     FSharp.Formatting.CommandTool (2.9.3)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
+    HashLib (2.0.1)
     jQuery (2.1.3)
     Knockout (0.0.1)
       AspNetMvc (>= 4.0.0.0)

--- a/paket.lock
+++ b/paket.lock
@@ -12,7 +12,7 @@ NUGET
     FsCheck.Xunit (1.0.4)
       FsCheck (>= 1.0.4)
       xunit (>= 1.9.2)
-    FSharp.Compiler.Service (0.0.89)
+    FSharp.Compiler.Service (1.3.1.0)
     FSharp.Core (3.1.2.1)
     FSharp.Formatting (2.9.3)
       FSharp.Compiler.Service (>= 0.0.87)

--- a/src/app/FAKE/Cli.fs
+++ b/src/app/FAKE/Cli.fs
@@ -15,6 +15,7 @@ type FakeArg =
     | [<AltCommandLine("-b")>] [<Rest>] Boot of string
     | [<AltCommandLine("-br")>] Break
     | [<AltCommandLine("-st")>] Single_Target
+    | [<AltCommandLine("-nc")>] NoCache
     interface IArgParserTemplate with
         member x.Usage = 
             match x with
@@ -27,6 +28,7 @@ type FakeArg =
             | Boot _ -> "Boostrapp your FAKE script."
             | Break -> "Pauses FAKE with a Debugger.Break() near the start"
             | Single_Target -> "Runs only the specified target and not the dependencies."
+            | NoCache -> "Disables caching of compiled script"
 
 /// Return the parsed FAKE args or the parse exception.
 let parsedArgsOrEx args = 

--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -116,7 +116,8 @@ try
                     
                 //TODO if printDetails then printEnvironment cmdArgs args
 
-                if not (runBuildScriptWithFsiArgsAt printDetails fsiArgs envVars) then Environment.ExitCode <- 1
+                let useCache = not (fakeArgs.Contains <@ Cli.NoCache @>)
+                if not (runBuildScriptWithFsiArgsAt printDetails fsiArgs envVars useCache true) then Environment.ExitCode <- 1
                 else if printDetails then log "Ready."
 
                 ()
@@ -135,7 +136,7 @@ try
                 let printDetails = containsParam "details" cmdArgs
                 if printDetails then
                     printEnvironment cmdArgs args
-                if not (runBuildScript printDetails buildScriptArg fsiArgs args) then Environment.ExitCode <- 1
+                if not (runBuildScript printDetails buildScriptArg fsiArgs args true true) then Environment.ExitCode <- 1
                 else if printDetails then log "Ready."
             | Some handler ->
                 handler.Interact()

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -273,6 +273,17 @@
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>
+        <Reference Include="HashLib">
+          <HintPath>..\..\..\packages\HashLib\lib\net40\HashLib.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
         <Reference Include="Microsoft.Web.XmlTransform">
           <HintPath>..\..\..\packages\Microsoft.Web.Xdt\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
           <Private>True</Private>

--- a/src/app/FakeLib/paket.references
+++ b/src/app/FakeLib/paket.references
@@ -4,3 +4,4 @@ Mono.Web.Xdt
 Mono.Cecil
 Nuget.Core
 Newtonsoft.Json
+HashLib

--- a/src/test/Test.FAKECore/FSIHelperSpecs.cs
+++ b/src/test/Test.FAKECore/FSIHelperSpecs.cs
@@ -167,64 +167,6 @@ namespace Test.FAKECore
 
                 included.ShouldEqual(new string[] { "justname", "./relative/path", "C:/absolute/path" });
             };
-        //It should_load_assembly =
-        //    () =>
-        //    {
-        //        var scriptPath = (Path.GetTempFileName() + ".fsx").Replace("\\", "/");
-
-        //        var script = 
-        //                "#r \"HashLib\"\nlet " +
-        //                "hasher = HashLib.HashFactory.Checksum.CreateCRC32a()\n" +
-        //                "printf \"%s\" (hasher.ComputeString(\"foo\").ToString())";
-        //        File.WriteAllText(scriptPath, script);
-
-        //        RunExplicit(scriptPath, "", true).ShouldEqual(
-        //            "Cache doesnt exist" + nl + 
-        //            "D9DD4FEE" + nl + 
-        //            "Saved cache" + nl);
-
-        //        RunExplicit(scriptPath, "", true).ShouldEqual(
-        //            "Using cache" + nl +
-        //            "D9DD4FEE");
-        //    };
     }
 
-    //public class when_running_the_fake_cli
-    //{
-    //    static string RunExplicit(string scriptFilePath, string arguments)
-    //    {
-            
-    //        var process = new System.Diagnostics.Process();
-    //        process.StartInfo.FileName = ".\\FAKE.exe";
-    //        process.StartInfo.Arguments = "\"" + scriptFilePath + "\" " + arguments;
-    //        process.StartInfo.UseShellExecute = false;
-    //        process.StartInfo.RedirectStandardOutput = true;
-    //        process.StartInfo.WorkingDirectory = Directory.GetCurrentDirectory();
-    //        process.StartInfo.RedirectStandardError = true;
-    //        process.Start();
-    //        //* Read the output (or the error)
-    //        string output = process.StandardOutput.ReadToEnd();
-    //        Console.WriteLine(output);
-    //        string err = process.StandardError.ReadToEnd();
-    //        //Console.WriteLine(err);
-    //        process.WaitForExit();
-    //        if (process.ExitCode != 0)
-    //        {
-    //            throw new Exception("Process exited with code " + process.ExitCode + ". Error: \n" + err);
-    //        }
-    //        return output;
-    //    }
-
-    //    static string Run(string script, string arguments) {
-    //        var scriptFilePath = Path.GetTempFileName() + ".fsx";
-    //        File.WriteAllText(scriptFilePath, script);
-    //        var result = RunExplicit(scriptFilePath, arguments);
-    //        File.Delete(scriptFilePath);
-    //        return result;
-    //    }
-
-        
-    //    It should_print_foobar =
-    //        () => Run("printfn \"foobar\"", "").ShouldEqual("foobar");
-    //}
 }

--- a/src/test/Test.FAKECore/FSIHelperSpecs.cs
+++ b/src/test/Test.FAKECore/FSIHelperSpecs.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using Fake;
+using Machine.Specifications;
+
+namespace Test.FAKECore
+{
+    public class when_running_script
+    {
+        
+        static string RunExplicit(string scriptFilePath, string arguments, bool useCache)
+        {
+            var stdOut = Console.Out;
+
+            var sbOut = new System.Text.StringBuilder();
+            var outStream = new StringWriter(sbOut);
+            Console.SetOut(outStream);
+            Tuple<bool, Microsoft.FSharp.Collections.FSharpList<ProcessHelper.ConsoleMessage>> result;
+            try
+            {
+                result = FSIHelper.executeBuildScriptWithArgsAndReturnMessages(scriptFilePath, new string[] { }, useCache, false);
+            }
+            finally
+            {
+                Console.SetOut(stdOut); // Now all output start going back to console window
+                Console.Write(sbOut.ToString());
+            }
+
+
+            if (!result.Item1)
+            {
+                var errors = result.Item2.Where(x => x.IsError).Select(x => x.Message);
+                throw new Exception("Executing script failed. Errors: \n" + String.Join("\n", errors));
+            }
+            foreach (var x in result.Item2)
+            {
+                Console.WriteLine(x.Message);
+            }
+            var messages = result.Item2.Where(x => !x.IsError).Select(x => x.Message);
+            return sbOut.ToString();
+        }
+
+        static string Run(string script, string arguments, bool useCache) {
+            var scriptFilePath = Path.GetTempFileName() + ".fsx";
+            string result;
+            try
+            {
+                File.WriteAllText(scriptFilePath, script);
+                result = RunExplicit(scriptFilePath, arguments, useCache);
+            }
+            finally
+            {
+                File.Delete(scriptFilePath);
+            }
+            
+            return result;
+        }
+
+        It should_use_then_invalidate_cache =
+            () => {
+                var arguments = "";
+                var scriptFilePath = Path.GetTempFileName() + ".fsx";
+                var scriptFileName = Path.GetFileName(scriptFilePath);
+                try
+                {
+                    File.WriteAllText(scriptFilePath, "printf \"foobar\"");
+                    var scriptHash = FSIHelper.getScriptHash(scriptFilePath);
+                    var cacheFilePath = "./.fake/" + scriptFileName + "_" + scriptHash + ".dll";
+                    var nl = System.Environment.NewLine;
+
+                    File.Exists(cacheFilePath).ShouldEqual(false);
+
+                    RunExplicit(scriptFilePath, arguments, false).ShouldEqual("foobar");
+                    File.Exists(cacheFilePath).ShouldEqual(false);
+
+                    RunExplicit(scriptFilePath, arguments, true).ShouldEqual(
+                        "Cache doesnt exist" + nl + "foobar" + nl + "Saved cache" + nl);
+                    File.Exists(cacheFilePath).ShouldEqual(true);
+
+                    RunExplicit(scriptFilePath, arguments, true).ShouldEqual("Using cache" + nl + "foobar");
+
+                    File.WriteAllText(scriptFilePath, "printf \"foobarbaz\"");
+                    
+                    var changedScriptHash = FSIHelper.getScriptHash(scriptFilePath);
+                    RunExplicit(scriptFilePath, arguments, true).ShouldEqual("Cache is invalid, recompiling" + nl + "foobarbaz" + nl + "Saved cache" + nl);
+                    //File.Exists(cacheFilePath).ShouldEqual(false);
+                    File.Exists("./.fake/" + scriptFileName + "_" + changedScriptHash + ".dll").ShouldEqual(true);
+
+                }
+                finally
+                {
+                    if (File.Exists(scriptFilePath)) File.Delete(scriptFilePath);
+                    //if (Directory.Exists("./.fake")) Directory.Delete("./.fake");
+                }
+            };
+
+        It should_load_file =
+            () => {
+                var mainPath = Path.GetTempFileName() + ".fsx";
+                var loadedPath = Path.GetTempFileName() + ".fsx";
+                try
+                {
+                    var mainScript = "printf \"main\"\n#load \"" + loadedPath.ToString().Replace("\\", "/") + "\"";
+                    var loadedScript = "printf \"loaded;\"";
+                    File.WriteAllText(mainPath, mainScript);
+                    File.WriteAllText(loadedPath, loadedScript);
+
+                    RunExplicit(mainPath, "", false).ShouldEqual("loaded;main");
+                }
+                finally
+                {
+                    File.Delete(mainPath);
+                    File.Delete(loadedPath);
+                }
+                
+            };
+
+        It should_change_hash_when_loaded_file_changes =
+            () =>
+            {
+                var mainPath = (Path.GetTempFileName() + ".fsx").Replace("\\","/");
+                var middle1Path = (Path.GetTempFileName() + ".fsx").Replace("\\","/");
+                var middle2Path = (Path.GetTempFileName() + ".fsx").Replace("\\","/");
+                var lastPath = (Path.GetTempFileName() + ".fsx").Replace("\\","/");
+
+                var lastScript = "printfn \"foobar\"";
+                var middle2Script = "#load @\"" + lastPath + "\"";
+                var middle1Script = "#load \"\"\"" + middle2Path + "\"\"\"";
+                var mainScript = "#load \"" + middle1Path + "\"";
+
+                File.WriteAllText(mainPath, mainScript);
+                File.WriteAllText(middle1Path, middle1Script);
+                File.WriteAllText(middle2Path, middle2Script);
+                File.WriteAllText(lastPath, lastScript);
+
+                var hash = FSIHelper.getScriptHash(mainPath);
+
+                File.WriteAllText(lastPath, "printfn \"foobarbaz\"");
+
+                var newHash = FSIHelper.getScriptHash(mainPath);
+                hash.ShouldNotEqual(newHash);
+            };
+            //() => Run("printfn \"foobar\"\n#load \"C:/Projects/test.fsx\"", "", false).ShouldEqual("foobar");
+
+    }
+
+    //public class when_running_the_fake_cli
+    //{
+    //    static string RunExplicit(string scriptFilePath, string arguments)
+    //    {
+            
+    //        var process = new System.Diagnostics.Process();
+    //        process.StartInfo.FileName = ".\\FAKE.exe";
+    //        process.StartInfo.Arguments = "\"" + scriptFilePath + "\" " + arguments;
+    //        process.StartInfo.UseShellExecute = false;
+    //        process.StartInfo.RedirectStandardOutput = true;
+    //        process.StartInfo.WorkingDirectory = Directory.GetCurrentDirectory();
+    //        process.StartInfo.RedirectStandardError = true;
+    //        process.Start();
+    //        //* Read the output (or the error)
+    //        string output = process.StandardOutput.ReadToEnd();
+    //        Console.WriteLine(output);
+    //        string err = process.StandardError.ReadToEnd();
+    //        //Console.WriteLine(err);
+    //        process.WaitForExit();
+    //        if (process.ExitCode != 0)
+    //        {
+    //            throw new Exception("Process exited with code " + process.ExitCode + ". Error: \n" + err);
+    //        }
+    //        return output;
+    //    }
+
+    //    static string Run(string script, string arguments) {
+    //        var scriptFilePath = Path.GetTempFileName() + ".fsx";
+    //        File.WriteAllText(scriptFilePath, script);
+    //        var result = RunExplicit(scriptFilePath, arguments);
+    //        File.Delete(scriptFilePath);
+    //        return result;
+    //    }
+
+        
+    //    It should_print_foobar =
+    //        () => Run("printfn \"foobar\"", "").ShouldEqual("foobar");
+    //}
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblySpecs.cs" />
+    <Compile Include="FSIHelperSpecs.cs" />
     <Compile Include="CliSpecs.cs" />
     <Compile Include="FileHandling\CopyFileSpecs.cs" />
     <Compile Include="FixProjectFileSpecs.cs" />


### PR DESCRIPTION
Caches the script file to a compiled dll when first run. Uses crc32 to hash the script, prevents using old dll when the script file has changed. Also recursively follows `#load`.

Takes 3312 milliseconds to interpret script without saving cache.
Takes 3326 milliseconds to interpret script and save cache.
Takes 260 milliseconds to run cached dll.

Fixes #646, and makes #645 less needed.