### PR TITLE
[WIP] General FAKE improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ release.cmd
 Samples/typescript/out/
 help/RELEASE_NOTES.md
 paket.exe
+paket-files/
 
 # Ignore the Vagrant local directories
 .vagrant/*

--- a/build.fsx
+++ b/build.fsx
@@ -158,9 +158,10 @@ Target "Bootstrap" (fun _ ->
         let clear () =
             // Will make sure the test call actually compiles the script.
             // Note: We cannot just clean .fake here as it might be locked by the currently executing code :)
-            Directory.EnumerateFiles(".fake")
-              |> Seq.filter (fun s -> (Path.GetFileName s).StartsWith script)
-              |> Seq.iter File.Delete
+            if Directory.Exists ".fake" then
+                Directory.EnumerateFiles(".fake")
+                  |> Seq.filter (fun s -> (Path.GetFileName s).StartsWith script)
+                  |> Seq.iter File.Delete
         let executeTarget target =
             if clearCache then clear ()
             ExecProcess (fun info ->

--- a/build.fsx
+++ b/build.fsx
@@ -152,6 +152,7 @@ Target "Test" (fun _ ->
 
 Target "Bootstrap" (fun _ ->
     let buildScript = "build.fsx"
+    let testScript = "testbuild.fsx"
     // Check if we can build ourself with the new binaries.
     let test clearCache script =
         let clear () =
@@ -160,7 +161,6 @@ Target "Bootstrap" (fun _ ->
             Directory.EnumerateFiles(".fake")
               |> Seq.filter (fun s -> (Path.GetFileName s).StartsWith script)
               |> Seq.iter File.Delete
-            File.Copy(buildScript, script, true)
         let executeTarget target =
             if clearCache then clear ()
             ExecProcess (fun info ->
@@ -173,7 +173,10 @@ Target "Bootstrap" (fun _ ->
 
         let result = executeTarget "FailFast"
         if result = 0 then failwith "Bootstrapping failed"
-    let testScript = "testbuild.fsx"
+
+    File.ReadAllText buildScript
+    |> fun s -> s.Replace("#I @\"packages/build/FAKE/tools/\"", "#I @\"build/\"")
+    |> fun text -> File.WriteAllText(testScript, text)
 
     try
       // Will compile the script.

--- a/build.fsx
+++ b/build.fsx
@@ -9,6 +9,7 @@ open System.IO
 open SourceLink
 open Fake.ReleaseNotesHelper
 
+
 // properties
 let projectName = "FAKE"
 let projectSummary = "FAKE - F# Make - Get rid of the noise in your build scripts."
@@ -149,6 +150,39 @@ Target "Test" (fun _ ->
     |>  xUnit id
 )
 
+Target "Bootstrap" (fun _ ->
+    let buildScript = "build.fsx"
+    // Check if we can build ourself with the new binaries.
+    let test clearCache script =
+        let clear () =
+            // Will make sure the test call actually compiles the script.
+            // Note: We cannot just clean .fake here as it might be locked by the currently executing code :)
+            Directory.EnumerateFiles(".fake")
+              |> Seq.filter (fun s -> (Path.GetFileName s).StartsWith script)
+              |> Seq.iter File.Delete
+            File.Copy(buildScript, script, true)
+        let executeTarget target =
+            if clearCache then clear ()
+            ExecProcess (fun info ->
+                info.FileName <- "build/FAKE.exe"
+                info.WorkingDirectory <- "."
+                info.Arguments <- sprintf "%s %s -pd" script target) (System.TimeSpan.FromMinutes 3.0)
+
+        let result = executeTarget "PrintColors"
+        if result <> 0 then failwith "Bootstrapping failed"
+
+        let result = executeTarget "FailFast"
+        if result = 0 then failwith "Bootstrapping failed"
+    let testScript = "testbuild.fsx"
+
+    try
+      // Will compile the script.
+      test true testScript
+      // Will use the compiled/cached version.
+      test false testScript
+    finally File.Delete(testScript)
+)
+
 Target "SourceLink" (fun _ ->
     !! "src/app/**/*.fsproj" 
     |> Seq.iter (fun f ->
@@ -287,7 +321,18 @@ Target "Release" (fun _ ->
     Branches.tag "" release.NugetVersion
     Branches.pushTag "" "origin" release.NugetVersion
 )
-
+open System
+Target "PrintColors" (fun s ->
+  let color (color: ConsoleColor) (code : unit -> _) =
+      let before = Console.ForegroundColor
+      try
+        Console.ForegroundColor <- color
+        code ()
+      finally
+        Console.ForegroundColor <- before
+  color ConsoleColor.Magenta (fun _ -> printfn "TestMagenta")
+)
+Target "FailFast" (fun _ -> failwith "fail fast")
 Target "Default" DoNothing
 
 // Dependencies
@@ -296,6 +341,7 @@ Target "Default" DoNothing
     ==> "BuildSolution"
     //==> "ILRepack"
     ==> "Test"
+    ==> "Bootstrap"
     ==> "Default"
     ==> "CopyLicense"
     =?> ("GenerateDocs", isLocalBuild && not isLinux)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -38,6 +38,8 @@ nuget FluentMigrator.Runner
 nuget HashLib
 nuget FSharp.Compiler.Service
 
+github matthid/Yaaf.FSharp.Scripting src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs
+
 group Build
 content: none
 source http://nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -81,7 +81,10 @@ NUGET
     xunit.extensions (1.9.2)
       xunit (1.9.2)
     xunit.runners (1.9.2)
-
+GITHUB
+  remote: matthid/Yaaf.FSharp.Scripting
+  specs:
+    src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs (8295ec5cacc78c7b1eb369d7cd72fcd81f9c8ff7)
 GROUP Build
 CONTENT: NONE
 NUGET

--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -55,7 +55,9 @@ try
         | Choice1Of2(fakeArgs) ->
             
             //Break to allow a debugger to be attached here
-            if fakeArgs.Contains <@ Cli.Break @> then Diagnostics.Debugger.Break()
+            if fakeArgs.Contains <@ Cli.Break @> then
+                Diagnostics.Debugger.Launch() |> ignore
+                Diagnostics.Debugger.Break() |> ignore
 
             //Boot and version force us to ignore other args, so check for them and handle.
             let isBoot, bootArgs = fakeArgs.Contains <@ Cli.Boot @>, fakeArgs.GetResults <@ Cli.Boot @>
@@ -162,3 +164,5 @@ try
 
 finally
     traceEndBuild()
+    if !TargetHelper.ExitCode.exitCode <> 0 then exit !TargetHelper.ExitCode.exitCode
+    if Environment.ExitCode <> 0 then exit Environment.ExitCode

--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -9,6 +9,7 @@ open System.Diagnostics
 open System.Threading
 open System.Text.RegularExpressions
 open System.Xml.Linq
+open Yaaf.FSharp.Scripting
 
 let private FSIPath = @".\tools\FSharp\;.\lib\FSharp\;[ProgramFilesX86]\Microsoft SDKs\F#\4.0\Framework\v4.0;[ProgramFilesX86]\Microsoft SDKs\F#\3.1\Framework\v4.0;[ProgramFilesX86]\Microsoft SDKs\F#\3.0\Framework\v4.0;[ProgramFiles]\Microsoft F#\v4.0\;[ProgramFilesX86]\Microsoft F#\v4.0\;[ProgramFiles]\FSharp-2.0.0.0\bin\;[ProgramFilesX86]\FSharp-2.0.0.0\bin\;[ProgramFiles]\FSharp-1.9.9.9\bin\;[ProgramFilesX86]\FSharp-1.9.9.9\bin\"
 
@@ -203,59 +204,33 @@ type private AssemblySource =
 | Disk
 
 let hashRegex = Text.RegularExpressions.Regex("(?<script>.+)_(?<hash>[a-zA-Z0-9]+\.dll$)", System.Text.RegularExpressions.RegexOptions.Compiled)
-/// Run the given FAKE script with fsi.exe at the given working directory. Provides full access to Fsi options and args. Redirect output and error messages.
-let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(fsiOptions, scriptPath, scriptArgs)) env onErrMsg onOutMsg useCache cleanCache =
 
