### PR TITLE
Wix directory hierarchy

### DIFF
--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -423,7 +423,27 @@ let getDirectoryId (directoryName : string) =
 
 ///create a directory component hierarchy from a root folder
 let rec bulkComponentTreeCreation fileFilter directoryInfo =
-    bulkComponentTreeSubCreation fileFilter directoryInfo ""    
+    let directories = directoryInfo
+                      |> subDirectories
+                      |> Seq.map (fun d -> bulkComponentTreeSubCreation fileFilter d directoryInfo.Name)
+    let components = directoryInfo
+                        |> filesInDir
+                        |> Seq.filter fileFilter
+                        |> Seq.map (fun file -> 
+                                        { 
+                                            Id = "f" + (file.Name).GetHashCode().ToString().Replace("-", "")
+                                            Name = file.Name
+                                            Source = file.FullName
+                                        })
+                        |> Seq.map(fun file->
+                                        C{
+                                            Id = "c" + file.Id.Substring(1)
+                                            Guid = "*"
+                                            Files = [file]
+                                            ServiceControls = []
+                                            ServiceInstalls = []
+                                        })
+    Seq.append directories components  
 and private bulkComponentTreeSubCreation fileFilter directoryInfo directoryId =    
     let directories = directoryInfo
                       |> subDirectories

--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -79,11 +79,13 @@ type InstallUninstall =
     | Install
     | Uninstall
     | Both
+    | Never
     override w.ToString() = 
         match w with
         | Install -> "install"
         | Uninstall -> "uninstall"
         | Both -> "both"
+        | Never -> null
 
 /// These are used in many methods for generating WiX nodes, regard them as booleans
 type YesOrNo = 
@@ -100,7 +102,7 @@ type WiXServiceControl =
         Id : string
         Name: string
         Remove : InstallUninstall
-        Start : InstallUninstall option
+        Start : InstallUninstall
         Stop : InstallUninstall
         Wait : YesOrNo
     }
@@ -109,9 +111,15 @@ type WiXServiceControl =
             {
                 yield ("Id", w.Id)
                 yield ("Name", w.Name)
-                yield ("Remove", w.Remove.ToString())
-                if w.Start.IsSome then yield ("Start", w.Start.Value.ToString())
-                yield ("Stop", w.Stop.ToString())
+                match w.Remove with
+                | Never -> ()
+                | _ -> yield ("Remove", w.Remove.ToString())
+                match w.Start with
+                | Never -> ()
+                | _ -> yield ("Start", w.Start.ToString())
+                match w.Stop with
+                | Never -> ()
+                | _ -> yield ("Stop", w.Stop.ToString())
                 yield ("Wait", w.Wait.ToString())
             }
     override w.ToString() = 
@@ -124,7 +132,7 @@ let WiXServiceControlDefaults =
         Id = "ServiceControl"
         Name = "Service"
         Remove = Both
-        Start = Some(Both)
+        Start = Install
         Stop = Both
         Wait = Yes
     }

--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -196,7 +196,7 @@ type WiXServiceDependency =
     member w.createAttributeList () =
         seq {           
             yield ("Id", w.Id)           
-            if w.Group.IsSome then yield ("Group", w.Group.Value.ToString())                         
+            if w.Group.IsSome then yield ("Group", w.Group.Value.ToString())
         }
     override w.ToString() =
         sprintf "<ServiceDependency%s />"
@@ -1150,6 +1150,9 @@ type Script =
 
         /// You can nest InstallExecuteSequence actions in here
         ActionSequences : WiXCustomActionExecution seq
+
+        /// You can add custom replacements for the wix xml here.
+        CustomReplacements: (string * string) seq
     }
 
 /// Default values for WiX Script properties
@@ -1173,6 +1176,7 @@ let ScriptDefaults =
         Features = []
         CustomActions = []
         ActionSequences = []
+        CustomReplacements = []
     }
 
 /// Generates WiX Template with specified file name (you can prepend location too)
@@ -1287,7 +1291,7 @@ let FillInWixScript wiXPath (setParams : WiXScript -> WiXScript) =
         "@Product.Features@", parameters.Features
         "@Product.CustomActions@", parameters.CustomActions
         "@Product.ActionSequences@", parameters.ActionSequences
-        "@Build.number@", parameters.BuildNumber]
+        "@Build.number@", parameters.BuildNumber]    
     processTemplates replacements wixScript
     
 /// Takes path where script files reside and sets all parameters as defined
@@ -1335,6 +1339,8 @@ let FillInWiXTemplate wiXPath setParams =
         "@Product.CustomActions@", Seq.fold(fun acc elem -> acc + elem.ToString()) "" parameters.CustomActions
         "@Product.ActionSequences@", Seq.fold(fun acc elem -> acc + elem.ToString()) "" parameters.ActionSequences
         "@Build.number@", parameters.BuildNumber]
+    let customReplacements = parameters.CustomReplacements |> Seq.map (fun (key, value) -> ((sprintf "@Custom.%s@" key), value)) |> List.ofSeq
+    let replacements = replacements @ customReplacements
     processTemplates replacements wixScript
 
 /// Generates a feature based on the given parameters, use toString on it when embedding it


### PR DESCRIPTION
Added the ability to create a full directory component hierarchy, where directories can contain components and directories.
Now you are able to use attachServiceControlToComponents and attachServiceInstallToComponents to on a directory component hierarchy.

There is on minor breaking change:
The property Start in WiXServiceControl is now an option to provide the ability not to start a service on install. If someone has set the property manually, the property has to be changed from e.g. Both to Some(Both)