### PR TITLE
remove none working code from FSC sample

### DIFF
--- a/help/fsc.md
+++ b/help/fsc.md
@@ -13,13 +13,6 @@ The `Fsc` task can be used in standard FAKE targets:
     open Fake
     open Fake.FscHelper
 
-    Target "Something.dll" (fun _ ->
-      !! "src/**/*.fs"
-      |> Fsc (fun p ->
-               { p with Output = "Something.dll"
-                        FscTarget = Library })
-    )
-
     Target "Otherthing.dll" (fun _ ->
       ["Otherthing.fs"; "Otherthing2.fs"]
       |> Fsc (fun p -> { p with FscTarget = Library })


### PR DESCRIPTION
The first sample would no longer work with FSC because `!! "src/**/*.fs"` will produce a sequence of string while Fsc only accepts a list of strings.

Anyway I don't think it make much sense to blindly pass all `.fs` unordered to Fsc.