### PR TITLE
Specify type of 'UploadTestResultsXml' first argument

### DIFF
--- a/src/app/FakeLib/AppVeyor.fs
+++ b/src/app/FakeLib/AppVeyor.fs
@@ -152,8 +152,8 @@ type TestResultsType =
     | NUnit
     | Xunit
 
-/// Uploads the test results .xml file to the Test tab of the build console.
-let UploadTestResultsXml testResultsType outputDir =
+/// Uploads all the test results ".xml" files in a directory to make them visible in Test tab of the build console.
+let UploadTestResultsXml (testResultsType : TestResultsType) outputDir =
     if buildServer = BuildServer.AppVeyor then
         let resultsType = (sprintf "%A" testResultsType).ToLower()
         let url = sprintf "https://ci.appveyor.com/api/testresults/%s/%s" resultsType AppVeyorEnvironment.JobId


### PR DESCRIPTION
The argument was infered to be `'a` but the type should be `TestResultsType`.

It made both completion and the documentation at https://fsharp.github.io/FAKE/apidocs/fake-appveyor.html hard to read and understand.