### PR TITLE
Add "or a package name" to NuGet install doc

### DIFF
--- a/src/app/FakeLib/NuGet/Install.fs
+++ b/src/app/FakeLib/NuGet/Install.fs
@@ -77,7 +77,7 @@ let buildArgs (param: NugetInstallParams) =
 /// ## Parameters
 ///
 ///  - `setParams` - Function used to manipulate the default parameters.
-///  - `packagesFile` - Path to the `*.sln`, `*.*proj` or `packages.config` file.
+///  - `packagesFile` - Path to the `*.sln`, `*.*proj` or `packages.config` file, or simply a NuGet package name
 let NugetInstall setParams packageName =
     traceStartTask "NugetInstall" packageName
     let param = NugetInstallDefaults |> setParams


### PR DESCRIPTION
I tested this: while `NugetInstall` does work with a `packages.config`,
it also just works with a package name, e.g. `NUnit.Runners`; in fact,
despite the fact that the documentation calls the parameter `packageFiles`,
it is called `packageName` in the code.

However, I haven't been able to regenerate the documentation yet to
confirm that I understand how the documentation works, because I'm on
Linux. I'll have to try on Windows, unless someone more knowledgeable
can just confirm that this will update the API docs.