### PR TITLE
DotCoverMSTest support

### DIFF
--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -220,12 +220,12 @@ let internal buildMSTestArgsForDotCover parameters assemblies =
             sprintf @"%s\%s.trx" parameters.ResultsDir (DateTime.Now.ToString("yyyyMMdd-HHmmss.ff"))
         else null
     new StringBuilder()
-    |> appendIfNotNull testcontainers ""
-    |> appendIfNotNull parameters.Category "/category:"
-    |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
-    |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
-    |> appendIfNotNull testResultsFile "/resultsfile:"
-    |> appendIfTrue parameters.NoIsolation "/noisolation"
+    |> appendWithoutQuotesIfNotNull testcontainers ""
+    |> appendWithoutQuotesIfNotNull parameters.Category "/category:"
+    |> appendWithoutQuotesIfNotNull parameters.TestMetadataPath "/testmetadata:"
+    |> appendWithoutQuotesIfNotNull parameters.TestSettingsPath "/testsettings:"
+    |> appendWithoutQuotesIfNotNull testResultsFile "/resultsfile:"
+    |> appendIfTrueWithoutQuotes parameters.NoIsolation "/noisolation"
     |> toText
 
 /// Runs the dotCover "cover" command against the MSTest test runner.

--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -78,6 +78,12 @@ let inline appendIfTrueWithoutQuotes p s builder =
 /// Appends a text if the predicate is false.
 let inline appendIfFalse p = appendIfTrue (not p)
 
+/// Appends a text without quoting if the value is not null.
+let inline appendWithoutQuotesIfNotNull (value : Object) s = 
+    appendIfTrueWithoutQuotes (value <> null) (match value with
+                                  | :? String as sv -> (sprintf "%s%s" s sv)
+                                  | _ -> (sprintf "%s%A" s value))
+
 /// Appends a text if the value is not null.
 let inline appendIfNotNull (value : Object) s = 
     appendIfTrue (value <> null) (match value with


### PR DESCRIPTION
Added support for using DotCover with MSTest.

The original MSTest runner runs all test assemblies in a separate run. That might have some benefits, and I don't want to change this for the DotCover support without a proper discussion as it might break backwards compatibilty for users using MSTest with multiple assemblies. For DotCover it is quite nescessary, otherwise we create too many DotCover reports.

Tried it on five test assemblies with 1100 tests and it seems to work fine.

Will use both this and the XUnit2DotCover quite a lot going forward.