### PR TITLE
Loaded dlls versions are used to invalidate cache.

### DIFF
--- a/src/test/Test.FAKECore/FSIHelperSpecs.cs
+++ b/src/test/Test.FAKECore/FSIHelperSpecs.cs
@@ -67,9 +67,9 @@ namespace Test.FAKECore
 
         static string nl = System.Environment.NewLine;
 
-        static Tuple<string, string> sc(string path, string contents)
+        static FSIHelper.Script script(string path, string contents)
         {
-            return new Tuple<string, string>(path.Replace("\\", "/"), contents);
+            return new FSIHelper.Script(contents, path.Replace("\\", "/"), null, null);
         }
 
         It should_use_then_invalidate_cache =
@@ -82,7 +82,7 @@ namespace Test.FAKECore
                 {
                     File.WriteAllText(scriptFilePath, "printf \"foobar\"");
                     var scriptHash =
-                            FSIHelper.getScriptHash(new Tuple<string, string>[] { sc(scriptFilePath, "printf \"foobar\"") });
+                            FSIHelper.getScriptHash(new FSIHelper.Script[] { script(scriptFilePath, "printf \"foobar\"") });
 
                     var cacheFilePath = Path.Combine(".", ".fake", scriptFileName + "_" + scriptHash + ".dll");
 
@@ -105,7 +105,7 @@ namespace Test.FAKECore
 
                     File.WriteAllText(scriptFilePath, "printf \"foobarbaz\"");
 
-                    var changedScriptHash = FSIHelper.getScriptHash(new Tuple<string, string>[] { sc(scriptFilePath, "printf \"foobarbaz\"") });
+                    var changedScriptHash = FSIHelper.getScriptHash(new FSIHelper.Script[] { script(scriptFilePath, "printf \"foobarbaz\"") });
                     RunExplicit(scriptFilePath, arguments, true)
                         .ShouldStartWith("Cache is invalid, recompiling");
 


### PR DESCRIPTION
Fixes #880