### PR TITLE
Add support for outputting NUnit style test result XML to Fake.Testing.XUnit2

### DIFF
--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -33,6 +33,7 @@ Valid options:
                          : if specified more than once, acts as an AND operation
   -xml <filename>        : output results to xUnit.net v2 style XML file
   -xmlv1 <filename>      : output results to xUnit.net v1 style XML file
+  -nunit <filename>      : output results to NUnit-style XML file
   -html <filename>       : output results to HTML file
 *)
 
@@ -79,6 +80,8 @@ type XUnit2Params =
       XmlOutputPath : string option
       /// The output path of the xUnit XML report (in the xUnit v1 style).
       XmlV1OutputPath : string option
+      /// The output path of the NUnit XML report.
+      NUnitXmlOutputPath : string option
       /// The working directory for running the xunit console runner.
       WorkingDir : string option
       /// Run xUnit with shadow copy enabled.
@@ -126,6 +129,7 @@ let XUnit2Defaults =
       HtmlOutputPath = None
       XmlOutputPath = None
       XmlV1OutputPath = None
+      NUnitXmlOutputPath = None
       IncludeTraits = []
       ExcludeTraits = []
       ShadowCopy = true
@@ -157,6 +161,7 @@ let internal buildXUnit2Args assemblies parameters =
     |> appendIfTrueWithoutQuotes parameters.Silent "-silent"
     |> appendIfSome parameters.XmlOutputPath (sprintf @"-xml ""%s""")
     |> appendIfSome parameters.XmlV1OutputPath (sprintf @"-xmlv1 ""%s""")
+    |> appendIfSome parameters.NUnitXmlOutputPath (sprintf @"-nunit ""%s""")
     |> appendIfSome parameters.HtmlOutputPath (sprintf @"-html ""%s""")
     |> appendTraits parameters.IncludeTraits "-trait"
     |> appendTraits parameters.ExcludeTraits "-notrait"

--- a/src/test/Test.FAKECore/XUnit2Specs.cs
+++ b/src/test/Test.FAKECore/XUnit2Specs.cs
@@ -46,6 +46,7 @@ namespace Test.FAKECore.XUnit2Specs
         {
             Arguments.ShouldNotContain(" -xml");
             Arguments.ShouldNotContain(" -xmlv1");
+            Arguments.ShouldNotContain(" -nunit");
             Arguments.ShouldNotContain(" -html");
         };
 
@@ -83,6 +84,7 @@ namespace Test.FAKECore.XUnit2Specs
                 XUnit2.XUnit2Defaults.HtmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlV1OutputPath,
+                XUnit2.XUnit2Defaults.NUnitXmlOutputPath,
                 XUnit2.XUnit2Defaults.WorkingDir,
                 XUnit2.XUnit2Defaults.ShadowCopy,
                 XUnit2.XUnit2Defaults.Silent,
@@ -117,6 +119,7 @@ namespace Test.FAKECore.XUnit2Specs
                 FSharpOption<string>.Some("html.html"),
                 FSharpOption<string>.Some("xml.xml"),
                 FSharpOption<string>.Some("xmlv1.xml"),
+                FSharpOption<string>.Some("nunit.xml"),
                 XUnit2.XUnit2Defaults.WorkingDir,
                 XUnit2.XUnit2Defaults.ShadowCopy,
                 XUnit2.XUnit2Defaults.Silent,
@@ -137,6 +140,9 @@ namespace Test.FAKECore.XUnit2Specs
 
         It should_include_the_expected_XML_v1_reporting_argument = () =>
             Arguments.ShouldContain(@" -xmlv1 ""xmlv1.xml""");
+
+        It should_include_the_expected_NUnit_XML_reporting_argument = () =>
+            Arguments.ShouldContain(@" -nunit ""nunit.xml""");
     }
 
     internal class When_using_parameters_which_request_total_parallel_execution
@@ -151,6 +157,7 @@ namespace Test.FAKECore.XUnit2Specs
                 XUnit2.XUnit2Defaults.HtmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlV1OutputPath,
+                XUnit2.XUnit2Defaults.NUnitXmlOutputPath,
                 XUnit2.XUnit2Defaults.WorkingDir,
                 XUnit2.XUnit2Defaults.ShadowCopy,
                 XUnit2.XUnit2Defaults.Silent,
@@ -182,6 +189,7 @@ namespace Test.FAKECore.XUnit2Specs
                 XUnit2.XUnit2Defaults.HtmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlV1OutputPath,
+                XUnit2.XUnit2Defaults.NUnitXmlOutputPath,
                 XUnit2.XUnit2Defaults.WorkingDir,
                 XUnit2.XUnit2Defaults.ShadowCopy,
                 XUnit2.XUnit2Defaults.Silent,
@@ -213,6 +221,7 @@ namespace Test.FAKECore.XUnit2Specs
                 XUnit2.XUnit2Defaults.HtmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlV1OutputPath,
+                XUnit2.XUnit2Defaults.NUnitXmlOutputPath,
                 XUnit2.XUnit2Defaults.WorkingDir,
                 XUnit2.XUnit2Defaults.ShadowCopy,
                 XUnit2.XUnit2Defaults.Silent,
@@ -245,6 +254,7 @@ namespace Test.FAKECore.XUnit2Specs
                 XUnit2.XUnit2Defaults.HtmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlOutputPath,
                 XUnit2.XUnit2Defaults.XmlV1OutputPath,
+                XUnit2.XUnit2Defaults.NUnitXmlOutputPath,
                 XUnit2.XUnit2Defaults.WorkingDir,
                 !XUnit2.XUnit2Defaults.ShadowCopy,
                 !XUnit2.XUnit2Defaults.Silent,


### PR DESCRIPTION
The xUnit2 Console runner supports outputting test results in NUnit style XML, but this option is not included in Fake.Testing.XUnit2.

This PR adds in the param ```NUnitXmlOutputPath ``` to ```XUnit2Params```, and works the same way as the other test output params.

This is also similar to Fake.Testing.XUnit, which already has this option:
https://github.com/fsharp/FAKE/blob/master/src/app/FakeLib/UnitTest/XUnit/XUnit.fs#L17