### PR TITLE
Fixed bug that prevented using directory names with spaces in WiX

### DIFF
--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -601,7 +601,7 @@ let getFileIdFromWiXString wiXString fileRegex =
         |> Seq.filter(fun line -> Regex.IsMatch(line, "Name=\"" + fileRegex + "\""))
         |> Seq.head
         // Substring starts immediately after "Id=" tag and is as long as the given file id
-        |> fun f -> f.Substring(f.IndexOf("Id=") + 4, Regex.Match(f, "Id=\"\S*\"").Length - 5)
+        |> fun f -> f.Substring(f.IndexOf("Id=") + 4, Regex.Match(f, "Id=\"[^\"]*\"").Length - 5)
 
 
 /// Retrieves all component ids from given WiX directory string
@@ -617,7 +617,7 @@ let getComponentIdsFromWiXString wiXString =
     // Filter for lines which have a name tag matching the given regex, pick the first and return its ID
     lines
         |> Seq.filter(fun line -> Regex.IsMatch(line, "<Component"))
-        |> Seq.map(fun f -> sprintf "<ComponentRef Id=\"%s\" />" (f.Substring(f.IndexOf("Id=") + 4, Regex.Match(f, "Id=\"\S*\"").Length - 5)))
+        |> Seq.map(fun f -> sprintf "<ComponentRef Id=\"%s\" />" (f.Substring(f.IndexOf("Id=") + 4, Regex.Match(f, "Id=\"[^\"]*\"").Length - 5)))
         |> System.String.Concat
 
 /// Creates WiX ComponentRef tags from the given DirectoryInfo

--- a/src/test/Test.FAKECore/WiXHelperSpec.cs
+++ b/src/test/Test.FAKECore/WiXHelperSpec.cs
@@ -30,4 +30,43 @@ namespace Test.FAKECore.WiXHelperSpec
 		private It should_return_a_proper_XML_tag_on_method_call_ToString = () => Arguments.ToString()
 			.ShouldContain("<Directory Id=\"1\" Name=\"Foo\"></Directory");
 	}
+
+    internal class When_Getting_Component_IDs_From_Directories
+    {
+        private static string Parameters;
+        private static string Arguments;
+
+        Establish context = () => {
+            Parameters = "<Component Id=\"1234\" Name=\"Folder Name With Spaces\">";
+        };
+
+        Because of = () => {
+            Arguments = WiXHelper.getComponentIdsFromWiXString(Parameters);
+            Console.WriteLine(Arguments.ToString());
+        };
+
+        private It should_return_the_Id_successfully = () => Arguments.ToString()
+            .ShouldEqual(WiXHelper.WiXComponentRefDefaults
+                            .With(p => p.Id, "1234")
+                            .ToString());
+    }
+
+    internal class When_Getting_File_IDs_From_Directories
+    {
+        private static string Parameters;
+        private static string Arguments;
+
+        Establish context = () =>
+        {
+            Parameters = "<File Id=\"5678 ABC\" Name=\"Test.exe\" Source=\"C:\\Some\\Path\" />";
+        };
+        
+        Because of = () => {
+            Arguments = WiXHelper.getFileIdFromWiXString(Parameters, @"\S*.exe");
+            Console.WriteLine(Arguments.ToString());
+        };
+
+        private It should_return_the_Id_successfully = () => Arguments.ToString()
+            .ShouldEqual("5678 ABC");
+    }
 }


### PR DESCRIPTION
This should resolve #1129.
Let's ask @devfunkd whether it resolves his issues.