-    if printDetails then traceFAKE "Running Buildscript: %s" scriptPath
+type private CacheInfo =
+  {
+    ScriptFileName : string
+    AssemblyPath : string
+    AssemblyWarningsPath : string
+    CacheConfigPath : string
+    CacheConfig : Lazy<Cache.CacheConfig>
+    IsValid : bool
+  }
 
-    // Add arguments to the Environment
-    for (k,v) in env do
-      Environment.SetEnvironmentVariable(k, v, EnvironmentVariableTarget.Process)
-
-    // Create an env var that only contains the build script args part from the --fsiargs (or "").
-    Environment.SetEnvironmentVariable("fsiargs-buildscriptargs", String.Join(" ", scriptArgs))
-
-    let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration()
-
-    let options =
-        [ "fsi.exe"; "--noninteractive" ] @ fsiOptions
-        |> List.toArray
-
-    let sbOut = Text.StringBuilder()
-    let sbErr = Text.StringBuilder()
-    let handleMessages() =
-        let handleMessagesFrom (sb:Text.StringBuilder) onMsg =
-            let s = sb.ToString()
-            if not <| String.IsNullOrEmpty s
-                then onMsg s
-        handleMessagesFrom sbOut onOutMsg
-        handleMessagesFrom sbErr onErrMsg
-    let handleException (ex : Exception) = 
-        onErrMsg (ex.ToString())
-
-    use outStream = new StringWriter(sbOut)
-    use errStream = new StringWriter(sbErr)
-    use stdin = new StreamReader(Stream.Null)
-
-    let scriptPath =
-        if Path.IsPathRooted scriptPath then
-            scriptPath
-        else
-            Path.Combine(Directory.GetCurrentDirectory(), scriptPath)
-        
+let private getCacheInfoFromScript printDetails fsiOptions scriptPath =
     let allScriptContents = getAllScripts scriptPath
     let scriptHash = lazy (getScriptHash allScriptContents fsiOptions)
     //TODO this is only calculating the hash for the input file, not anything #load-ed
     
