### PR TITLE
use compileFiles in compile as instructed in [<Obsolete "Use FscHelpe…

### DIFF
--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -498,7 +498,7 @@ let compile (fscParams : FscParam list) (inputFiles : string list) : int =
     let fscParams = if fscParams = [] then FscParam.Defaults else fscParams
     let argList = fscParams |> List.map string
     traceStartTask "Fsc " taskDesc
-    let res = fscList inputFiles argList
+    let res = compileFiles inputFiles argList
     traceEndTask "Fsc " taskDesc
     res
 


### PR DESCRIPTION
…r.compileFiles instead">]

Nothing should really change for now. Base for a workaround "fix" to https://github.com/fsharp/FAKE/issues/689 that [makes it impossible to build Fable plugins on build machine without Visual Studio 2015](https://github.com/fsprojects/Fable/blob/master/build.fsx#L67-L79) see https://github.com/fsprojects/Fable/issues/35#issuecomment-190324604