### PR TITLE
Fix case sensitivity on package name when search references in Paket.lock

### DIFF
--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -167,13 +167,13 @@ let GetDependenciesForReferencesFile (referencesFile:string) =
                 if fi.Exists then fi.FullName else find fi.Directory.Parent.FullName
             find <| FileInfo(referencesFile).Directory.FullName
         
-        let breakInParts (line : string) = Regex.Match(line,"^[ ]{4}([^ ].+) \((.+)\)")
+        let breakInParts (line : string) = match Regex.Match(line,"^[ ]{4}([^ ].+) \((.+)\)") with
+                                           | m when m.Success && m.Groups.Count = 3 -> Some (m.Groups.[1].Value, m.Groups.[2].Value)
+                                           | _ -> None
 
         getPaketLockFile
         >> File.ReadAllLines
-        >> Array.map breakInParts
-        >> Array.filter (fun x -> x.Success && x.Groups.Count = 3)
-        >> Array.map (fun x -> x.Groups.[1].Value, x.Groups.[2].Value)
+        >> Array.choose breakInParts
 
     let refLines = getReferenceFilePackages referencesFile
 

--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -167,10 +167,11 @@ let GetDependenciesForReferencesFile (referencesFile:string) =
         find <| FileInfo(referencesFile).Directory.FullName
 
     let lines = File.ReadAllLines(lockFile)
+                |> Array.map (fun s -> s.Trim())
 
     let getVersion package =
-        let line = lines |> Array.find (fun l -> l.StartsWith("    " + package))
-        let start = line.Replace("    " + package + " (","")
+        let line = lines |> Array.find (fun l -> l.StartsWith(package, StringComparison.InvariantCultureIgnoreCase))
+        let start = line.Replace(package + " (","")
         start.Substring(0,start.IndexOf(")"))
 
     nugetLines

--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -167,11 +167,10 @@ let GetDependenciesForReferencesFile (referencesFile:string) =
                 if fi.Exists then fi.FullName else find fi.Directory.Parent.FullName
             find <| FileInfo(referencesFile).Directory.FullName
         
-        let breakInParts (line : string) = Regex.Match(line,"(.+) \((.+)\)")
+        let breakInParts (line : string) = Regex.Match(line,"^[ ]{4}([^ ].+) \((.+)\)")
 
         getPaketLockFile
         >> File.ReadAllLines
-        >> Array.map (fun s -> s.Trim())
         >> Array.map breakInParts
         >> Array.filter (fun x -> x.Success && x.Groups.Count = 3)
         >> Array.map (fun x -> x.Groups.[1].Value, x.Groups.[2].Value)


### PR DESCRIPTION
I get a "KeyNotFoundException" when I try to match my references from "paket.references" with those in "paket.lock" because sometimes cases are not the same on package name.
