### PR TITLE
Updated as per latest git version support.

### DIFF
--- a/src/app/FakeLib/Git/CommitMessage.fs
+++ b/src/app/FakeLib/Git/CommitMessage.fs
@@ -9,7 +9,8 @@ open System.IO
 
 /// Returns the commit message file.
 let getCommitMessageFileInfo repositoryDir = 
-    (findGitDir repositoryDir).FullName + "\\COMMITMESSAGE"
+    //(findGitDir repositoryDir).FullName + "\\COMMITMESSAGE"
+    (findGitDir repositoryDir).FullName + "\\COMMIT_EDITMSG"
       |> fileInfo
 
 /// Gets the commit message


### PR DESCRIPTION
As per latest git 2.6.x there is no COMMITMESSAGE file but it is replaced by COMMIT_EDITMSG file. I guess that is same file you are looking for. It is having last commit message. I have keep the original code commented (only file name changed.). If it is required.  