### PR TITLE
Add shared sln R# settings with ShadowCopy off.

### DIFF
--- a/FAKE.sln.DotSettings
+++ b/FAKE.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
FAKE tests that depend on files can't be run when R# is set to shadow copy assemblies being tested.  This file switches this off for all R# users that have the shared sln settings enabled.

Requested by @forki in #992.

NOTE:  This means you can't build the sln, while your tests are running.