### PR TITLE
Add maintainers note to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,3 +24,7 @@ See the [project home page](http://fsharp.github.com/FAKE/) for tutorials and [A
 ## How to contribute code
 
 See the [contributing page](http://fsharp.github.com/FAKE/contributing.html).
+
+## Maintainers
+
+Although this project is hosted in the [fsharp](https://github.com/fsharp) repository for historical reasons, it is _not_ maintained and managed by the F# Core Engineering Group. The F# Core Engineering Group acknowledges that the independent owner and maintainer of this project is [Steffen Forkmann](http://github.com/forki).


### PR DESCRIPTION
We clarified the status of the repositories under "github.com/fsharp" at the last F# Foundation meeting.

The summary is that FAKE and F# Data are welcome to stay under the "fsharp" organization. We'd just like to add an explicit note to the README saying that those are independent projects.