### PR TITLE
Soft dependencies

### DIFF
--- a/help/soft-dependencies.md
+++ b/help/soft-dependencies.md
@@ -10,8 +10,8 @@ say that target B has a soft dependency on target A:
     // Or equivalently
     "B" <=? "A"
 
-With this soft dependency, running B will not force A to run, but it means that A must run before B *if* A will be 
-run during the build (due to other dependencies).
+With this soft dependency, running B will not require that A be run first. However it does mean that *if* A is run 
+(due to other dependencies) it must be run before B.
 
 ## Example
 

--- a/help/soft-dependencies.md
+++ b/help/soft-dependencies.md
@@ -1,0 +1,34 @@
+# Soft dependencies
+
+Typically you will define dependencies among your targets using the `==>` and `<==` operators, and these 
+dependencies define the order in which the targets are executed during a build.
+
+You can also define soft dependencies among targets using the  `?=>` and `<=?` operators.  For example, you might
+say that target B has a soft dependency on target A: 
+    
+    "A" ?=> "B"
+    // Or equivalently
+    "B" <=? "A"
+
+With this soft dependency, running B will not force A to run, but it means that A must run before B *if* A will be 
+run during the build (due to other dependencies).
+
+## Example
+
+	// *** Define Targets ***
+	Target "Clean" (fun () -> 
+		trace " --- Cleaning stuff --- "
+	)
+
+	Target "Build" (fun () -> 
+		trace " --- Building the app --- "
+	)
+
+	Target "Rebuild" DoNothing
+
+	// *** Define Dependencies ***
+	"Build" => "Rebuild"
+	"Clean" => "Rebuild"
+	// Make sure "Clean" happens before "Build", if "Clean" is is executed during a build.
+	"Clean" ?=> "Build"
+   

--- a/src/app/FakeLib/AdditionalSyntax.fs
+++ b/src/app/FakeLib/AdditionalSyntax.fs
@@ -48,12 +48,31 @@ let rec addDependenciesOnSameLevel target dependency =
         Dependencies target [x]
     | _  -> ()
 
+/// Specifies that two targets have the same dependencies
+let rec addSoftDependenciesOnSameLevel target dependency =
+    match sameLevels.TryGetValue dependency with
+    | true, x -> 
+        addSoftDependenciesOnSameLevel target x
+        SoftDependencies target [x]
+    | _  -> ()
+
+
 /// Defines a dependency - y is dependent on x
 let inline (==>) x y =
     addDependenciesOnSameLevel y x 
     Dependencies y [x]
-
     y
