### PR TITLE
Create separate environ variable helpers

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -34,6 +34,12 @@ let environVars target =
 /// Sets the environment variable with the given name
 let setEnvironVar name value = Environment.SetEnvironmentVariable(name, value)
 
+/// Sets the environment variable with the given name for the current user.
+let setUserEnvironVar name value = Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.User)
+
+/// Sets the environment variable with the given name for the current machine.
+let setMachineEnvironVar name value = Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Machine)
+
 /// Sets the environment variable with the given name for the current process.
 let setProcessEnvironVar name value = Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process)
 


### PR DESCRIPTION
Currently, `setProcessEnvironVar` is exactly the same as `setEnvironVar` as noted [here](https://msdn.microsoft.com/en-us/library/z46c489x(v=vs.110).aspx).

##### What has changed?
- Mark `setEnvironVar` as obsolete and note to use `setProcessEnvironVar`.

##### What has been added?
- Create individual environment variable setters that wrap the `Environment.SetEnvironmentVariable` method.