### PR TITLE
Azure Web Jobs now get created during deploy if they do not already exist

### DIFF
--- a/help/azurewebjobs.md
+++ b/help/azurewebjobs.md
@@ -2,7 +2,7 @@
 
 FAKE can be used to zip the output directory of a project and push it to Azure via the [zip controller](https://github.com/projectkudu/kudu/wiki/REST-API#zip).
 
-You'll need to know the ftp details of the website to publish the web jobs to. Also the web jobs need to already exist on the azure dashboard.
+You'll need to know the http authentication details of the website to publish the web jobs to. If the web job does not already exist, it will be created as part of the deploy.
 
 In your `build.fsx` add the following:
 

--- a/src/app/FakeLib/AzureWebJobs.fs
+++ b/src/app/FakeLib/AzureWebJobs.fs
@@ -6,6 +6,7 @@ open System.IO
 open System
 open System.Net
 open System.Collections.Generic
+open System.Text
 
 /// The running modes of webjobs
 [<RequireQualifiedAccess>]
@@ -70,13 +71,16 @@ let PackageWebJobs webSites =
     webSites |> List.iter (fun webSite -> webSite.WebJobs |> List.iter (zipWebJob webSite))
 
 let private deployWebJobToWebSite webSite webJob =
-    let uploadApi = Uri(webSite.Url, sprintf"api/zip/site/wwwroot/App_Data/jobs/%s/%s" (jobTypePath webJob.JobType) webJob.Name)
+    let uploadUri = Uri(webSite.Url, sprintf "api/%swebjobs/%s" (jobTypePath webJob.JobType) webJob.Name)
     let filePath = webJob.PackageLocation
-    tracefn "Deploying %s webjob to %O" filePath uploadApi
-    use client = new WebClientWithTimeout()
-
-    client.Credentials <-NetworkCredential(webSite.UserName, webSite.Password)
-    client.UploadData(uploadApi,"PUT",File.ReadAllBytes(filePath)) |> ignore
+    tracefn "Deploying %s webjob to %O" filePath uploadUri
+    use client = new WebClientWithTimeout(Credentials = NetworkCredential(webSite.UserName, webSite.Password))
+    
+    client.Headers.Add(HttpRequestHeader.ContentType, "application/zip")
+    client.Headers.Add("Content-Disposition", sprintf "attachment; filename=%s" (Path.GetFileName webJob.PackageLocation))
+    
+    let response = client.UploadFile("https://tcappdev.scm.azurewebsites.net/api/continuouswebjobs/samplewebjob", "PUT", @"C:\Users\Isaac\Source\Repos\tag-functional\bin\webjobs\tcappdev.zip")
+    tracefn "Response from webjob upload: %s" (Encoding.ASCII.GetString response)
 
 let private deployWebJobsToWebSite webSite = 
     webSite.WebJobs |> List.iter (deployWebJobToWebSite webSite)


### PR DESCRIPTION
This was using a non webjob-specific API to perform deploys which meant you had to first create the webjob some other way.

Now it uses a specific webjobs API so the webjob is created on deploy if it doesn't already exist.