### PR TITLE
Fix #992 test failure when space in temp path.

### DIFF
--- a/src/app/FakeLib/CscHelper.fs
+++ b/src/app/FakeLib/CscHelper.fs
@@ -78,11 +78,21 @@ let cscExe toolPath (srcFiles : string list) (opts : string list) : int =
 ///                                Target = ...
 ///                                ... })
 let csc (setParams : CscParams -> CscParams) (inputFiles : string list) : int =
-    let inputFiles = inputFiles |> Seq.toList
+    // Helper to quote a path with spaces in it, if not already quoted.  See https://github.com/fsharp/FAKE/issues/992
+    let ensureQuotedPath (path : string) =
+        // Sensitive to being backwards compatible with people that are using
+        // Csc AND quoting their paths.  Only quote if space in path and quotes not detected.
+        // MAYBE this should go in the FileSystemHelper module?
+        if path.Contains(" ") then
+            if (path.StartsWith("\"") && path.EndsWith("\"")) || (path.StartsWith("'") && path.EndsWith("'")) then path
+            else sprintf "\"%s\"" path
+        else path
+        
+    let inputFiles = inputFiles |> Seq.map ensureQuotedPath |> Seq.toList
     let taskDesc = inputFiles |> separated ", "
     let cscParams = setParams CscParams.Default
 
-    let output = if cscParams.Output <> "" then [sprintf "/out:%s" cscParams.Output] else []
+    let output = if cscParams.Output <> "" then [sprintf "/out:%s" (ensureQuotedPath cscParams.Output)] else []
     let target =
         match cscParams.Target with
         | Exe -> [ "/target:exe" ]
@@ -98,7 +108,7 @@ let csc (setParams : CscParams -> CscParams) (inputFiles : string list) : int =
         | AnyCpu -> [ "/platform:anycpu" ]
     let references =
         cscParams.References
-        |> List.map (fun r -> sprintf "/reference:%s" r)
+        |> List.map (ensureQuotedPath >> (sprintf "/reference:%s"))
     let debug = if cscParams.Debug then [ "/debug" ] else []
     let argList =
         output @ target @ platform @ references @ debug @ cscParams.OtherParams


### PR DESCRIPTION
Tests invoking csc.exe were failing when paths contained a space.  Updated csc invocation to ensure quote references, output path and input file paths when a space is detected and not already quoted.

Tried to be light touch and backwards compatible.  Not sure how widely used CscHelper is used in the wild.