### PR TITLE
Changes in Octokit.fsx

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -33,6 +33,7 @@ type private HttpClientWithTimeout(timeout : TimeSpan) as this =
     interface Internal.IHttpClient with
         member __.Send(request : Internal.IRequest, ct : CancellationToken) =
             setter.Force()
+            match request with :? Internal.Request as r -> r.Timeout <- timeout | _ -> ()
             base.Send(request, ct)
 
 let private isRunningOnMono = System.Type.GetType ("Mono.Runtime") <> null


### PR DESCRIPTION
This PR attempts to work around [a known issue](https://github.com/octokit/octokit.net/issues/963) in the Octokit.Net library, in which user-supplied timeouts are not passed to the underlying `HttpClient` object. This results in timeout errors when uploading github release assets that are sufficiently large.

I have also included a new `uploadFiles` method that can upload multiple assets in parallel.