### PR TITLE
Don't show the obsolete usage.

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -12,10 +12,6 @@ let printUsage () =
     printfn " FAKE usage"
     printfn "-------------------"
     Cli.printUsage ()
-    printfn "--------------------"
-    printfn " Classic FAKE usage"
-    printfn "--------------------"
-    CommandlineParams.printAllParams()
 
 let printEnvironment cmdArgs args =
     printVersion()


### PR DESCRIPTION
Maybe don't event advertise the old usage in the CLI :). See https://github.com/fsharp/FAKE/pull/1090