### PR TITLE
[WP] Added more comfortable types to WiXHelper, flagged old ones obsolete

### DIFF
--- a/help/wix.md
+++ b/help/wix.md
@@ -1,0 +1,104 @@
+# Create WiX Setup
+
+If you often ship software to customers, it might be comfortable for you to install it using setups rather than manually deploying.
+FAKE provides you with support for creating MSI setups using the WiX Toolset (http://wixtoolset.org/).
+
+## Minimal working example
+
+    Target "BuildWiXSetup" (fun _ ->
+        // This defines, which files should be collected when running bulkComponentCreation
+        let fileFilter = fun (file : FileInfo) -> 
+            if file.Extension = ".dll" || file.Extension = ".exe" || file.Extension = ".config" then 
+                true 
+            else 
+                false
+            
+        // Collect Files which should be shipped. Pass directory with your deployment output for deployDir
+        let components = bulkComponentCreation fileFilter (DirectoryInfo deployDir)
+                 
+        // Collect component references for usage in features
+        let componentRefs = components |> Seq.map(fun comp -> comp.ToComponentRef())
+
+        let completeFeature = generateFeatureElement (fun f -> 
+                                                        {f with  
+                                                            Id = "Complete"
+                                                            Title = "Complete Feature"
+                                                            Level = 1 
+                                                            Description = "Installs all features"
+                                                            Components = componentRefs
+                                                            Display = Expand 
+                                                        })
+
+        // Generates a predefined WiX template with placeholders which will be replaced in "FillInWiXScript"
+        generateWiXScript "SetupTemplate.wxs"
+
+        let WiXUIMondo = generateUIRef (fun f ->
+                                            {f with
+                                                Id = "WixUI_Mondo"
+                                            })
+
+        let WiXUIError = generateUIRef (fun f ->
+                                            {f with
+                                                Id = "WixUI_ErrorProgressText"
+                                            })
+
+        let MajorUpgrade = generateMajorUpgradeVersion(
+                                fun f ->
+                                    {f with 
+                                        Schedule = MajorUpgradeSchedule.AfterInstallExecute
+                                        DowngradeErrorMessage = "A later version is already installed, exiting."
+                                    })
+
+        FillInWiXTemplate "" (fun f ->
+                                {f with
+                                    // Guid which should be generated on every build
+                                    ProductCode = Guid.NewGuid()
+                                    ProductName = "Test Setup"
+                                    Description = "Description of Test Setup"
+                                    ProductLanguage = 1033
+                                    ProductVersion = "1.0.0"
+                                    ProductPublisher = "YouOrYourCompany"
+                                    // Set fixed upgrade guid, this should never change for this project!
+                                    UpgradeGuid = WixProductUpgradeGuid
+                                    MajorUpgrade = [MajorUpgrade]
+                                    UIRefs = [WiXUIMondo; WiXUIError]
+                                    ProgramFilesFolder = ProgramFiles32
+                                    Components = components
+                                    BuildNumber = "Build number"
+                                    Features = [completeFeature]
+                                })
+            
+
+        // run the WiX tools
+        WiX (fun p -> {p with ToolDirectory = WiXPath}) 
+            setupFileName
+            @".\SetupTemplate.wxs"
+    )
+
+## Further possibilities
+Besides just plainly shipping those files as setup you can also use the custom action and custom action execution elements to execute various commands before or after certain events during the installation.
+This gives you the possibility to for example install, uninstall, start or stop certain services when you need to.
+If your software is for example running as a service at your customer's side, you would need to manually stop and start the services on upgrades.
+WiX knows the "ServiceControl" element for starting, stopping and removing services. You attach it to components.
+If a component's files change and it has a Service Control element, the service that is referred to will be started, stopped or uninstalled, just as you defined it.
+You can use the attachServiceToControlComponents function for attaching service controls to components. You would only have to slightly change the above example:
+
+### Example
+    let serviceControl = generateServiceControl(fun f -> {f with 
+                                                            Id = "PickAnId"
+                                                            Name = "QualifiedNameOfYourService"
+                                                            Start = InstallUninstall.Install
+                                                            Stop = InstallUninstall.Both
+                                                            Remove = InstallUninstall.Uninstall})
+
+    // This defines, that all executable files should be tagged with the service control element
+    let componentSelector = fun (comp : WiXComponent) -> comp.Files |> Seq.exists(fun file -> file.Name.EndsWith(".exe")) 
+
+    let components = attachServiceControlToComponents
+                        (bulkComponentCreation (fun file -> 
+                            if file.Extension = ".dll" || file.Extension = ".exe" || file.Extension = ".config" then 
+                                true 
+                            else 
+                                false) (DirectoryInfo deployDir))
+                        componentSelector 
+                        [serviceControl]


### PR DESCRIPTION
Hey all, 

I did some slight changes to the WiXHelper, so that WiX Features, Custom Actions and Custom Action Executions don't get passed around as concatenated strings, but as sequences of their types.
The old types and functions using them were flagged as obsolete.

@forki: Two questions remaining:
1: I have a module called "Test.Fake.Deploy.Web.WixHelper" which resides in \src\test\Test.Fake.Deploy.Web. It does not seem to be included in the solution, where would this go?
2: I'd like to contribute the minimal working example of a WiX Target as section to the github.io page (https://fsharp.github.io/FAKE/). Where can I add this section? 
Edit: Ah found it, goes to /help.

Kind Regards