### PR TITLE
Add date to ReleaseNotes type definition

### DIFF
--- a/src/app/FakeLib/ReleaseNotesHelper.fs
+++ b/src/app/FakeLib/ReleaseNotesHelper.fs
@@ -75,7 +75,7 @@ let parseVersions =
         assemblyVersion, nugetVersion
 
 let parseDate =
-    let dateRegex = getRegEx @"(19|20)\d\d([- /.])(0[1-9]|1[012])\2(0[1-9]|[12][0-9]|3[01])"
+    let dateRegex = getRegEx @"(19|20)\d\d([- /.])(0[1-9]|1[012]|[1-9])\2(0[1-9]|[12][0-9]|3[01]|[1-9])"
     fun line ->
         let possibleDate = dateRegex.Match line
         match possibleDate.Success with

--- a/src/app/FakeLib/ReleaseNotesHelper.fs
+++ b/src/app/FakeLib/ReleaseNotesHelper.fs
@@ -49,14 +49,17 @@ type ReleaseNotes =
       NugetVersion: string
       /// Semantic version
       SemVer: SemVerHelper.SemVerInfo
+      /// Release date
+      Date : DateTime option
       // The parsed release notes.
       Notes: string list }
     override x.ToString() = sprintf "%A" x
 
-    static member New(assemblyVersion,nugetVersion,notes) = { 
+    static member New(assemblyVersion,nugetVersion,date,notes) = { 
         AssemblyVersion = assemblyVersion
         NugetVersion = nugetVersion
         SemVer = SemVerHelper.parse nugetVersion
+        Date = date
         Notes = notes }
 
 let parseVersions =
@@ -71,6 +74,17 @@ let parseVersions =
         then failwithf "Unable to parse valid NuGet version from release notes (%s)." line
         assemblyVersion, nugetVersion
 
+let parseDate =
+    let dateRegex = getRegEx @"(19|20)\d\d([- /.])(0[1-9]|1[012])\2(0[1-9]|[12][0-9]|3[01])"
+    fun line ->
+        let possibleDate = dateRegex.Match line
+        match possibleDate.Success with
+        | false -> None
+        | true ->
+            match DateTime.TryParse possibleDate.Value with
+            | false, _ -> None
+            | true, x -> Some(x)
+
 /// Parse simple release notes sequence
 let private parseSimpleReleaseNotes line =
     let assemblyVersion, nugetVersion = parseVersions line
@@ -83,7 +97,7 @@ let private parseSimpleReleaseNotes line =
         |> List.map (trimDot >> trim)
         |> List.filter isNotNullOrEmpty
         |> List.map (fun x -> x + ".")
-    ReleaseNotes.New(assemblyVersion.Value, nugetVersion.Value, notes)
+    ReleaseNotes.New(assemblyVersion.Value, nugetVersion.Value, None, notes)
 
 /// Parse "complex" release notes text sequence
 let private parseAllComplexReleaseNotes (text: seq<string>) =
@@ -102,7 +116,8 @@ let private parseAllComplexReleaseNotes (text: seq<string>) =
         match findNextNotesBlock text with
         | Some(header,(notes, rest)) ->
             let assemblyVer, nugetVer = parseVersions header
-            let newReleaseNotes = ReleaseNotes.New(assemblyVer.Value,nugetVer.Value,notes |> List.filter isNotNullOrEmpty |> List.rev)
+            let date = parseDate header
+            let newReleaseNotes = ReleaseNotes.New(assemblyVer.Value,nugetVer.Value,date,notes |> List.filter isNotNullOrEmpty |> List.rev)
             loop (newReleaseNotes::releaseNotes) rest
         | None -> releaseNotes
 

--- a/src/test/Test.FAKECore/ReleaseNotesSpecs.cs
+++ b/src/test/Test.FAKECore/ReleaseNotesSpecs.cs
@@ -37,6 +37,7 @@ namespace Test.FAKECore
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected = ReleaseNotesHelper.ReleaseNotes.New("1.1.10",
             "1.1.10",
+            new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 09, 12)),
             new[]
             {
                 "Support for heterogeneous XML attributes.",
@@ -52,20 +53,20 @@ namespace Test.FAKECore
 
         It should_parse_empty_notes =
             () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(@"### New in 1.1.10 (Released 2013/09/12)"))
