### PR TITLE
TC: Add open-close block helpers

### DIFF
--- a/src/app/FakeLib/TeamCityHelper.fs
+++ b/src/app/FakeLib/TeamCityHelper.fs
@@ -25,6 +25,12 @@ let sendToTeamCity format message =
 let sendStrToTeamCity s = 
     if buildServer = TeamCity then postMessage (LogMessage(RemoveLineBreaks s, true))
 
+/// Open Named Block
+let sendOpenBlock = sendToTeamCity "##teamcity[blockOpened name='%s']"
+
+/// Close Named Block
+let sendCloseBlock = sendToTeamCity "##teamcity[blockClosed name='%s']"
+
 /// Sends an error to TeamCity
 let sendTeamCityError error = sendToTeamCity "##teamcity[buildStatus status='FAILURE' text='%s']" error
 


### PR DESCRIPTION
Added helper methods for TeamCity blocks

**Usage**
```fs
Target "MyTarget" (fun _ ->
  sendOpenBlock "MyTarget"
  // target code here
  sendCloseBlock "MyTarget"
)
```

This nifty little thing gets you from this:

![Before](https://googledrive.com/host/0B-VFiD-Al4feS19md3ZpVFRMSzA/TC-blocks-before.png)

to this (targets in an expandable tree view):

![After](https://googledrive.com/host/0B-VFiD-Al4feS19md3ZpVFRMSzA/TC-blocks-after.png)

**Futures**
As a next step it would be awesome to use this feature by default in the target output (when running in TeamCity) instead of going the long way round and polluting every target with `sendOpenBlock` / `sendCloseBlock`.