### PR TITLE
Disable NodeReuse on TeamCity, it can lead to consecutive builds failing

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -6,6 +6,7 @@ open System
 open System.IO
 open System.Configuration
 open System.Xml.Linq
+open BuildServerHelper
 
 /// A type to represent MSBuild project files.
 type MSBuildProject = XDocument
@@ -148,7 +149,7 @@ let mutable MSBuildDefaults =
       Properties = []
       MaxCpuCount = Some None
       NoLogo = false
-      NodeReuse = true
+      NodeReuse = not (buildServer = TeamCity)
       ToolsVersion = None
       Verbosity = None
       NoConsoleLogger = false


### PR DESCRIPTION
If nodereuse is on, TC can not clean files before after the nodes have been shut down (60 seconds
http://blogs.msdn.com/b/msbuild/archive/2007/04/16/node-reuse-in-multiproc-msbuild.aspx)
This means consecutive builds will fail. This might also be true for other build servers.

This was discussed in https://github.com/fsharp/FAKE/issues/1109
I don't think figuring out the clean-strategy from TC is straight forward, so I assume it's easier to just disable nodereuse on TC.