### PR TITLE
Fixed issue with IDs that did not start with a letter

### DIFF
--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -577,11 +577,11 @@ let rec wixDir fileFilter asSubDir (directoryInfo : DirectoryInfo) =
         if files = "" then ""
         else 
             split '\n' files
-            |> Seq.map(fun f -> sprintf "<Component Id=\"%s\" Guid=\"%s\">\r\n%s\r\n</Component>\r\n" (compName (directoryInfo.Name.GetHashCode().ToString("x8"))) "*" f)
+            |> Seq.map(fun f -> sprintf "<Component Id=\"c%s\" Guid=\"%s\">\r\n%s\r\n</Component>\r\n" (compName (directoryInfo.Name.GetHashCode().ToString("x8"))) "*" f)
             |> toLines
 
     if asSubDir then 
-        sprintf "<Directory Id=\"%s\" Name=\"%s\">\r\n%s%s\r\n</Directory>\r\n" (dirName (directoryInfo.Name.GetHashCode().ToString("x8"))) 
+        sprintf "<Directory Id=\"d%s\" Name=\"%s\">\r\n%s%s\r\n</Directory>\r\n" (dirName (directoryInfo.Name.GetHashCode().ToString("x8"))) 
             directoryInfo.Name dirs compo
     else sprintf "%s%s" dirs compo
 


### PR DESCRIPTION
This makes sure, that components and directories created by wiXDir function always start with a letter.