### PR TITLE
add tests and fix regex

### DIFF
--- a/src/app/FakeLib/Git/Information.fs
+++ b/src/app/FakeLib/Git/Information.fs
@@ -7,7 +7,7 @@ open System
 open System.Text.RegularExpressions
 open System.IO
    
-let versionRegex = Regex("^git version ([\d.]{5}).*$", RegexOptions.Compiled)
+let versionRegex = Regex("^git version ([\d.]*).*$", RegexOptions.Compiled)
 
 /// Gets the git version
 let getVersion repositoryDir = 
@@ -17,16 +17,18 @@ let getVersion repositoryDir =
 let isVersionHigherOrEqual currentVersion referenceVersion = 
   
     parseVersion currentVersion >= parseVersion referenceVersion
-                
+
+/// [omit]       
+let extractGitVersion version =
+    let regexRes = versionRegex.Match version 
+    if regexRes.Success then
+        regexRes.Groups.[1].Value
+    else
+        failwith "unable to find git version"
+         
 let isGitVersionHigherOrEqual referenceVersion = 
 
-    let currentVersion = getVersion "."
-    let regexRes = versionRegex.Match currentVersion 
-    let versionParts =
-        if regexRes.Success then
-            regexRes.Groups.[1].Value
-        else
-            failwith "unable to find git version"
+    let versionParts = getVersion "." |> extractGitVersion
 
     isVersionHigherOrEqual versionParts referenceVersion
 

--- a/src/test/Test.Git/GitInformationSpec.cs
+++ b/src/test/Test.Git/GitInformationSpec.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Machine.Specifications;
+using Fake.Git;
+
+namespace Test.Git
+{
+	public class when_getting_git_information
+	{
+		It should_be_able_to_get_the_git_version = 
+			() => Information
+				.extractGitVersion("git version 2.4.9")
+				.ShouldEqual("2.4.9");
+
+		It should_be_able_to_get_the_git_version_apple = 
+			() => Information
+				.extractGitVersion("git version 2.4.9 (Apple Git-60)")
+				.ShouldEqual("2.4.9");
+
+		It should_be_able_to_get_the_git_silly = 
+			() => Information
+				.extractGitVersion("git version 400.44312.9 (Apple Git-60)")
+				.ShouldEqual("400.44312.9");
+	}
+}
+

--- a/src/test/Test.Git/Test.Git.csproj
+++ b/src/test/Test.Git/Test.Git.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Sha1Specs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="GitInformationSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\app\FakeLib\FakeLib.fsproj">


### PR DESCRIPTION
Also adds some tests. Just to be sure. 

Followup to #1006 as that would not parse versions containing more then 5 characters.