### PR TITLE
tell the clr to use the cached assemblies even when it tries to reload them with a different context.

### DIFF
--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -289,7 +289,10 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
               | _ ->
                 match loadedAssemblies
                       |> Seq.map snd
-                      |> Seq.tryFind (fun asem -> asem.GetName().Name = name.Name) with
+                      |> Seq.tryFind (fun asem ->
+                          let n = asem.GetName()
+                          n.Name = name.Name &&
+                          n.GetPublicKeyToken() = name.GetPublicKeyToken()) with
                 | Some (asem) ->
                     traceFAKE "Redirect assembly from '%s' to '%s'" ev.Name asem.FullName
                     asem


### PR DESCRIPTION
The problem is that in some situations the runtime loads some of the cached assemblies twice in different "load contexts". This leads to `missingmethodexceptions` or `typecastexceptions` or similar exceptions.

Currently I have the `-nc` option (to disable cache) in place as a workaround.

Note: Please read my follow-up in-line comments as well as one of the changes might be breaking some FAKE scripts.