### PR TITLE
Add support for builds within Team Foundation Server (and VSO).

### DIFF
--- a/src/app/FakeLib/BuildServerHelper.fs
+++ b/src/app/FakeLib/BuildServerHelper.fs
@@ -4,6 +4,7 @@ module Fake.BuildServerHelper
 
 /// The server type option.
 type BuildServer = 
+    | TeamFoundation
     | TeamCity
     | CCNet
     | Jenkins
@@ -28,6 +29,16 @@ let localBuildLabel = "LocalBuild"
 /// Defines the XML output file - used for build servers like CruiseControl.NET.
 /// This output file can be specified by using the *logfile* build parameter.
 let mutable xmlOutputFile = getBuildParamOrDefault "logfile" "./output/Results.xml"
+
+/// Checks if we are on Team Foundation
+/// [omit]
+let isTFBuild =
+    let tfbuild = environVar "TF_BUILD"
+    tfbuild <> null && tfbuild.ToLowerInvariant() = "true"
+
+/// Build number retrieved from Team Foundation
+/// [omit]
+let tfBuildNumber = environVar "BUILD_BUILDNUMBER"
 
 /// Build number retrieved from TeamCity
 /// [omit]
@@ -65,6 +76,7 @@ let buildServer =
     elif not (isNullOrEmpty travisBuildNumber) then Travis
     elif not (isNullOrEmpty appVeyorBuildVersion) then AppVeyor
     elif isGitlabCI then GitLabCI
+    elif isTFBuild then TeamFoundation
     else LocalBuild
 
 /// The current build version as detected from the current build server.
@@ -77,6 +89,7 @@ let buildVersion =
     | Travis -> getVersion travisBuildNumber
     | AppVeyor -> getVersion appVeyorBuildVersion
     | GitLabCI -> getVersion gitlabCIBuildNumber
+    | TeamFoundation -> getVersion tfBuildNumber
     | LocalBuild -> getVersion localBuildLabel
 
 /// Is true when the current build is a local build.

--- a/src/app/FakeLib/Git/Information.fs
+++ b/src/app/FakeLib/Git/Information.fs
@@ -23,7 +23,10 @@ let isGitVersionHigherOrEqual referenceVersion =
     isVersionHigherOrEqual versionParts referenceVersion
 
 /// Gets the git branch name
-let getBranchName repositoryDir = 
+let getBranchName repositoryDir =
+    if (repositoryDir = "" || repositoryDir = ".") && buildServer = TeamFoundation then
+        environVar "BUILD_SOURCEBRANCHNAME"
+    else
     let ok,msg,errors = runGitCommand repositoryDir "status"
     let s = msg |> Seq.head 
 
@@ -37,7 +40,10 @@ let getBranchName repositoryDir =
     if startsWith replaceNoBranchString s then noBranch else s.Replace(replaceBranchString,"")
 
 /// Returns the SHA1 of the current HEAD
-let getCurrentSHA1 repositoryDir = getSHA1 repositoryDir "HEAD"
+let getCurrentSHA1 repositoryDir =
+    if (repositoryDir = "" || repositoryDir = ".") && buildServer = TeamFoundation then
+        environVar "BUILD_SOURCEVERSION"
+    else getSHA1 repositoryDir "HEAD"
 
 /// Shows the git status
 let showStatus repositoryDir = showGitCommand repositoryDir "status"
@@ -74,8 +80,11 @@ let getLastTag() = (describe "").Split('-') |> Seq.head
 
 /// Gets the current hash of the current repository
 let getCurrentHash() =
-    let tmp =
-        (shortlog "").Split(' ') 
-          |> Seq.head
-          |> fun s -> s.Split('m')
-    if tmp |> Array.length > 2 then tmp.[1].Substring(0,6) else tmp.[0].Substring(0,6)
+    if buildServer = TeamFoundation then
+        environVar "BUILD_SOURCEVERSION"
+    else
+        let tmp =
+            (shortlog "").Split(' ')
+            |> Seq.head
+            |> fun s -> s.Split('m')
+        if tmp |> Array.length > 2 then tmp.[1].Substring(0,6) else tmp.[0].Substring(0,6)


### PR DESCRIPTION
The `BuildServerHelper.fs` changes are simply the build server detection.

The changes in the `Information.fs` should probably be discussed:
The problem is that TF creates a copy of the repository without the `.git` folder. Therefore we cannot use any `git` commands. I tried to use the information provided by TF to fill some gaps.

Maybe some kind of fallback behavior would be more robust? But first I want to here your opinion on this "kind of magic" first.