### PR TITLE
Ensure FSI-ASSEMBLY.dll path exists

### DIFF
--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -339,6 +339,12 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
                             let di = Directory.CreateDirectory cacheDir.FullName 
                             di.Attributes <- FileAttributes.Directory ||| FileAttributes.Hidden
 
+                        let destinationFile = FileInfo(assemblyPath.Value)
+                        let targetDirectory = destinationFile.Directory
+
+                        if (not <| targetDirectory.Exists) then targetDirectory.Create()
+                        if (destinationFile.Exists) then destinationFile.Delete()
+
                         File.Move("FSI-ASSEMBLY.dll", assemblyPath.Value)
                     
                         if File.Exists("FSI-ASSEMBLY.pdb") then


### PR DESCRIPTION
fixes fsharp/FAKE#946 - relative paths seem to be confused between the path of the fake.exe and the path of the project.

I'm happy for someone who knows more than I do to do a deeper dive, but this seems adequate for what I assume is a temporary location.