### PR TITLE
Workaround for #689 - run fsc.exe

### DIFF
--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -321,7 +321,7 @@ type FscParam =
     ///  Display the commandline flags and their usage
     | Help
     ///  Compile using fsx.exe
-    | UseFsxExe
+    | useFscExe
 
 (* - ADVANCED - *)
     /// Specify the codepage used to read source files
@@ -420,7 +420,7 @@ type FscParam =
         | MLCompatibility -> arg "mlcompatibility"
         | NoLogo -> arg "nologo"
         | Help -> arg "help"
-        | UseFsxExe -> arg "useFsxExe"
+        | useFscExe -> arg "useFscExe"
         | Codepage n -> argp "codepage" <| string n
         | Utf8Output -> arg "utf8output"
         | FullPaths -> arg "fullpaths"
@@ -451,7 +451,7 @@ type FscParam =
 let compileFiles (srcFiles : string list) (opts : string list) : int = 
     let scs = SimpleSourceCodeServices()
     
-    let useFsxExe = opts |> Seq.exists (fun e -> e = "--useFsxExe" )
+    let useFscExe = opts |> Seq.exists (fun e -> e = "--useFscExe" )
     let optsArr = 
         // If output file name is specified, pass it on to fsc.
         if Seq.exists (fun e -> e = "-o" || e.StartsWith("--out:")) opts then opts @ srcFiles
@@ -465,7 +465,7 @@ let compileFiles (srcFiles : string list) (opts : string list) : int =
 
     trace <| sprintf "FSC with args:%A" optsArr
 
-    if not(useFsxExe) then
+    if not(useFscExe) then
       // Always prepend "fsc.exe" since fsc compiler skips the first argument
       let optsArr = Array.append [|"fsc.exe"|] optsArr
       let errors, exitCode = scs.Compile optsArr
@@ -480,7 +480,7 @@ let compileFiles (srcFiles : string list) (opts : string list) : int =
     else
         ExecProcess (fun info ->
             info.FileName <- (@"fsc.exe")
-            info.Arguments <- String.Concat( optsArr |> Array.filter(fun f -> f <> "--useFsxExe" ) |> Array.map( fun f -> f + " " ) )
+            info.Arguments <- String.Concat( optsArr |> Array.filter(fun f -> f <> "--useFscExe" ) |> Array.map( fun f -> f + " " ) )
         ) (System.TimeSpan.FromMinutes 5.)
 
 /// Compiles the given F# source files with the specified parameters.

--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -321,7 +321,7 @@ type FscParam =
     ///  Display the commandline flags and their usage
     | Help
     ///  Compile using fsx.exe
-    | useFscExe
+    | UseFscExe
 
 (* - ADVANCED - *)
     /// Specify the codepage used to read source files
@@ -420,7 +420,7 @@ type FscParam =
         | MLCompatibility -> arg "mlcompatibility"
         | NoLogo -> arg "nologo"
         | Help -> arg "help"
-        | useFscExe -> arg "useFscExe"
+        | UseFscExe -> arg "UseFscExe"
         | Codepage n -> argp "codepage" <| string n
         | Utf8Output -> arg "utf8output"
         | FullPaths -> arg "fullpaths"
@@ -451,7 +451,7 @@ type FscParam =
 let compileFiles (srcFiles : string list) (opts : string list) : int = 
     let scs = SimpleSourceCodeServices()
     
-    let useFscExe = opts |> Seq.exists (fun e -> e = "--useFscExe" )
+    let UseFscExe = opts |> Seq.exists (fun e -> e = "--UseFscExe" )
     let optsArr = 
         // If output file name is specified, pass it on to fsc.
         if Seq.exists (fun e -> e = "-o" || e.StartsWith("--out:")) opts then opts @ srcFiles
@@ -465,7 +465,7 @@ let compileFiles (srcFiles : string list) (opts : string list) : int =
 
     trace <| sprintf "FSC with args:%A" optsArr
 
-    if not(useFscExe) then
+    if not(UseFscExe) then
       // Always prepend "fsc.exe" since fsc compiler skips the first argument
       let optsArr = Array.append [|"fsc.exe"|] optsArr
       let errors, exitCode = scs.Compile optsArr
@@ -480,7 +480,7 @@ let compileFiles (srcFiles : string list) (opts : string list) : int =
     else
         ExecProcess (fun info ->
             info.FileName <- (@"fsc.exe")
-            info.Arguments <- String.Concat( optsArr |> Array.filter(fun f -> f <> "--useFscExe" ) |> Array.map( fun f -> f + " " ) )
+            info.Arguments <- String.Concat( optsArr |> Array.filter(fun f -> f <> "--UseFscExe" ) |> Array.map( fun f -> f + " " ) )
         ) (System.TimeSpan.FromMinutes 5.)
 
 /// Compiles the given F# source files with the specified parameters.


### PR DESCRIPTION
#689 issue reported and also spotted on other places like https://github.com/fsprojects/Fable/issues/35#issuecomment-190324604

I took very simplistic approach and simply try to call `fsc.exe` if `UseFsxExe` parameter is supplied like

```
FscHelper.compile [
            FscHelper.UseFscExe
            FscHelper.Lib [ "bin/Debug" ]
        ]
```
This is probably oversimplistic and does not solve the originally reported issue. On the other hand it works. Should be removed in the future when the root cause of #689 is fixed.

No tests supplied, sorry, but [tested agains the repository from the #689](https://github.com/davidpodhola/CompileFsx/commit/a98cadf24e86c37bab92886aa05cb83f2ea478e9).