-    let scriptFileName = lazy(Path.GetFileName(scriptPath))
-    let hashPath = lazy("./.fake/" + scriptFileName.Value + "_" + scriptHash.Value)
-    let assemblyPath = lazy(hashPath.Value + ".dll")
-    let cacheConfigPath = lazy(hashPath.Value + "_config.xml")
-    let cacheConfig = lazy(Cache.read cacheConfigPath.Value)
-    let cacheValid = lazy (
+    let scriptFileName = Path.GetFileName(scriptPath)
+    let hashPath = "./.fake/" + scriptFileName + "_" + scriptHash.Value
+    let assemblyPath = hashPath + ".dll"
+    let assemblyWarningsPath = hashPath + "_warnings.txt"
+    let cacheConfigPath = hashPath + "_config.xml"
+    let cacheConfig = lazy Cache.read cacheConfigPath
+    let cacheValid =
         let cacheFilesExist = 
-            System.IO.File.Exists(assemblyPath.Value) &&
-            System.IO.File.Exists(cacheConfigPath.Value) 
+            File.Exists(assemblyPath) &&
+            File.Exists(cacheConfigPath) &&
+            File.Exists(assemblyWarningsPath)
         if cacheFilesExist then
             let loadedAssemblies =
                 cacheConfig.Value.Assemblies
@@ -302,37 +277,86 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
             assemVersionValidCount = Seq.length cacheConfig.Value.Assemblies
         else
             false
-    )
+    { ScriptFileName = scriptFileName
+      AssemblyPath = assemblyPath
+      AssemblyWarningsPath = assemblyWarningsPath
+      CacheConfigPath = cacheConfigPath
+      CacheConfig = cacheConfig
+      IsValid = cacheValid }
 
