### PR TITLE
dotCover runner for Xunit2

### DIFF
--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -180,6 +180,18 @@ let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUni
 
     traceEndTask "DotCoverNUnit" details
 
+/// Runs the dotCover "cover" command against the XUnit2 test runner.
+/// ## Parameters
+///
+///  - `setDotCoverParams` - Function used to overwrite the dotCover report default parameters.
+///  - `setXUnit2Params` - Function used to overwrite the XUnit2 default parameters.
+///
+/// ## Sample
+///
+///     !! (buildDir @@ buildMode @@ "/*.Unit.Tests.dll") 
+///         |> DotCoverXUnit2 
+///             (fun  -> dotCoverOptions )
+///             (fun nUnitOptions -> nUnitOptions) 
 let DotCoverXUnit2 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setXUnit2Params: XUnit2Params -> XUnit2Params) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "

--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -5,6 +5,7 @@ open Fake
 open System
 open System.IO
 open System.Text
+open Fake.Testing.XUnit2
 
 type DotCoverReportType = 
   | Html = 0
@@ -178,6 +179,23 @@ let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUni
                   } |> setDotCoverParams)
 
     traceEndTask "DotCoverNUnit" details
+
+let DotCoverXUnit2 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setXUnit2Params: XUnit2Params -> XUnit2Params) (assemblies: string seq) =
+    let assemblies = assemblies |> Seq.toArray
+    let details =  assemblies |> separated ", "
+    traceStartTask "DotCoverXUnit2" details
+
+    let parameters = XUnit2Defaults |> setXUnit2Params
+    let args = buildXUnit2Args assemblies parameters 
+    
+    DotCover (fun p ->
+                  {p with
+                     TargetExecutable = parameters.ToolPath 
+                     TargetArguments = args
+                  } |> setDotCoverParams)
+
+    traceEndTask "DotCoverXUnit2" details
+
 
 /// Runs the dotCover "cover" command against the MSpec test runner.
 /// ## Parameters

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -148,7 +148,7 @@ let XUnit2Defaults =
       Silent = false
       Wait = false }
 
-let internal buildXUnit2Args assemblies parameters =
+let buildXUnit2Args assemblies parameters =
     let formatTrait traitFlag (name, value) =
         sprintf @"%s ""%s=%s""" traitFlag name value
     let appendTraits traitsList traitFlag sb =


### PR DESCRIPTION
(Added support for running dotCover using the Xunit2 test runner. Couldn't find tests for similar libraries, so I haven't added any tests. Tried a little bit locally and it seemed to work for simple cases. I will use this at work, so I'm happy to test it out on more complex real-life scenarios.

Also, it seems there are some differences in how the different test runner helpers are structured, I couldn't really figure it out... 