### PR TITLE
add functionality for deleting files and folders to FTP Helper

### DIFF
--- a/src/app/FakeLib/FtpHelper.fs
+++ b/src/app/FakeLib/FtpHelper.fs
@@ -141,3 +141,54 @@ and private upload server user pwd (fsi : FileSystemInfo) (rootDir : string) =
         uploadAFolder server user pwd fsi.FullName (sprintf "%s\\%s" rootDir fsi.Name)
     | "System.IO.FileInfo" -> uploadAFile server user pwd (sprintf "%s\\%s" rootDir fsi.Name) fsi.FullName
     | _ -> logfn "Unknown object found at %A" fsi
+
+/// Deletes a single file from remote FTP folder.
+/// ## Parameters
+///  - `destPath` - The full path to the file which needs to be deleted, including all its parent folders
+///  - `server` - FTP Server name (ex: "ftp://10.100.200.300:21/")
+///  - `user` - FTP Server login name (ex: "joebloggs")
+///  - `pwd` - FTP Server login password (ex: "J0Eblogg5")
+let deleteAFile (server : string) (user : string) (pwd : string) (destPath : string) = 
+    logfn "Deleting %s" destPath
+    destPath
+    |> fun p -> getServerInfo (sprintf "%s/%s" server p) user pwd WebRequestMethods.Ftp.DeleteFile
+    |> fun si -> 
+        use response = (si.Request.GetResponse() :?> FtpWebResponse)
+        logfn "Delete file %s status: %s" destPath response.StatusDescription
+
+let private getFolderContents (server : string) (user : string) (pwd : string) (destPath : string) =
+    getServerInfo (sprintf "%s/%s" server destPath) user pwd WebRequestMethods.Ftp.ListDirectory
+    |> fun si -> 
+        use response = (si.Request.GetResponse() :?> FtpWebResponse)
+        use responseStream = response.GetResponseStream()
+        use reader = new StreamReader(responseStream)
+        [ while not reader.EndOfStream do yield reader.ReadLine() ]
+
+let private deleteEmptyFolder (server : string) (user : string) (pwd : string) (destPath : string) =
+    destPath
+    |> fun p -> getServerInfo (sprintf "%s/%s" server p) user pwd WebRequestMethods.Ftp.RemoveDirectory
+    |> fun si -> 
+        use response = (si.Request.GetResponse() :?> FtpWebResponse)
+        logfn "Delete folder %s status: %s" destPath response.StatusDescription
+
+/// Deletes a single folder from remote FTP folder.
+/// ## Parameters
+///  - `destPath` - The full path to the folder which needs to be deleted, including all its parent folders
+///  - `server` - FTP Server name (ex: "ftp://10.100.200.300:21/")
+///  - `user` - FTP Server login name (ex: "joebloggs")
+///  - `pwd` - FTP Server login password (ex: "J0Eblogg5")
+let rec deleteAFolder (server : string) (user : string) (pwd : string) (destPath : string) = 
+    logfn "Deleting %s" destPath
+    let folderContents = getFolderContents server user pwd destPath
+
+    if folderContents |> List.isEmpty then
+        deleteEmptyFolder server user pwd destPath
+    else
+        folderContents
+        |> List.iter (fun entry ->
+                        try
+                            deleteAFile server user pwd (Path.Combine(destPath, entry))
+                        with
+                        | _ -> deleteAFolder server user pwd (Path.Combine(destPath, entry)))
+
+        deleteEmptyFolder server user pwd destPath


### PR DESCRIPTION
While working on an automated deployment scenario, we noticed that the ability to delete stuff from an FTP server would come in handy