+/// Run the given FAKE script with fsi.exe at the given working directory. Provides full access to Fsi options and args. Redirect output and error messages.
+let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(fsiOptions, scriptPath, scriptArgs)) env onErrMsg onOutMsg useCache cleanCache =
+
+    if printDetails then traceFAKE "Running Buildscript: %s" scriptPath
+
+    // Add arguments to the Environment
+    for (k,v) in env do
+      Environment.SetEnvironmentVariable(k, v, EnvironmentVariableTarget.Process)
+
+    // Create an env var that only contains the build script args part from the --fsiargs (or "").
+    Environment.SetEnvironmentVariable("fsiargs-buildscriptargs", String.Join(" ", scriptArgs))
+
+    let options =
+        (FsiOptions.Default.AsArgs |> Array.toList) @ fsiOptions
+        |> FsiOptions.ofArgs
+
+    let handleException (ex : Exception) =
+        onErrMsg (ex.ToString())
+
+    let scriptPath =
+        if Path.IsPathRooted scriptPath then
+            scriptPath
+        else
+            Path.Combine(Directory.GetCurrentDirectory(), scriptPath)
+
+    let cacheInfo = getCacheInfoFromScript printDetails fsiOptions scriptPath
     let getScriptAndHash fileName =
         let matched = hashRegex.Match(fileName)
         matched.Groups.Item("script").Value, matched.Groups.Item("hash").Value
 
-    if useCache && cacheValid.Value then
+    if useCache && cacheInfo.IsValid then
         
         if printDetails then trace "Using cache"
-        let noExtension = Path.GetFileNameWithoutExtension(scriptFileName.Value)
-        let fullName = 
-            sprintf "<StartupCode$FSI_0001>.$FSI_0001_%s%s$%s" 
-                (noExtension.Substring(0, 1).ToUpper())
-                (noExtension.Substring(1))
-                (Path.GetExtension(scriptFileName.Value).Substring(1))
+        let noExtension = Path.GetFileNameWithoutExtension(cacheInfo.ScriptFileName)
 
-        let assembly = Reflection.Assembly.LoadFrom(assemblyPath.Value)
-
-        let mainModule = assembly.GetType(fullName)
-        
+        let startString = "<StartupCode$FSI_"
+        let endString =
+          sprintf "_%s%s$%s"
+            (noExtension.Substring(0, 1).ToUpper())
+            (noExtension.Substring(1))
+            (Path.GetExtension(cacheInfo.ScriptFileName).Substring(1))
+        let fullName i = sprintf "%s%s>.$FSI_%s%s" startString i i endString
+        let exampleName = fullName "0001"
+        let parseName (n:string) =
+            if n.Length >= exampleName.Length &&
+               n.Substring(0, startString.Length) = startString &&
+               n.Substring(n.Length - endString.Length) = endString then
+                let num = n.Substring(startString.Length, 4)
+                assert (fullName num = n)
+                Some (num)
+            else None
         try
-            let _result = 
-                mainModule.InvokeMember(
-                    "main@",
-                    BindingFlags.InvokeMethod ||| BindingFlags.Public ||| BindingFlags.Static, 
-                    null, null, [||])
-            true
-        with
-        | ex ->
-            handleException ex
-            false
+            match Reflection.Assembly.LoadFrom(cacheInfo.AssemblyPath)
+                  .GetTypes()
+                  |> Seq.filter (fun t -> parseName t.FullName |> Option.isSome)
+                  |> Seq.tryHead with
+            | Some mainModule ->
+              try
+                  mainModule.InvokeMember(
+                      "main@",
+                      BindingFlags.InvokeMethod ||| BindingFlags.Public ||| BindingFlags.Static,
+                      null, null, [||])
+                  |> ignore
+                  true
+              with
+              | ex ->
+                  handleException ex
+                  false
+            | None -> failwithf "We could not find a type similar to '%s' in the cached assembly!" exampleName
+        finally
+            try
+                traceFAKE "%s" (File.ReadAllText cacheInfo.AssemblyWarningsPath)
+            with e -> traceError (e.ToString())
     else
         let cacheDir = DirectoryInfo(Path.Combine(".",".fake"))
         if useCache then
