### PR TITLE
Added ability to optionally pass in SiteId to configure IIS Site.

### DIFF
--- a/src/app/Fake.IIS/Script.fsx
+++ b/src/app/Fake.IIS/Script.fsx
@@ -10,19 +10,21 @@ let appPool = "fake.appPool"
 let port = ":8081:"
 let vdir = "/fakevdir"
 let appDir = @"C:\Users"
+let path =  @"C:\inetpub\wwwroot"
 
 UnlockSection "system.webServer/security/authentication/anonymousauthentication"
 
+let site = SiteConfig(siteName, port, path, appPool)
 let dotNetFourAppPool = ApplicationPoolConfig(siteName, allow32on64 = true, identity = Administration.ProcessModelIdentityType.LocalSystem)
 let dotNetTwoAppPool = ApplicationPoolConfig(siteName, runtime = "v2.0", allow32on64 = true)
 
 (IIS
-  (Site siteName "http" port @"C:\inetpub\wwwroot" appPool)
+  (Site site)
   (ApplicationPool dotNetFourAppPool)
   (Some(Application vdir appDir)))
 
 (IIS
-  (Site siteName "http" port @"C:\inetpub\wwwroot" appPool)
+  (Site site)
   (ApplicationPool dotNetTwoAppPool)
   (Some(Application "/vdir2" @"C:\temp")))
 


### PR DESCRIPTION
Added ability to optionally pass in SiteId to configure IIS Site. For Issue #844 . 

Continued to clean up method signatures, and took a first pass at allowing defaulting faulting of SiteConfig properties. This would allow a user to implement a class, like the following, and supply defaults for the application or follow standards easier. 

```fsharp
type UserSiteConfig(siteName:string, ?physicalPath:string)  = class
  let defaultPath = Path.Combine("c:\\inetpub\\wwwroot", siteName)
  let defaultPort = 80
  let defaultProtocol = "http"

  interface ISiteConfig with 
    member this.name = siteName
    member this.appPool = siteName
    member this.protocol = defaultProtocol 
    member this.binding = sprintf ":%d:%s" defaultPort siteName
    member this.physicalPath = defaultArg physicalPath defaultPath
    member this.id = None
end
```

Willing to continue to collaborate on pushing this module forward. Would love to get some unit tests wrapped around the current functionality to help test drive out future functionality. 