-                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", FSharpList<string>.Empty));
+                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 09, 12)), FSharpList<string>.Empty));
 
         It should_parse_simple_format =
             () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(@"
 * 1.1.9 - Infer booleans for ints that only manifest 0 and 1. Support for partially overriding the Schema in CsvProvider.
 * 1.1.10 - Support for heterogeneous XML attributes. Make CsvFile re-entrant."))
-                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10",
+                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", null,
                     new[] {"Support for heterogeneous XML attributes.", "Make CsvFile re-entrant."}.ToFSharpList()));
 
 
         It should_parse_simple_format_with_dots =
             () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(@"
 * 1.2.0 - Allow currency symbols on decimals. Remove .AsTuple member from CsvProvider. CsvProvider now uses GetSample instead of constructor like the other providers."))
-                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.2.0", "1.2.0",
+                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.2.0", "1.2.0", null,
                     new[]
                     {
                         "Allow currency symbols on decimals.", "Remove .AsTuple member from CsvProvider.",
@@ -98,7 +99,7 @@ namespace Test.FAKECore
 #### 2.0.0-alpha001 - December 15 2013
 * A";
         static readonly ReleaseNotesHelper.ReleaseNotes expected =
-            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-alpha2", new[] { "B" }.ToFSharpList());
+            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-alpha2", null, new[] { "B" }.ToFSharpList());
 
         It should_parse =
            () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(input)).ShouldEqual(expected);
@@ -131,7 +132,7 @@ namespace Test.FAKECore
 #### 2.0.0-alpha001 - December 15 2013
 * A";
         static readonly ReleaseNotesHelper.ReleaseNotes expected =
-            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-rc007", new[] { "A" }.ToFSharpList());
+            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-rc007", null, new[] { "A" }.ToFSharpList());
 
         It should_parse =
            () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(input)).ShouldEqual(expected);
@@ -159,6 +160,7 @@ namespace Test.FAKECore
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected = ReleaseNotesHelper.ReleaseNotes.New("1.1.10",
             "1.1.10",
+            new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 09, 12)),
             new[]
             {
                 "Support for heterogeneous XML attributes.",
@@ -174,13 +176,13 @@ namespace Test.FAKECore
 
         It should_parse_empty_notes =
             () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(@"### New in 1.1.10 (Released 2013/09/12)"))
-                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", FSharpList<string>.Empty));
+                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 09, 12)), FSharpList<string>.Empty));
 
         It should_parse_simple_format =
             () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(@"
 * 1.1.10 - Support for heterogeneous XML attributes. Make CsvFile re-entrant.
 * 1.0.9 - Infer booleans for ints that only manifest 0 and 1. Support for partially overriding the Schema in CsvProvider."))
-                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10",
+                .ShouldEqual(ReleaseNotesHelper.ReleaseNotes.New("1.1.10", "1.1.10", null,
                     new[] {"Support for heterogeneous XML attributes.", "Make CsvFile re-entrant."}.ToFSharpList()));
 
         It should_throws_on_empty_seq_input =
@@ -215,6 +217,7 @@ namespace Test.FAKECore
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected = ReleaseNotesHelper.ReleaseNotes.New("1.1.10",
             "1.1.10",
+            new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 09, 12)),
             new[]
             {
                 "Support for heterogeneous XML attributes.",
@@ -226,6 +229,7 @@ namespace Test.FAKECore
                 .ToFSharpList());
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected2 = ReleaseNotesHelper.ReleaseNotes.New("1.1.9", "1.1.9",
+            new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 07, 21)),
             new[] {"Infer booleans for ints that only manifest 0 and 1."}
                 .ToFSharpList());
 
@@ -249,6 +253,7 @@ namespace Test.FAKECore
 
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected = ReleaseNotesHelper.ReleaseNotes.New("0.1.3", "0.1.3",
+            new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 11, 5)),
             new[]
             {
                 "New Xamarin Component store versions of Octokit.net",
@@ -275,6 +280,7 @@ namespace Test.FAKECore
 
 
         static readonly ReleaseNotesHelper.ReleaseNotes expected = ReleaseNotesHelper.ReleaseNotes.New("1.8.0", "1.8.0",
+            null,
             new[]
             {
                 "When the subject's constructor throws an exception, it is now bubbled up and shown in the failure message.",
@@ -303,6 +309,7 @@ namespace Test.FAKECore
         static readonly ReleaseNotesHelper.ReleaseNotes expected =
             ReleaseNotesHelper.ReleaseNotes.New("1.0.0",
                 "1.0.0-rc.1",
+                new Microsoft.FSharp.Core.FSharpOption<DateTime>(new DateTime(2013, 10, 30)),
                 new[]
                 {
                     "Initial release"
@@ -312,6 +319,7 @@ namespace Test.FAKECore
         static readonly ReleaseNotesHelper.ReleaseNotes expected2 =
             ReleaseNotesHelper.ReleaseNotes.New("1.0.0",
                 "1.0.0-beta.2",
+                null,
                 new[]
                 {
                     "Fixed problems with Microsoft.Threading.Tasks"


### PR DESCRIPTION
Adds a new "Date" field as a `DateTime option` to the `ReleaseNotes` record type, and performs simple parsing of dates from the complex release notes format. The regex I used finds dates in the format of `YYYY-MM-DD`, with the option to use any of `- /.` as the separators, but I pass the matched result to `DateTime.TryParse`. Should be able to change the regex (or add additional regexes) to match other date formats, but really, who doesn't use ISO-8601? :wink: