### PR TITLE
Add support for VS2015 VSTest executable

### DIFF
--- a/src/app/FakeLib/UnitTest/VSTest.fs
+++ b/src/app/FakeLib/UnitTest/VSTest.fs
@@ -6,7 +6,8 @@ open System.Text
 
 /// [omit]
 let vsTestPaths = 
-    [|  @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow";
+    [|  @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow";
+        @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow";
         @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow" |]
 
 /// [omit]


### PR DESCRIPTION
Allows using the VS2015 VSTest console executable from the VSTest helper.