### PR TITLE
RegistryHelper

### DIFF
--- a/src/app/FakeLib/RegistryHelper.fs
+++ b/src/app/FakeLib/RegistryHelper.fs
@@ -5,7 +5,7 @@ module Fake.RegistryHelper
 open Microsoft.Win32
 
 /// Registry base keys.
-type RegistryBaseKey = 
+type RegistryBaseKey =
     | HKEYLocalMachine
     | HKEYClassesRoot
     | HKEYUsers
@@ -15,7 +15,7 @@ type RegistryBaseKey =
 
 /// Maps the RegistryBaseKey to a RegistryKey
 /// [omit]
-let getKey name = 
+let getKey name =
     match name with
     | HKEYLocalMachine -> Registry.LocalMachine
     | HKEYClassesRoot -> Registry.ClassesRoot
@@ -26,7 +26,7 @@ let getKey name =
 
 /// Maps the RegistryBaseKey to a RegistryKey for a 64bit System
 /// [omit]
-let get64BitKey name = 
+let get64BitKey name =
     match name with
     | HKEYLocalMachine -> RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64)
     | HKEYClassesRoot -> RegistryKey.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Registry64)
@@ -37,27 +37,27 @@ let get64BitKey name =
 
 /// Maps the RegistryBaseKey to a RegistryKey for a 32bit System
 /// [omit]
-let get32BitKey name = 
+let get32BitKey name =
     match name with
     | HKEYLocalMachine -> RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
     | HKEYClassesRoot -> RegistryKey.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Registry32)
     | HKEYUsers -> RegistryKey.OpenBaseKey(RegistryHive.Users, RegistryView.Registry32)
     | HKEYCurrentUser -> RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32)
     | HKEYCurrentConfig -> RegistryKey.OpenBaseKey(RegistryHive.CurrentConfig, RegistryView.Registry32)
-    | HKEYPerformanceData -> RegistryKey.OpenBaseKey(RegistryHive.PerformanceData, RegistryView.Registry32)   
+    | HKEYPerformanceData -> RegistryKey.OpenBaseKey(RegistryHive.PerformanceData, RegistryView.Registry32)
 
 /// Gets a 64-bit registy key
-let getRegistryKey64 baseKey subKey (writePermission : bool) =     
+let getRegistryKey64 baseKey subKey (writePermission : bool) =
     (get64BitKey baseKey).OpenSubKey(subKey, writePermission)
-    
+
 /// Gets a registy key and falls back to 32 bit if the 64bit key is not there
-let getRegistryKey baseKey subKey (writePermission : bool) =     
+let getRegistryKey baseKey subKey (writePermission : bool) =
     let x64BitKey = (getKey baseKey).OpenSubKey(subKey, writePermission)
-    if x64BitKey <> null then x64BitKey else  
+    if x64BitKey <> null then x64BitKey else
     (get32BitKey baseKey).OpenSubKey(subKey, writePermission)  // fall back to 32 bit
 
 /// Gets a registy value as string
-let getRegistryValue baseKey subKey value = 
+let getRegistryValue baseKey subKey value =
     use key = getRegistryKey baseKey subKey false
     if key = null then
         failwithf "Registry subkey %s could not be found for key %A" subKey baseKey
@@ -67,7 +67,7 @@ let getRegistryValue baseKey subKey value =
     value.ToString()
 
 /// Gets a registy value as string
-let getRegistryValue64 baseKey subKey value = 
+let getRegistryValue64 baseKey subKey value =
     use key = getRegistryKey64 baseKey subKey false
     if key = null then
         failwithf "Registry subkey %s could not be found for key %A" subKey baseKey
@@ -80,12 +80,12 @@ let getRegistryValue64 baseKey subKey value =
 let createRegistrySubKey baseKey subKey = (getKey baseKey).CreateSubKey subKey |> ignore
 
 /// Sets a registry value
-let setRegistryValue<'T> baseKey subKey keyName (value : 'T) = 
+let setRegistryValue<'T> baseKey subKey keyName (value : 'T) =
     use key = getRegistryKey baseKey subKey true
     key.SetValue(keyName, value)
 
 /// Deletes the registry value from its key
-let deleteRegistryValue baseKey subKey keyName = 
+let deleteRegistryValue baseKey subKey keyName =
     use key = getRegistryKey baseKey subKey true
     key.DeleteValue keyName
 
@@ -93,4 +93,5 @@ let deleteRegistryValue baseKey subKey keyName =
 let valueExistsForKey = fun baseKey sub_key value ->
     let key = getRegistryKey baseKey sub_key false
     key.GetValueNames()
-    |> Seq.exists (fun v -> v = value) 
+    |> Seq.exists (fun v -> v = value)
+

--- a/src/app/FakeLib/RegistryHelper.fs
+++ b/src/app/FakeLib/RegistryHelper.fs
@@ -89,9 +89,23 @@ let deleteRegistryValue baseKey subKey keyName =
     use key = getRegistryKey baseKey subKey true
     key.DeleteValue keyName
 
-/// Returns whether or not a registry value exists for a key
-let valueExistsForKey = fun baseKey sub_key value ->
-    let key = getRegistryKey baseKey sub_key false
+/// Deletes a registry subKey
+let deleteRegistrySubKey baseKey subKey keyName =
+    use key = getRegistryKey baseKey subKey true
+    key.DeleteSubKey keyName
+
+/// Returns all the value names of a registry key
+let getRegistryValueNames baseKey subKey =
+    use key = getRegistryKey baseKey subKey false
     key.GetValueNames()
+
+/// Returns whether or not a registry value exists for a key
+let valueExistsForKey = fun baseKey subKey value ->
+    getRegistryValueNames baseKey subKey
     |> Seq.exists (fun v -> v = value)
+
+/// Returns all the subKey names of a registry key
+let getRegistrySubKeyNames baseKey subKey =
+    use key = getRegistryKey baseKey subKey false
+    key.GetSubKeyNames()
 


### PR DESCRIPTION
Here are some additional registry function, as per #966.

I think the function ``createRegistrySubKey`` should be changed to follow the pattern of the other ones, but I didn't want to change the API without consulting.

It should:
1. ``use`` the key, since it's an IDisposable
2. have a signature with ``baseKey``, ``subKey`` and ``keyName``.

Additional cleanup should include renaming ``keyName`` to ``valueName`` or ``value`` in ``setRegistryValue`` and ``deleteRegistryValue``.