+
+
+/// Defines a soft dependency. x must run before y, if it is present, but y does not require x to be run.
+let inline (?=>) x y = 
+   addSoftDependenciesOnSameLevel y x 
+   SoftDependencies y [x]
+   y
+
+/// Defines a soft dependency. x must run before y, if it is present, but y does not require x to be run.
+let inline (<=?) y x = x ?=> y
+
 
 /// Defines that x and y are not dependent on each other but y is dependent on all dependencies of x.
 let inline (<=>) x y =   

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -13,11 +13,16 @@ type TargetDescription = string
 type 'a TargetTemplate =
     { Name: string;
       Dependencies: string list;
+      SoftDependencies: string list;
       Description: TargetDescription;
       Function : 'a -> unit}
-   
+  
 /// A Target can be run during the build
 type Target = unit TargetTemplate
+
+type private DependencyType = 
+    | Hard = 1
+    | Soft = 2
 
 /// [omit]
 let mutable PrintStackTraceOnError = false
@@ -78,18 +83,26 @@ let dependencyString target =
       |> Seq.map (fun d -> (getTarget d).Name)
       |> separated ", "
       |> sprintf "(==> %s)"
+
+/// Returns the soft  DependencyString for the given target.
+let softDependencyString target =
+    if target.SoftDependencies.IsEmpty then String.Empty else
+    target.SoftDependencies
+      |> Seq.map (fun d -> (getTarget d).Name)
+      |> separated ", "
+      |> sprintf "(?=> %s)"
     
 /// Do nothing - fun () -> () - Can be used to define empty targets.
 let DoNothing = (fun () -> ())
 
-/// Checks whether the dependency can be added.
+/// Checks whether the dependency (soft or normal) can be added.
 /// [omit]
-let checkIfDependencyCanBeAdded targetName dependentTargetName =
+let checkIfDependencyCanBeAddedCore fGetDependencies targetName dependentTargetName =
     let target = getTarget targetName
     let dependentTarget = getTarget dependentTargetName
 
     let rec checkDependencies dependentTarget =
-        dependentTarget.Dependencies 
+          fGetDependencies dependentTarget
           |> List.iter (fun dep ->
                if toLower dep = toLower targetName then 
                   failwithf "Cyclic dependency between %s and %s" targetName dependentTarget.Name
@@ -97,6 +110,16 @@ let checkIfDependencyCanBeAdded targetName dependentTargetName =
       
     checkDependencies dependentTarget
     target,dependentTarget
+
+/// Checks whether the dependency can be added.
+/// [omit]
+let checkIfDependencyCanBeAdded targetName dependentTargetName =
+   checkIfDependencyCanBeAddedCore (fun target -> target.Dependencies) targetName dependentTargetName
+
+/// Checks whether the soft dependency can be added.
+/// [omit]
+let checkIfSoftDependencyCanBeAdded targetName dependentTargetName =
+   checkIfDependencyCanBeAddedCore (fun target -> target.SoftDependencies) targetName dependentTargetName
 
 /// Adds the dependency to the front of the list of dependencies.
 /// [omit]
@@ -112,13 +135,29 @@ let dependencyAtEnd targetName dependentTargetName =
     
     TargetDict.[toLower targetName] <- { target with Dependencies = target.Dependencies @ [dependentTargetName] }
 
+
+/// Appends the dependency to the list of soft dependencies.
+/// [omit]
+let softDependencyAtEnd targetName dependentTargetName =
+    let target,dependentTarget = checkIfDependencyCanBeAdded targetName dependentTargetName
+    
+    TargetDict.[toLower targetName] <- { target with SoftDependencies = target.SoftDependencies @ [dependentTargetName] }
+
 /// Adds the dependency to the list of dependencies.
 /// [omit]
 let dependency targetName dependentTargetName = dependencyAtEnd targetName dependentTargetName
+
+/// Adds the dependency to the list of soft dependencies.
+/// [omit]
+let softDependency targetName dependentTargetName = softDependencyAtEnd targetName dependentTargetName
   
 /// Adds the dependencies to the list of dependencies.
 /// [omit]
 let Dependencies targetName dependentTargetNames = dependentTargetNames |> List.iter (dependency targetName)
+
+/// Adds the dependencies to the list of soft dependencies.
+/// [omit]
+let SoftDependencies targetName dependentTargetNames = dependentTargetNames |> List.iter (softDependency targetName)
 
 /// Backwards dependencies operator - x is dependent on ys.
 let inline (<==) x ys = Dependencies x ys
@@ -151,6 +190,7 @@ let targetFromTemplate template name parameters =
     TargetDict.Add(toLower name,
       { Name = name; 
         Dependencies = [];
+        SoftDependencies = [];
         Description = template.Description;
         Function = fun () ->
           // Don't run function now
@@ -202,6 +242,7 @@ let TargetTemplateWithDependencies dependencies body name parameters =
     let template = 
         { Name = String.Empty
           Dependencies = dependencies
+          SoftDependencies = []
           Description = LastDescription
           Function = body }
     targetFromTemplate template name parameters
@@ -288,30 +329,63 @@ let PrintTargets() =
     log "The following targets are available:"
     for t in TargetDict.Values do
         logfn "   %s%s" t.Name (if isNullOrEmpty t.Description then "" else sprintf " - %s" t.Description)
+ 
+
+// Maps the specified dependency type into the list of targets
+let private withDependencyType (depType:DependencyType) targets =
+    targets |> List.map (fun t -> depType, t)
+
+// Helper function for visiting targets in a dependency tree 
+let private visitDependencies fVisit targetName = 
+    let visit fGetDependencies fVisit targetName = 
+        let visited = new HashSet<_>()
+        let ordered = new List<_>()
+        let rec visitDependenciesAux level (depType,targetName) = 
+            let target = TargetDict.[toLower targetName]
+            let isVisited = visited.Contains targetName
+            visited.Add targetName |> ignore
+            fVisit (target, depType, level, isVisited)
+            (fGetDependencies target) |> Seq.iter (visitDependenciesAux (level + 1))
+            if not isVisited then ordered.Add targetName 
+        visitDependenciesAux 0 (DependencyType.Hard, targetName)
+        visited, ordered 
+    
+    // First pass is to accumulate targets in (hard) dependency graph 
+    let visited, _ = visit (fun t -> t.Dependencies |> withDependencyType DependencyType.Hard) (fun _ -> ()) targetName
+ 
+    let getDependencies (t: TargetTemplate<unit>) = 
+        if visited.Contains t.Name then
+            (t.Dependencies |> withDependencyType DependencyType.Hard) @ 
+            (t.SoftDependencies |> List.filter visited.Contains |> withDependencyType DependencyType.Soft)
+        else 
+            t.Dependencies |> withDependencyType DependencyType.Hard 
+
+    // Now make second pass, adding in soft depencencies if approrpriate
+    visit getDependencies fVisit targetName
+    
               
 /// <summary>Writes a dependency graph.</summary>
 /// <param name="verbose">Whether to print verbose output or not.</param>
 /// <param name="target">The target for which the dependencies should be printed.</param>
-let PrintDependencyGraph verbose target =
+let PrintDependencyGraph verbose target = 
     match TargetDict.TryGetValue (toLower target) with
     | false,_ -> PrintTargets()
     | true,target ->
         logfn "%sDependencyGraph for Target %s:" (if verbose then String.Empty else "Shortened ") target.Name
-        let printed = new HashSet<_>()
-        let order = new List<_>()
-        let rec printDependencies indent act =
-            let target = TargetDict.[toLower act]
-            let addToOrder = not (printed.Contains (toLower act))
-            printed.Add (toLower act) |> ignore
-    
-            if addToOrder || verbose then log <| sprintf "%s<== %s" (String(' ', indent * 3)) act
-            Seq.iter (printDependencies (indent+1)) target.Dependencies
-            if addToOrder then order.Add act
+
+        let logDependency ((t: TargetTemplate<unit>), depType, level, isVisited) =
+            if verbose ||  not isVisited then
+                let indent = (String(' ', level * 3))
+                if depType = DependencyType.Soft then
+                    log <| sprintf "%s<=? %s" indent t.Name
+                else
+                    log <| sprintf "%s<== %s" indent t.Name
+
+        let _, ordered = visitDependencies logDependency target.Name
         
-        printDependencies 0 target.Name
         log ""
         log "The resulting target order is:"
-        Seq.iter (logfn " - %s") order
+        Seq.iter (logfn " - %s") ordered
 
 /// Writes a summary of errors reported during build.
 let WriteErrors () =
@@ -352,7 +426,7 @@ let WriteTaskTimeSummary total =
     traceLine()
 
 let private changeExitCodeIfErrorOccured() = if errors <> [] then exit 42 
-
+   
 /// [omit]
 let isListMode = hasBuildParam "list"
 
@@ -367,34 +441,30 @@ let listTargets() =
 // Instead of the target can be used the list dependencies graph parameter.
 let doesTargetMeanListTargets target = target = "--listTargets"  || target = "-lt"
 
+
 /// Determines a parallel build order for the given set of targets
 let determineBuildOrder (target : string) =
     
     let t = getTarget target
 
-    // determines the maximal level at which a target occurs
-    let rec determineLevels (currentLevel : int) (levels : Map<string, int>) (t : seq<TargetTemplate<unit>>) =
-        let levels = 
-            t |> Seq.fold (fun m t -> 
-                match Map.tryFind t.Name m with
-                    | Some mapLevel when mapLevel >= currentLevel -> m
-                    | _ -> Map.add t.Name currentLevel m
-            ) levels
-            
-        t |> Seq.map (fun t -> t.Dependencies |> Seq.map getTarget) 
-          |> Seq.fold (determineLevels (currentLevel + 1)) levels
+    let targetLevels = new Dictionary<_,_>()
+    let addTargetLevel ((target: TargetTemplate<unit>), _, level, _ ) =
+        match targetLevels.TryGetValue target.Name with
+        | true, mapLevel when mapLevel >= level -> ()
+        | _ -> targetLevels.[target.Name] <- level
 
-    let levels = determineLevels 0 Map.empty [t]
+    let visited, ordered = visitDependencies addTargetLevel target
 
     // the results are grouped by their level, sorted descending (by level) and 
     // finally grouped together in a list<TargetTemplate<unit>[]>
     let result = 
-        levels |> Map.toSeq
-               |> Seq.groupBy snd
-               |> Seq.sortBy (fun (l,_) -> -l)
-               |> Seq.map snd
-               |> Seq.map (fun v -> v |> Seq.map fst |> Seq.distinct |> Seq.map getTarget |> Seq.toArray)
-               |> Seq.toList
+        targetLevels 
+        |> Seq.map (fun pair -> pair.Key, pair.Value)
+        |> Seq.groupBy snd
+        |> Seq.sortBy (fun (l,_) -> -l)
+        |> Seq.map snd
+        |> Seq.map (fun v -> v |> Seq.map fst |> Seq.distinct |> Seq.map getTarget |> Seq.toArray)
+        |> Seq.toList
 
     // Note that this build order cannot be considered "optimal" 
     // since it may introduce order where actually no dependencies
@@ -428,39 +498,38 @@ let run targetName =
     if doesTargetMeanListTargets targetName then listTargets() else
     if LastDescription <> null then failwithf "You set a task description (%A) but didn't specify a task." LastDescription
 
-    let rec runTarget targetName =
-        if errors = [] && ExecutedTargets.Contains (toLower targetName) |> not then
-            let target = getTarget targetName      
-      
-            if hasBuildParam "single-target" then
-                traceImportant "Single target mode ==> Skipping dependencies."
-            else
-                List.iter runTarget target.Dependencies
-      
-            runSingleTarget target            
-
+    let rec runTargets (targets: TargetTemplate<unit> array) =
+        let lastTarget = targets |> Array.last
+        if errors = [] && ExecutedTargets.Contains (lastTarget.Name) |> not then
+           let firstTarget = targets |> Array.head
+           if hasBuildParam "single-target" then
+               traceImportant "Single target mode ==> Skipping dependencies."
+               runSingleTarget lastTarget 
+           else
+               targets |> Array.iter runSingleTarget
     
     let watch = new System.Diagnostics.Stopwatch()
     watch.Start()        
     try
         tracefn "Building project with version: %s" buildVersion
         let parallelJobs = environVarOrDefault "parallel-jobs" "1" |> int
-      
+
+        // Figure out the order in in which targets can be run, and which can be run in parallel.
+        let order = determineBuildOrder targetName
 
         if parallelJobs > 1 then
             tracefn "Running parallel build with %d workers" parallelJobs
-
-            // determine a parallel build order
-            let order = determineBuildOrder targetName
 
             // run every level in parallel
             for par in order do
                 runTargetsParallel parallelJobs par
 
         else
-            // single threaded build
+            // single threaded build. We flatten out the groupings of targets that determineBuildOrder
+            // returns, since we don't care about parallel execution.
             PrintDependencyGraph false targetName
-            runTarget targetName
+            let flattenedOrder = order |> Seq.collect id |> Seq.toArray
+            runTargets flattenedOrder
 
     finally
         if errors <> [] then


### PR DESCRIPTION
This PR adds the soft dependency operators ?=> and <=?. 

If B has a soft dependency on A, that means that if A and B are part of a dependency graph, A must be run before B.  But B does not require that A be run.

Soft dependencies can help address this issue raised here:
http://stackoverflow.com/questions/21334283/fake-patterns-to-separate-target-build-order-from-dependencies 