### PR TITLE
Fixed WatchChanges not properly removing subdirectories from watch list

### DIFF
--- a/src/app/FakeLib/ChangeWatcher.fs
+++ b/src/app/FakeLib/ChangeWatcher.fs
@@ -45,7 +45,7 @@ let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileInclude
     let dirsToWatch = 
         dirsToWatch |> Seq.filter (fun d -> 
                            dirsToWatch
-                           |> Seq.exists (fun p -> p.StartsWith d && p <> d)
+                           |> Seq.exists (fun p -> d.StartsWith p && p <> d)
                            |> not)
     tracefn "dirs to watch: %A" dirsToWatch
  

--- a/src/app/FakeLib/ChangeWatcher.fs
+++ b/src/app/FakeLib/ChangeWatcher.fs
@@ -19,6 +19,17 @@ let private handleWatcherEvents (status : FileStatus) (onChange : FileChange -> 
                 Name = e.Name
                 Status = status })
 
+let private calcDirsToWatch fileIncludes =
+    let dirsToWatch = fileIncludes.Includes |> Seq.map (fun file -> Globbing.getRoot fileIncludes.BaseDirectory file)
+    
+    // remove subdirectories from watch list so that we don't get duplicate file watchers running
+    dirsToWatch 
+    |> Seq.filter (fun d -> 
+                    dirsToWatch
+                    |> Seq.exists (fun p -> d.StartsWith p && p <> d)
+                    |> not)
+    |> Seq.toList
+
 /// Watches the for changes in the matching files.
 /// Returns an IDisposable which allows to dispose all FileSystemWatchers.
 ///
@@ -39,14 +50,8 @@ let private handleWatcherEvents (status : FileStatus) (onChange : FileChange -> 
 ///     )
 ///
 let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileIncludes) = 
-    let dirsToWatch = fileIncludes.Includes |> Seq.map (fun file -> Globbing.getRoot fileIncludes.BaseDirectory file)
-    
-    // remove subdirectories from watch list so that we don't get duplicate file watchers running
-    let dirsToWatch = 
-        dirsToWatch |> Seq.filter (fun d -> 
-                           dirsToWatch
-                           |> Seq.exists (fun p -> d.StartsWith p && p <> d)
-                           |> not)
+    let dirsToWatch = fileIncludes |> calcDirsToWatch
+
     tracefn "dirs to watch: %A" dirsToWatch
  
     // we collect changes in a mutable ref cell and wait for a few milliseconds to 
@@ -84,7 +89,7 @@ let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : FileInclude
               (timer:System.Timers.Timer).Start() )
     
     let watchers = 
-        dirsToWatch |> List.ofSeq |> List.map (fun dir -> 
+        dirsToWatch |> List.map (fun dir -> 
                            tracefn "watching dir: %s" dir
 
                            let watcher = new FileSystemWatcher(FullName dir, "*.*")

--- a/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
+++ b/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
@@ -1,0 +1,34 @@
+﻿using Fake;
+using Machine.Specifications;
+using Microsoft.FSharp.Collections;
+
+namespace Test.FAKECore
+{
+    public class when_calculating_directories_to_watch
+    {
+        It should_watch_multiple_directories =
+            () =>
+            {
+                var includes = ListModule.OfArray(new[] { @"test1\bin\*.dll", @"test2\bin\*.dll", });
+                var fileIncludes = new FileSystem.FileIncludes(@"C:\Project", includes, ListModule.Empty<string>());
+
+                var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
+
+                dirsToWatch.Length.ShouldEqual(2);
+                dirsToWatch.ShouldContain(@"C:\Project\test1\bin");
+                dirsToWatch.ShouldContain(@"C:\Project\test2\bin");
+            };
+
+        It should_only_take_the_most_root_path_when_multiple_directories_share_a_root =
+            () =>
+            {
+                var includes = ListModule.OfArray(new[] { @"tests\**\test1\bin\*.dll", @"tests\test2\bin\*.dll", });
+                var fileIncludes = new FileSystem.FileIncludes(@"C:\Project", includes, ListModule.Empty<string>());
+
+                var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
+
+                dirsToWatch.Length.ShouldEqual(1);
+                dirsToWatch.ShouldContain(@"C:\Project\tests");
+            };
+    }
+}

--- a/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
+++ b/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
@@ -1,4 +1,5 @@
-﻿using Fake;
+﻿using System.Linq;
+using Fake;
 using Machine.Specifications;
 using Microsoft.FSharp.Collections;
 
@@ -15,8 +16,8 @@ namespace Test.FAKECore
                 var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
 
                 dirsToWatch.Length.ShouldEqual(2);
-                dirsToWatch.ShouldContain(@"C:\Project\test1\bin");
-                dirsToWatch.ShouldContain(@"C:\Project\test2\bin");
+                dirsToWatch.ShouldContain(Fake.Globbing.normalizePath(@"C:\Project\test1\bin"));
+                dirsToWatch.ShouldContain(Fake.Globbing.normalizePath(@"C:\Project\test2\bin"));
             };
 
         It should_only_take_the_most_root_path_when_multiple_directories_share_a_root =
@@ -28,7 +29,7 @@ namespace Test.FAKECore
                 var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
 
                 dirsToWatch.Length.ShouldEqual(1);
-                dirsToWatch.ShouldContain(@"C:\Project\tests");
+                dirsToWatch.ShouldContain(Fake.Globbing.normalizePath(@"C:\Project\tests"));
             };
     }
 }

--- a/src/test/Test.FAKECore/Test.FAKECore.csproj
+++ b/src/test/Test.FAKECore/Test.FAKECore.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblySpecs.cs" />
+    <Compile Include="ChangeWatcherSpecs.cs" />
     <Compile Include="FSIHelperSpecs.cs" />
     <Compile Include="CliSpecs.cs" />
     <Compile Include="FileHandling\CopyFileSpecs.cs" />


### PR DESCRIPTION
In the scenario where `WatchChanges` is used with multiple includes, if one include is a subdirectory of another, WatchChanges will not watch the correct directory.

For example:
```fsharp
use watcher = 
    !! "parent/*.*" ++ "parent/child/*.*"
    |> WatchChanges (fun changes ->
        tracefn "%A" changes)
```
`/parent/child` will be watched (incorrectly), instead of `/parent`.

This PR fixes this issue and refactors the code a little in order to implement a couple of tests to ensure the correct behaviour when eliminating subdirectories from the watch list.