### PR TITLE
Nunit Domain Fix per #855

### DIFF
--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -31,7 +31,7 @@ type NUnitDomainModel =
     | MultipleDomainModel with
     member x.ParamString =
         match x with
-        | DefaultDomainModel -> ""
+        | DefaultDomainModel -> "None"
         | SingleDomainModel -> "Single"
         | MultipleDomainModel -> "Multiple"
 
@@ -136,7 +136,7 @@ let NUnitDefaults =
       XsltTransformFile = ""
       TimeOut = TimeSpan.FromMinutes 5.0
       DisableShadowCopy = false
-      Domain = DefaultDomainModel
+      Domain = SingleDomainModel
       ErrorLevel = Error 
       Fixture = ""}
 


### PR DESCRIPTION
As per #855  and https://github.com/fscheck/FsCheck/issues/115 the FsCheck/Mono workaround for this issue is to specify the -domain:None flag to nunit console runner, however FAKE's NunitDomainModel.Default doesn't specify none and as such the nunit console runner defaults to Single.

Aligned Default to specify None as per the Nunit docs
http://www.nunit.org/index.php?p=consoleCommandLine&r=2.5

Changed default to SingleDomainModel since Nunit console runner seems to default to single if no domain is specified.