### PR TITLE
Ensure that traceEndTask is called in DotCover

### DIFF
--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -182,18 +182,19 @@ let DotCoverReport (setParams: DotCoverReportParams -> DotCoverReportParams) =
 let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnitParams -> NUnitParams) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverNUnit" details
-
-    let parameters = NUnitDefaults |> setNUnitParams
-    let args = buildNUnitdArgs parameters assemblies
     
-    DotCover (fun p ->
-                  {p with
-                     TargetExecutable = parameters.ToolPath @@ parameters.ToolName
-                     TargetArguments = args
-                  } |> setDotCoverParams)
-
-    traceEndTask "DotCoverNUnit" details
+    traceStartTask "DotCoverNUnit" details
+    try
+        let parameters = NUnitDefaults |> setNUnitParams
+        let args = buildNUnitdArgs parameters assemblies
+    
+        DotCover (fun p ->
+                      {p with
+                         TargetExecutable = parameters.ToolPath @@ parameters.ToolName
+                         TargetArguments = args
+                      } |> setDotCoverParams)
+    finally
+        traceEndTask "DotCoverNUnit" details
 
 /// Runs the dotCover "cover" command against the NUnit test runner.
 /// ## Parameters
@@ -212,18 +213,19 @@ let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUni
 let DotCoverNUnit3 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnit3Params -> NUnit3Params) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverNUnit" details
 
-    let parameters = NUnit3Defaults |> setNUnitParams
-    let args = buildNUnit3Args parameters assemblies
+    traceStartTask "DotCoverNUnit3" details
+    try
+        let parameters = NUnit3Defaults |> setNUnitParams
+        let args = buildNUnit3Args parameters assemblies
     
-    DotCover (fun p ->
-                  {p with
-                     TargetExecutable = parameters.ToolPath
-                     TargetArguments = args
-                  } |> setDotCoverParams)
-
-    traceEndTask "DotCoverNUnit" details
+        DotCover (fun p ->
+                      {p with
+                         TargetExecutable = parameters.ToolPath
+                         TargetArguments = args
+                      } |> setDotCoverParams)
+    finally
+        traceEndTask "DotCoverNUnit3" details
 
 /// Runs the dotCover "cover" command against the XUnit2 test runner.
 /// ## Parameters

--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -182,8 +182,8 @@ let DotCoverReport (setParams: DotCoverReportParams -> DotCoverReportParams) =
 let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnitParams -> NUnitParams) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    
     traceStartTask "DotCoverNUnit" details
+
     try
         let parameters = NUnitDefaults |> setNUnitParams
         let args = buildNUnitdArgs parameters assemblies
@@ -213,8 +213,8 @@ let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUni
 let DotCoverNUnit3 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnit3Params -> NUnit3Params) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-
     traceStartTask "DotCoverNUnit3" details
+
     try
         let parameters = NUnit3Defaults |> setNUnitParams
         let args = buildNUnit3Args parameters assemblies
@@ -244,16 +244,17 @@ let DotCoverXUnit2 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setXUn
     let details =  assemblies |> separated ", "
     traceStartTask "DotCoverXUnit2" details
 
-    let parameters = XUnit2Defaults |> setXUnit2Params
-    let args = buildXUnit2Args assemblies parameters 
+    try
+        let parameters = XUnit2Defaults |> setXUnit2Params
+        let args = buildXUnit2Args assemblies parameters 
     
-    DotCover (fun p ->
-                  {p with
-                     TargetExecutable = parameters.ToolPath 
-                     TargetArguments = args
-                  } |> setDotCoverParams)
-
-    traceEndTask "DotCoverXUnit2" details
+        DotCover (fun p ->
+                      {p with
+                         TargetExecutable = parameters.ToolPath 
+                         TargetArguments = args
+                      } |> setDotCoverParams)
+    finally
+        traceEndTask "DotCoverXUnit2" details
 
 /// Builds the command line arguments from the given parameter record and the given assemblies.
 /// Runs all test assemblies in the same run for easier coverage management. 
@@ -291,16 +292,17 @@ let DotCoverMSTest (setDotCoverParams: DotCoverParams -> DotCoverParams) (setMST
     let details =  assemblies |> separated ", "
     traceStartTask "DotCoverMSTest " details
 
-    let parameters = MSTestDefaults |> setMSTestParams
-    let args = buildMSTestArgsForDotCover parameters assemblies
+    try
+        let parameters = MSTestDefaults |> setMSTestParams
+        let args = buildMSTestArgsForDotCover parameters assemblies
     
-    DotCover (fun p ->
-                  {p with
-                     TargetExecutable = parameters.ToolPath 
-                     TargetArguments = args
-                  } |> setDotCoverParams)
-
-    traceEndTask "DotCoverMSTest" details
+        DotCover (fun p ->
+                      {p with
+                         TargetExecutable = parameters.ToolPath 
+                         TargetArguments = args
+                      } |> setDotCoverParams)
+    finally
+        traceEndTask "DotCoverMSTest" details
 
 /// Runs the dotCover "cover" command against the MSpec test runner.
 /// ## Parameters
@@ -321,14 +323,15 @@ let DotCoverMSpec (setDotCoverParams: DotCoverParams -> DotCoverParams) (setMSpe
     let details =  assemblies |> separated ", "
     traceStartTask "DotCoverMSpec" details
 
-    let parameters = MSpecDefaults |> setMSpecParams            
+    try
+        let parameters = MSpecDefaults |> setMSpecParams            
    
-    let args = buildMSpecArgs parameters assemblies
+        let args = buildMSpecArgs parameters assemblies
     
-    DotCover (fun p ->
-                  {p with
-                     TargetExecutable = parameters.ToolPath
-                     TargetArguments = args
-                  } |> setDotCoverParams)
-
-    traceEndTask "DotCoverMSpec" details
+        DotCover (fun p ->
+                      {p with
+                         TargetExecutable = parameters.ToolPath
+                         TargetArguments = args
+                      } |> setDotCoverParams)
+    finally
+        traceEndTask "DotCoverMSpec" details


### PR DESCRIPTION
The `DotCover` function can throw if allowed to break the build on test errors and without a try/finally it could break the tag structure, generating an "Invalid tag structure" error.