### PR TITLE
support caching even when running RazorEngine as part of the build script.

### DIFF
--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -363,11 +363,10 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
                             |> Seq.filter(fun assem -> assem <> "RazorEngine.Compilation.ImpromptuInterfaceDynamicAssembly")
                             |> Seq.cache
                         if dynamicAssemblies |> Seq.length > 0 then
-                            if printDetails then
-                                let msg =
-                                    sprintf "Dynamic assemblies were generated during evaluation of script (%s).\nCan not save cache." 
-                                        (System.String.Join(", ", dynamicAssemblies))
-                                trace msg
+                            let msg =
+                                sprintf "Dynamic assemblies were generated during evaluation of script (%s).\nCan not save cache." 
+                                    (System.String.Join(", ", dynamicAssemblies))
+                            trace msg
 
                         else
                             let assemblies = 

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -353,16 +353,28 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
                             File.Delete("FSI-ASSEMBLY.dll.mdb")
 
                         let dynamicAssemblies = 
-                            System.AppDomain.CurrentDomain.GetAssemblies() 
+                            System.AppDomain.CurrentDomain.GetAssemblies()
                             |> Seq.filter(fun assem -> assem.IsDynamic)
-                            |> Seq.filter(fun assem -> assem.GetName().Name <> "FSI-ASSEMBLY")
+                            |> Seq.map(fun assem -> assem.GetName().Name)
+                            |> Seq.filter(fun assem -> assem <> "FSI-ASSEMBLY")
+                            // General Reflection.Emit helper (most likely harmless to ignore)
+                            |> Seq.filter(fun assem -> assem <> "Anonymously Hosted DynamicMethods Assembly")
+                            // RazorEngine generated
+                            |> Seq.filter(fun assem -> assem <> "RazorEngine.Compilation.ImpromptuInterfaceDynamicAssembly")
+                            |> Seq.cache
                         if dynamicAssemblies |> Seq.length > 0 then
-                            if printDetails then 
-                                trace "Dynamic assemblies were generated during evaluation of script.\nCan not save cache." 
+                            if printDetails then
+                                let msg =
+                                    sprintf "Dynamic assemblies were generated during evaluation of script (%s).\nCan not save cache." 
+                                        (System.String.Join(", ", dynamicAssemblies))
+                                trace msg
+
                         else
                             let assemblies = 
                                 System.AppDomain.CurrentDomain.GetAssemblies()
                                 |> Seq.filter(fun assem -> not assem.IsDynamic)
+                                // They are not dynamic, but can't be re-used either.
+                                |> Seq.filter(fun assem -> not <| assem.GetName().Name.StartsWith("CompiledRazorTemplates.Dynamic.RazorEngine_"))
                         
                             let cacheConfig : XDocument = Cache.create assemblies
                             cacheConfig.Save(cacheConfigPath.Value) 


### PR DESCRIPTION
Found while investigating https://github.com/tpetricek/FSharp.Formatting/issues/337.
Also shows the name of the assembly which disables the cache.