### PR TITLE
Added MSBuild properties to AndroidPackageParams

### DIFF
--- a/help/androidpublisher.md
+++ b/help/androidpublisher.md
@@ -34,6 +34,7 @@ https://developers.google.com/android-publisher/getting_started
                             ProjectPath = "Path to my project Droid.csproj"
                             Configuration = "Release"
                             OutputPath = androidBuildDir
+							Properties = ["MSBuild property", "MSBuild property value"]
                         })
 
         |> AndroidSignAndAlign (fun defaults ->


### PR DESCRIPTION
Additional parameters passed to MSBuild when using AndroidPackage function can be useful e.g. for disabling StyleCop. 