### PR TITLE
only add relative path prefix if not rooted path

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -443,9 +443,11 @@ let BuildWebsite outputPath projectFile =
     
     let currentDir = (directoryInfo ".").FullName
     let projectDir = (fileInfo projectFile).Directory.FullName
-    let mutable prefix = ""
+    
     let diff = slashes projectDir - slashes currentDir
-    prefix <- prefix + (String.replicate diff "../")
+    let prefix = if Path.IsPathRooted outputPath
+                 then ""
+                 else (String.replicate diff "../")
 
     MSBuildDebug "" "Rebuild" [ projectFile ] |> ignore
     MSBuild "" "_CopyWebApplication;_BuiltWebOutputGroupOutput" 


### PR DESCRIPTION
pull request for #1032 MSBuildHelper BuildWebsite fails with invalid OutDir path.