### PR TITLE
Add BASH completion for FAKE tasks

### DIFF
--- a/bash-completion/README.md
+++ b/bash-completion/README.md
@@ -1,0 +1,22 @@
+# BASH tab completion for possible FAKE tasks
+
+## Prerequisites
+
+If you have tab completion for other commands (such as git parameters) then you can skip to [Install](#install-completion-for-fake)
+
+##### OSX
+```bash
+brew install bash-completion
+```
+Paste the following into ~/.bash_profile (create the file if it doesn't already exist)
+```bash
+if [ -f $(brew --prefix)/etc/bash_completion ]; then
+    . $(brew --prefix)/etc/bash_completion
+fi
+```
+
+## Install completion for FAKE
+```bash
+cd bash-completion
+./install.sh
+```

--- a/bash-completion/fake
+++ b/bash-completion/fake
@@ -1,0 +1,29 @@
+_fake_completion()
+{
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [ -f build.fsx ] ; then
+        # egrep doesn't have the -P switch to match group on OSX
+        # so grep with perl instead as it's available on a default install
+        TASKS=$(perl -nle 'print $1 if m{Target \"(.+)\"}' build.fsx)
+        # Turn case-insensitive matching temporarily on, if necessary.
+        local nocasematchWasOff=0
+        shopt nocasematch >/dev/null || nocasematchWasOff=1
+        (( nocasematchWasOff )) && shopt -s nocasematch
+
+        # Loop over words in list and search for case-insensitive prefix match.
+        local w matches=()
+        for w in $TASKS; do
+            if [[ "$w" == "${cur}"* ]]; then matches+=("$w"); fi
+        done
+
+        # Restore state of 'nocasematch' option, if necessary.
+        (( nocasematchWasOff )) && shopt -u nocasematch
+
+        COMPREPLY=("${matches[@]}")
+        return 0
+    fi
+}
+complete -F _fake_completion fake
+complete -F _fake_completion ./build.sh

--- a/bash-completion/install.sh
+++ b/bash-completion/install.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+if [ -f $(brew --prefix)/etc/bash_completion ]; then
+    COMPLETIONS_FOLDER=$(brew --prefix)/etc/bash_completion.d
+else
+    COMPLETIONS_FOLDER=$(pkg-config --variable=completionsdir bash-completion)
+fi
+echo "Copying FAKE completions to $COMPLETIONS_FOLDER"
+THISDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+sudo cp $THISDIR/fake $COMPLETIONS_FOLDER
+source $COMPLETIONS_FOLDER/fake
+echo "Done!"


### PR DESCRIPTION
Adds case insensitive tab completion to BASH for FAKE tasks. 

![](https://raw.githubusercontent.com/nosami/nosami.github.io/master/fake-bash-completions.gif)

I wasn't sure where to put the files for this. I tested this on both OSX (El Capitan) and Ubuntu 15.10. 

In Ubuntu, just running the install.sh should set things up. On OSX, the user will need to also insert bash-completion if they haven't already done so.

Maybe this could be made easier.