### PR TITLE
Replace hard reference on gacutil path with automatic search for late…

### DIFF
--- a/src/app/FakeLib/GACHelper.fs
+++ b/src/app/FakeLib/GACHelper.fs
@@ -3,6 +3,10 @@ module Fake.GACHelper
 
 open System
 
+/// Path to newest `gacutil.exe`
+let gacutilToolPath = !! (sdkBasePath + "/**/gacutil.exe")  
+                             |> getNewestTool
+
 /// GAC parameters
 type GACParams = 
     { /// (Required) Path to the gacutil
@@ -13,8 +17,7 @@ type GACParams =
       WorkingDir : string }
 
 let mutable GACUtil = 
-    if isMono then "gacutil" else
-    ProgramFilesX86 @@ "Microsoft SDKs/Windows/v8.0A/bin/NETFX 4.0 Tools/gacutil.exe"
+    if isMono then "gacutil" else gacutilToolPath
 
 /// GACutil default parameters
 let GACDefaults = 


### PR DESCRIPTION
…st gacutil.exe

The existing path "Microsoft SDKs/Windows/v8.0A/bin/NETFX 4.0 Tools/gacutil.exe" doesn't exist on a Win 10 + Visual Studio 2015 dev environment.
RegAsmHelper solves a similar problem by searching for the latest regasm tools path (using EnvironmentHelper).
This patch solves this analogously.