### PR TITLE
Minor patch documentation FluentMigrator

### DIFF
--- a/help/fluentmigrator.md
+++ b/help/fluentmigrator.md
@@ -16,7 +16,7 @@ Usually your FAKE setup will look as follows:
     open Fake.FluentMigratorHelper
 
     // Assemblies with migrations
-    let assemblies = ["Migrations.dll"]
+    let assemblies = "Migrations.dll"
     
     // Using SQL Server 2014 LocalDB
     let connection = 
@@ -27,11 +27,11 @@ Usually your FAKE setup will look as follows:
     // Specify additional options or just use the defaults
     let options = {DefaultMigrationOptions with Profile="Staging"; Tags = ["US"; "Canada"]}
 
-    Target "Build" (fun _ 
+    Target "Build" (fun _ ->
         // Build your Migrations.dll assembly using MSBuild or whatever
     )
 
-    Target "MigrateDatabase" (fun _ 
+    Target "MigrateDatabase" (fun _ ->
         MigrateToLatest connection [assembly] options
     )
 

--- a/help/fluentmigrator.md
+++ b/help/fluentmigrator.md
@@ -16,7 +16,7 @@ Usually your FAKE setup will look as follows:
     open Fake.FluentMigratorHelper
 
     // Assemblies with migrations
-    let assemblies = "Migrations.dll"
+    let assembly = "Migrations.dll"
     
     // Using SQL Server 2014 LocalDB
     let connection = 


### PR DESCRIPTION
Just some little updates on the documentation to fix synthax errors. **I am not sure of me**.

But this is what I needed to start the migrations script.

For reference, here is my full Build.fsx :

```fsx
#r @"..\packages\FAKE.4.19.0\Tools\FakeLib.dll"
#r @"..\packages\FAKE.4.19.0\Tools\Fake.FluentMigrator.dll"

open Fake
open Fake.FluentMigratorHelper


let buildDir = "./build/"
// Assemblies with migrations
let assembly = buildDir @@ "Migration.dll"

// Using SQL Server 2014 LocalDB
let connection = 
  ConnectionString(
      @"Data Source=MMANGEL-PC\SQLEXPRESS;Initial Catalog=Herebris;Integrated Security=True",
      SqlServer(V2014))
      
// Specify additional options or just use the defaults
let options = DefaultMigrationOptions

Target "Clean" (fun _ ->
    CleanDir buildDir
)

Target "BuildAssembly" ( fun _ ->
    !! "./*.fsproj"
        |> MSBuildRelease buildDir "Build"
        |> Log "AppBuild-Output: "
)

Target "MigrateDatabase" (fun _ ->
    MigrateToLatest connection [assembly] options
)

"Clean"
    ==> "BuildAssembly" 
    ==> "MigrateDatabase"

RunTargetOrDefault "MigrateDatabase"
````
