### PR TITLE
Support target and args in build.cmd on Windows.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -13,8 +13,10 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
-SET TARGET=Default
+SET FAKE_PATH=packages\build\FAKE\tools\Fake.exe
 
-IF NOT [%1]==[] (SET TARGET=%~1)
-
-"packages\build\FAKE\tools\Fake.exe" "build.fsx" "target="%TARGET%""
+IF [%1]==[] (
+    "%FAKE_PATH%" "build.fsx" "Default" 
+) ELSE (
+    "%FAKE_PATH%" "build.fsx" %* 
+) 


### PR DESCRIPTION
For example, enable `build.cmd CreateNuget -st` by passing all args from build.cmd to
FAKE, if build.cmd has at least one arg.