### PR TITLE
Align NUnitDomainModel with NUnit documentation

### DIFF
--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -23,15 +23,18 @@ type NUnitProcessModel =
         | MultipleProcessModel -> "Multiple"
 /// The /domain option controls of the creation of AppDomains for running tests. See [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
 type NUnitDomainModel = 
-    /// No domain is created - the tests are run in the primary domain. This normally requires copying the NUnit assemblies into the same directory as your tests.
+    /// The default is to use multiple domains if multiple assemblies are listed on the command line. Otherwise a single domain is used.
     | DefaultDomainModel
+    /// No domain is created - the tests are run in the primary domain. This normally requires copying the NUnit assemblies into the same directory as your tests.
+    | NoDomainModel
     /// A test domain is created - this is how NUnit worked prior to version 2.4
     | SingleDomainModel
     /// A separate test domain is created for each assembly
     | MultipleDomainModel with
     member x.ParamString =
         match x with
-        | DefaultDomainModel -> "None"
+        | DefaultDomainModel -> ""
+        | NoDomainModel -> "None"
         | SingleDomainModel -> "Single"
         | MultipleDomainModel -> "Multiple"
 
@@ -136,7 +139,7 @@ let NUnitDefaults =
       XsltTransformFile = ""
       TimeOut = TimeSpan.FromMinutes 5.0
       DisableShadowCopy = false
-      Domain = SingleDomainModel
+      Domain = DefaultDomainModel
       ErrorLevel = Error 
       Fixture = ""}
 

--- a/src/test/Test.FAKECore/NunitCommonSpecs.cs
+++ b/src/test/Test.FAKECore/NunitCommonSpecs.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Fake;
+using FSharp.Testing;
+using Machine.Specifications;
+
+namespace Test.FAKECore.NunitCommonSpecs
+{
+    [Subject(typeof(NUnitCommon), "runner argument construction")]
+    internal abstract class BuildArgumentsSpecsBase
+    {
+        protected static NUnitCommon.NUnitParams Parameters;
+        protected static string[] Assemblies;
+        protected static string Arguments;
+
+        Establish context = () =>
+        {
+            Parameters = NUnitCommon.NUnitDefaults;
+            Assemblies = new[] { "test.dll", "other.dll" };
+        };
+
+        Because of = () =>
+        {
+            Arguments = NUnitCommon.buildNUnitdArgs(Parameters, Assemblies);
+            Console.WriteLine(Arguments);
+        };
+    }
+
+    internal class When_using_the_default_parameters
+        : BuildArgumentsSpecsBase
+    {
+        It should_not_disable_shadow_copy =
+            () => Arguments.ShouldNotContain("-noshadow");
+        It should_not_exclude_category =
+           () => Arguments.ShouldNotContain("-exclude:");
+        It should_not_include_category =
+           () => Arguments.ShouldNotContain("-include:");
+        It should_not_select_app_domain =
+           () => Arguments.ShouldNotContain("-domain:");
+        It should_not_show_logo =
+           () => Arguments.ShouldContain("-nologo");
+        It should_not_specify_error_out_file =
+           () => Arguments.ShouldNotContain("-err:");
+        It should_not_specify_fixture =
+           () => Arguments.ShouldNotContain("-fixture:");
+        It should_not_specify_framework =
+           () => Arguments.ShouldNotContain("-framework:");
+        It should_not_specify_out_file =
+           () => Arguments.ShouldNotContain("-out:");
+        It should_not_specify_process_model =
+           () => Arguments.ShouldNotContain("-process:");
+        It should_not_specify_xslt_transform_file =
+           () => Arguments.ShouldNotContain("-transform:");
+        It should_not_stop_on_error =
+           () => Arguments.ShouldNotContain("-stoponerror");
+        It should_not_test_in_new_thread =
+           () => Arguments.ShouldNotContain("-nothread");
+        It should_show_labels =
+           () => Arguments.ShouldContain("-labels");
+    }
+
+    internal class When_requesting_no_app_domain
+        : BuildArgumentsSpecsBase
+    {
+        Establish context =
+           () => Parameters = Parameters.With(p => p.Domain, NUnitCommon.NUnitDomainModel.NoDomainModel);
+
+        It should_request_no_app_domain =
+            () => Arguments.ShouldContain("-domain:None");
+    }
+
+    internal class When_requesting_single_app_domain
+        : BuildArgumentsSpecsBase
+    {
+        Establish context =
+           () => Parameters = Parameters.With(p => p.Domain, NUnitCommon.NUnitDomainModel.SingleDomainModel);
+
+        It should_request_single_app_domain =
+            () => Arguments.ShouldContain("-domain:Single");
+    }
+
+    internal class When_requesting_multiple_app_domains
+        : BuildArgumentsSpecsBase
+    {
+        Establish context =
+           () => Parameters = Parameters.With(p => p.Domain, NUnitCommon.NUnitDomainModel.MultipleDomainModel);
+
+        It should_request_multiple_app_domains =
+            () => Arguments.ShouldContain("-domain:Multiple");
+    }
+}

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Globbing\TestSample5\AbsoluteDirGlobbingSpecs.cs" />
     <Compile Include="NAVFiles\NAVSplitObjectSpecs.cs" />
     <Compile Include="NAVFiles\NavTestResultSpecs.cs" />
+    <Compile Include="NunitCommonSpecs.cs" />
     <Compile Include="OpenCoverHelperSpecs.cs" />
     <Compile Include="PackageMgt\PackagesConfigSpecs.cs" />
     <Compile Include="SemVerHelperSpecs.cs" />


### PR DESCRIPTION
This PR changes two things:
 - The default value for ```NUnitDomainModel``` is changed from ```SingleDomainModel``` to ```DefaultDomainModel```. In addition ```DefaultDomainModel``` is changed from ```None``` to ```""```, causing the parameter ```-domain``` to be excluded in the call to NUnit. This in effect reverts #883, as it caused regressions in exsiting build scripts (#896) that depends on NUnit selecting the App Domain Model itself, as specified in the documentation (http://www.nunit.org/index.php?p=consoleCommandLine&r=2.5).
 - Added a new value for ```NUnitDomainModel```, ```NoDomainModel```, which adds ```-domain:None``` to the command line. This gives the same effect as the change done in #883, but it's now an opt-in, and not a default value.

In effect:
 - App domain model should by default now be as before #883.
 - It is now possible to specify all of the supported app domain models supported by NUnit:
  - ```NoDomainModel```
  - ```SingleDomainModel```
  - ```MultipleDomainModel```
 - For #855 and fscheck/FsCheck#115, they should now specify ```Domain = NoDomainModel``` to get the intended behavior (```-domain:None```)

Also included tests to verify argument generation for ```NUnitDomainModel```.