@@ -341,7 +365,7 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
                     cacheDir.GetFiles()
                     |> Seq.filter(fun file -> 
                         let oldScriptName, _ = getScriptAndHash(file.Name)
-                        oldScriptName = scriptFileName.Value)
+                        oldScriptName = cacheInfo.ScriptFileName)
 
                 if (oldFiles |> Seq.length) > 0 then
                     if cleanCache then
@@ -352,79 +376,92 @@ let internal runFAKEScriptWithFsiArgsAndRedirectMessages printDetails (FsiArgs(f
                     if printDetails then trace "Cache doesn't exist"
             else
                 if printDetails then trace "Cache doesn't exist"
+
+        // Contains warnings and errors about the build script.
+        let fsiErrorOutput = new System.Text.StringBuilder()
+        let session =
+          try ScriptHost.Create
+                (options, preventStdOut = true,
+                  fsiErrWriter = ScriptHost.CreateForwardWriter
+                    ((fun s ->
+                        if String.IsNullOrWhiteSpace s |> not then
+                            fsiErrorOutput.AppendLine s |> ignore),
+                      removeNewLines = true),
+                  outWriter = ScriptHost.CreateForwardWriter onOutMsg,
+                  errWriter = ScriptHost.CreateForwardWriter onErrMsg)
+          with :? FsiEvaluationException as e ->
+              traceError "FsiEvaluationSession could not be created."
+              traceError e.Result.Error.Merged
+              reraise ()
+
         try
-            let session = FsiEvaluationSession.Create(fsiConfig, options, stdin, outStream, errStream)
             try
                 session.EvalScript scriptPath
-
-                try
-                    if useCache && not cacheValid.Value then
-                        let assemBuilder = session.DynamicAssembly :?> System.Reflection.Emit.AssemblyBuilder
-                        assemBuilder.Save("FSI-ASSEMBLY.dll")
-                        if not <| Directory.Exists cacheDir.FullName then
-                            let di = Directory.CreateDirectory cacheDir.FullName 
-                            di.Attributes <- FileAttributes.Directory ||| FileAttributes.Hidden
-
-                        let destinationFile = FileInfo(assemblyPath.Value)
-                        let targetDirectory = destinationFile.Directory
-
-                        if (not <| targetDirectory.Exists) then targetDirectory.Create()
-                        if (destinationFile.Exists) then destinationFile.Delete()
-
-                        File.Move("FSI-ASSEMBLY.dll", assemblyPath.Value)
-                    
-                        if File.Exists("FSI-ASSEMBLY.pdb") then
-                            File.Delete("FSI-ASSEMBLY.pdb")
-                        if File.Exists("FSI-ASSEMBLY.dll.mdb") then
-                            File.Delete("FSI-ASSEMBLY.dll.mdb")
-
-                        let dynamicAssemblies = 
-                            System.AppDomain.CurrentDomain.GetAssemblies()
-                            |> Seq.filter(fun assem -> assem.IsDynamic)
-                            |> Seq.map(fun assem -> assem.GetName().Name)
-                            |> Seq.filter(fun assem -> assem <> "FSI-ASSEMBLY")
-                            // General Reflection.Emit helper (most likely harmless to ignore)
-                            |> Seq.filter(fun assem -> assem <> "Anonymously Hosted DynamicMethods Assembly")
-                            // RazorEngine generated
-                            |> Seq.filter(fun assem -> assem <> "RazorEngine.Compilation.ImpromptuInterfaceDynamicAssembly")
-                            |> Seq.cache
-                        if dynamicAssemblies |> Seq.length > 0 then
-                            let msg =
-                                sprintf "Dynamic assemblies were generated during evaluation of script (%s).\nCan not save cache." 
-                                    (System.String.Join(", ", dynamicAssemblies))
-                            trace msg
-
-                        else
-                            let assemblies = 
-                                System.AppDomain.CurrentDomain.GetAssemblies()
-                                |> Seq.filter(fun assem -> not assem.IsDynamic)
-                                // They are not dynamic, but can't be re-used either.
-                                |> Seq.filter(fun assem -> not <| assem.GetName().Name.StartsWith("CompiledRazorTemplates.Dynamic.RazorEngine_"))
-                        
-                            let cacheConfig : XDocument = Cache.create assemblies
-                            cacheConfig.Save(cacheConfigPath.Value) 
-                            if printDetails then trace (System.Environment.NewLine + "Saved cache")
-                with 
-                | ex ->
-                    handleException ex
-                    reraise()
-                // TODO: Reactivate when FCS don't show output any more 
-                // handleMessages()
                 true
-            with
-            | _ex ->
-                handleMessages()
+            with :? FsiEvaluationException as eval ->
+                // Write Script Warnings & Errors at the end
+                handleException eval
                 false
-        with
-        | exn ->
-            traceError "FsiEvaluationSession could not be created."
-            traceError <| sbErr.ToString()
-            raise exn
+        finally
+            // Write Script Warnings & Errors at the end
+            traceFAKE "%O" fsiErrorOutput
+            // Cache in the error case as well.
+            try
+                if useCache && not cacheInfo.IsValid then
+                    session.DynamicAssemblyBuilder.Save("FSI-ASSEMBLY.dll")
+                    if not <| Directory.Exists cacheDir.FullName then
+                        let di = Directory.CreateDirectory cacheDir.FullName
+                        di.Attributes <- FileAttributes.Directory ||| FileAttributes.Hidden
+
+                    let destinationFile = FileInfo(cacheInfo.AssemblyPath)
+                    let targetDirectory = destinationFile.Directory
+
+                    if (not <| targetDirectory.Exists) then targetDirectory.Create()
+                    if (destinationFile.Exists) then destinationFile.Delete()
+
+                    File.WriteAllText(cacheInfo.AssemblyWarningsPath, fsiErrorOutput.ToString())
+                    File.Move("FSI-ASSEMBLY.dll", cacheInfo.AssemblyPath)
+                    
+                    if File.Exists("FSI-ASSEMBLY.pdb") then
+                        File.Delete("FSI-ASSEMBLY.pdb")
+                    if File.Exists("FSI-ASSEMBLY.dll.mdb") then
+                        File.Delete("FSI-ASSEMBLY.dll.mdb")
+
+                    let dynamicAssemblies =
+                        System.AppDomain.CurrentDomain.GetAssemblies()
+                        |> Seq.filter(fun assem -> assem.IsDynamic)
+                        |> Seq.map(fun assem -> assem.GetName().Name)
+                        |> Seq.filter(fun assem -> assem <> "FSI-ASSEMBLY")
+                        // General Reflection.Emit helper (most likely harmless to ignore)
+                        |> Seq.filter(fun assem -> assem <> "Anonymously Hosted DynamicMethods Assembly")
+                        // RazorEngine generated
+                        |> Seq.filter(fun assem -> assem <> "RazorEngine.Compilation.ImpromptuInterfaceDynamicAssembly")
+                        |> Seq.cache
+                    if dynamicAssemblies |> Seq.length > 0 then
+                        let msg =
+                            sprintf "Dynamic assemblies were generated during evaluation of script (%s).\nCan not save cache."
+                                (System.String.Join(", ", dynamicAssemblies))
+                        trace msg
+
+                    else
+                        let assemblies =
+                            System.AppDomain.CurrentDomain.GetAssemblies()
+                            |> Seq.filter(fun assem -> not assem.IsDynamic)
+                            // They are not dynamic, but can't be re-used either.
+                            |> Seq.filter(fun assem -> not <| assem.GetName().Name.StartsWith("CompiledRazorTemplates.Dynamic.RazorEngine_"))
+                        
+                        let cacheConfig : XDocument = Cache.create assemblies
+                        cacheConfig.Save(cacheInfo.CacheConfigPath)
+                        if printDetails then trace (System.Environment.NewLine + "Saved cache")
+            with ex ->
+                handleException ex
+                reraise()
 
 /// Run the given buildscript with fsi.exe and allows for extra arguments to the script. Returns output.
 let executeBuildScriptWithArgsAndReturnMessages script (scriptArgs: string[]) useCache cleanCache =
     let messages = ref []
     let appendMessage isError msg =
+        traceUnknown msg // Some test code expects that the executed script writes to stdout
         messages := { IsError = isError
                       Message = msg
                       Timestamp = DateTimeOffset.UtcNow } :: !messages
@@ -438,7 +475,7 @@ let executeBuildScriptWithArgsAndReturnMessages script (scriptArgs: string[]) us
 let runBuildScriptWithFsiArgsAt printDetails (FsiArgs(fsiOptions, script, scriptArgs)) env useCache cleanCache =
     runFAKEScriptWithFsiArgsAndRedirectMessages
         printDetails (FsiArgs(fsiOptions, script, scriptArgs)) env
-        traceError (fun s-> traceFAKE "%s" s)
+        traceError traceUnknown
         useCache
         cleanCache
 

--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -16,7 +16,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
@@ -30,12 +30,16 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\..\build\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\..\build\FakeLib.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\paket-files\matthid\Yaaf.FSharp.Scripting\src\source\Yaaf.FSharp.Scripting\YaafFSharpScripting.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/YaafFSharpScripting.fs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="UserInputHelper.fs" />
     <Compile Include="CSharpHelper.fs" />

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -278,7 +278,6 @@ let targetError targetName (exn:System.Exception) =
         | _ -> exn.ToString()
 
     let msg = sprintf "%s%s" (error exn) (if exn.InnerException <> null then "\n" + (exn.InnerException |> error) else "")
-            
     traceError <| sprintf "Running build failed.\nError:\n%s" msg
 
     let isFailedTestsException = exn :? UnitTestCommon.FailedTestsException
@@ -427,7 +426,9 @@ let WriteTaskTimeSummary total =
 
     traceLine()
 
-let private changeExitCodeIfErrorOccured() = if errors <> [] then exit 42 
+module ExitCode =
+    let exitCode = ref 0
+let private changeExitCodeIfErrorOccured() = if errors <> [] then Environment.ExitCode <- 42; ExitCode.exitCode := 42
    
 /// [omit]
 let isListMode = hasBuildParam "list"

--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -32,6 +32,9 @@ let logVerbosefn fmt =
 /// Writes a trace to the command line (in green)
 let trace message = postMessage (TraceMessage(message, true))
 
+/// Writes a trace to the command line (in the current console color)
+let traceUnknown message = postMessage (UnknownMessage(message, false))
+
 /// Writes a message to the command line (in green)
 let tracefn fmt = Printf.ksprintf trace fmt
 

--- a/src/app/FakeLib/UserInputHelper.fs
+++ b/src/app/FakeLib/UserInputHelper.fs
@@ -38,10 +38,11 @@ let internal readString (echo: bool) : string =
 
 let internal color (color: ConsoleColor) (code : unit -> _) =
     let before = Console.ForegroundColor
-    Console.ForegroundColor <- color
-    let result = code ()
-    Console.ForegroundColor <- before
-    result
+    try
+      Console.ForegroundColor <- color
+      code ()
+    finally
+      Console.ForegroundColor <- before
     
 /// Return a string entered by the user followed by enter. The input is echoed to the screen.
 let getUserInput prompt =

--- a/src/app/FakeLib/paket.references
+++ b/src/app/FakeLib/paket.references
@@ -1,3 +1,4 @@
+File: YaafFSharpScripting.fs
 FSharp.Core
 FSharp.Compiler.Service
 Mono.Web.Xdt


### PR DESCRIPTION
- Reintroduction of https://github.com/fsharp/FAKE/issues/794
- Print code-warnings (for example deprecation warnings) at the end of the build script.
- Add a bootstrapping step to build.fsx which checks if the newly generated FAKE.exe can handle caching, compiling, failing and non-failing build steps.
- Call Diagnostics.Debugger.Launch when `-br` is given.
- Refactor `runFAKEScriptWithFsiArgsAndRedirectMessages` a bit.
- Don't call `exit` too early otherwise finally blocks are not called properly -> warnings are not shown and script is not cached.

I'd like to make smaller commits but most of this stuff is related one way or another. I may be able to split the first point from the others if you wish (by printing warnings at the top).
