### PR TITLE
Better unknow target handling & build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,5 @@
 @echo off
+SETLOCAL
 
 cls
 
@@ -12,8 +13,8 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
-SET TARGET="Default"
+SET TARGET=Default
 
-IF NOT [%1]==[] (set TARGET="%1")
+IF NOT [%1]==[] (SET TARGET=%1)
 
 "packages\FAKE\tools\Fake.exe" "build.fsx" "target=%TARGET%"

--- a/build.cmd
+++ b/build.cmd
@@ -15,6 +15,6 @@ if errorlevel 1 (
 
 SET TARGET=Default
 
-IF NOT [%1]==[] (SET TARGET=%1)
+IF NOT [%1]==[] (SET TARGET=%~1)
 
-"packages\FAKE\tools\Fake.exe" "build.fsx" "target=%TARGET%"
+"packages\FAKE\tools\Fake.exe" "build.fsx" "target="%TARGET%""

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -302,7 +302,7 @@ let runFinalTargets() =
                let watch = new System.Diagnostics.Stopwatch()
                watch.Start()
                tracefn "Starting FinalTarget: %s" name
-               TargetDict.[toLower name].Function()
+               (getTarget name).Function()
                addExecutedTarget name watch.Elapsed
            with
            | exn -> targetError name exn)
@@ -318,7 +318,7 @@ let runBuildFailureTargets() =
                let watch = new System.Diagnostics.Stopwatch()
                watch.Start()
                tracefn "Starting BuildFailureTarget: %s" name
-               TargetDict.[toLower name].Function()
+               (getTarget name).Function()
                addExecutedTarget name watch.Elapsed
            with
            | exn -> targetError name exn)
@@ -335,7 +335,7 @@ let PrintTargets() =
 let private withDependencyType (depType:DependencyType) targets =
     targets |> List.map (fun t -> depType, t)
 
-// Helper function for visiting targets in a dependency tree. Retutrns a set containing the names of the all the 
+// Helper function for visiting targets in a dependency tree. Returns a set containing the names of the all the 
 // visited targets, and a list containing the targets visited ordered such that dependencies of a target appear earlier
 // in the list than the target.
 let private visitDependencies fVisit targetName = 
@@ -343,7 +343,7 @@ let private visitDependencies fVisit targetName =
         let visited = new HashSet<_>()
         let ordered = new List<_>()
         let rec visitDependenciesAux level (depType,targetName) = 
-            let target = TargetDict.[toLower targetName]
+            let target = getTarget targetName
             let isVisited = visited.Contains targetName
             visited.Add targetName |> ignore
             fVisit (target, depType, level, isVisited)


### PR DESCRIPTION
## Changes

TLDR:

* Used `SETLOCAL` in `build.cmd` to ensure that it doesn't touch the global environment
* Also made `build.cmd` handle build target names quoted or not as first arg
* Replaced all direct access to the target dictionary with the `getTarget` function that provide an nice error display.

## Why

I had a problem today where FAKE wasn't building some of our projects anymore, after searching the real reason was that I built fake in the same terminal a little bit before and that `build.cmd` set the environment variable `TARGET` to `"Default"` (With the quotes).

The problem with that is that while FAKE `build.cmd` pass it on the command line, and the extra quotes are removed from there our own build script doesn't and just call :

    RunTargetOrDefault "Default"

*(The fact that we also use a task named `Default` made that a lot harder to debug, took me time to understand who set this evironment variable)*

But `RunTargetOrDefault` will also use an environment variable  `TARGET` if it exists, except that it doesn't trim quotes :D

And then fake was failing with the not really helpful :

    System.Reflection.TargetInvocationException: Exception has been thrown by the target of an
    invocation. ---> System.Collections.Generic.KeyNotFoundException: The given key was not
    present in the dictionary.                                                                 
