### PR TITLE
WIP Warn when fail to parse cmd line args. Close #1082

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -126,6 +126,12 @@ try
 
         //None of the new style args parsed, so revert to the old skool.
         | Choice2Of2(ex) ->
+
+            // #1082 print a warning as we've been invoked with invalid OR old-style args.
+            traceImportant "Error parsing command line arguments.  You have a mistake in your args, or are using the pre-2.1.8 argument style:"
+            exceptionAndInnersToString ex |> traceImportant
+            trace "Attempting to run with pre-version 2.18 argument style, for backwards compat."
+
             if (cmdArgs.Length = 2 && paramIsHelp cmdArgs.[1]) || (cmdArgs.Length = 1 && List.length buildScripts = 0) then printUsage () else
             match Boot.ParseCommandLine(cmdArgs) with
             | None ->

--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -52,8 +52,9 @@ let traceFAKE fmt = Printf.ksprintf (fun text -> postMessage (ImportantMessage t
 let traceError error = postMessage (ErrorMessage error)
 
 open Microsoft.FSharp.Core.Printf
-/// Traces an exception details (in red)
-let traceException (ex:Exception) =
+
+/// Converts an exception and its inner exceptions to a nice string.
+let exceptionAndInnersToString (ex:Exception) =
     let sb = Text.StringBuilder()
     let delimeter = String.replicate 50 "*"
     let nl = Environment.NewLine
@@ -85,7 +86,10 @@ let traceException (ex:Exception) =
             if (e.InnerException <> null)
             then printException e.InnerException (count+1)
     printException ex 1
-    sb.ToString() |> traceError
+    sb.ToString()
+
+/// Traces an exception details (in red)
+let traceException (ex:Exception) = exceptionAndInnersToString ex |> traceError
 
 /// Traces the EnvironmentVariables
 let TraceEnvironmentVariables() = 


### PR DESCRIPTION
Print a warning when fail to parse command line args with Argu.  We still fall back to try and run with the pre-2.1.8 argument style.

Extracted exception formatting from the traceException function, so it could be used when tracing an exception as a warning.

This should help avoid confusion, as witnessed in #1072 and #594.

It looks like the image below.  This was the result of `ben.fsx target=Bob -st`, which is a mix of the old and new.  It is traced as a warning, but the text says `Error parsing command line arguments...`, so I'm not sure about the use of the word Error here.  We show the error and then in green, explain we are trying to fallback.  It would be good to get feedback on if this actually makes sense when you read it! 

![screen shot 2016-01-20 at 09 04 52](https://cloud.githubusercontent.com/assets/189409/12444183/3c16e1ac-bf55-11e5-86a3-afb9a77e81e6.png)
