### PR TITLE
Fix encoding of AssemblyInfo as written by ReplaceAssemblyInfoVersions

### DIFF
--- a/src/app/FakeLib/AssemblyInfoHelper.fs
+++ b/src/app/FakeLib/AssemblyInfoHelper.fs
@@ -254,10 +254,16 @@ let ReplaceAssemblyInfoVersions param =
         |> replaceAttribute "AssemblyCopyright" parameters.AssemblyCopyright
         |> replaceMetadataAttributes parameters.AssemblyMetadata
     
-    ReadFile parameters.OutputFileName
+    let encoding = Text.Encoding.GetEncoding "UTF-8"
+
+    let fileContent = File.ReadAllLines(parameters.OutputFileName, encoding)
+
+    use writer = new StreamWriter(parameters.OutputFileName, false, encoding)
+
+    fileContent
     |> Seq.map replaceLine
     |> Seq.toList // break laziness
-    |> WriteFile parameters.OutputFileName
+    |> Seq.iter writer.WriteLine
 
 /// Update all AssemblyInfo.[fs|cs|vb] files in the specified directory and its subdirectories
 /// ## Parameters


### PR DESCRIPTION
The function ReplaceAssemblyInfoVersions was reading files with the
encoding set by build param or defaulting to the system default, as
ReadFile and WriteFile do under the hood.

The AssemblyInfo files are always encoded in UTF-8. Therefore, the file
encoding that is actually used should not depend on a build param.