### PR TITLE
Make a new method for sending a coverage file to TeamCity

### DIFF
--- a/src/app/FakeLib/TeamCityHelper.fs
+++ b/src/app/FakeLib/TeamCityHelper.fs
@@ -84,9 +84,8 @@ let sendTeamCityDotNetCoverageImport path = sendToTeamCity "##teamcity[importDat
 type TeamCityDotNetCoverageTool = | DotCover | PartCover | NCover | NCover3 with override x.ToString() = match x with | DotCover -> "dotcover" | PartCover -> "partcover" | NCover -> "ncover" | NCover3 -> "ncover3"
 /// Sends an dotcover, partcover, ncover or ncover3 results filename to TeamCity    
 let sendTeamCityDotNetCoverageImportForTool path (tool : TeamCityDotNetCoverageTool) = 
-    if buildServer = TeamCity then
-        sprintf "##teamcity[importData type='dotNetCoverage' tool='%s' path='%s']" (string tool |> scrub) (path |> scrub)
-        |> fun f -> postMessage (LogMessage(f, true))
+    sprintf "##teamcity[importData type='dotNetCoverage' tool='%s' path='%s']" (string tool |> scrub) (path |> scrub)
+    |> sendStrToTeamCity
 
 /// Sends the full path to the dotCover home folder to override the bundled dotCover to TeamCity
 let sendTeamCityDotCoverHome = sendToTeamCity "##teamcity[dotNetCoverage dotcover_home='%s']"


### PR DESCRIPTION
Per #1059 this is a new function that adds the missing 'tool' property to the TC message for coverage reports.  Using this instead of the existing coverage I get the expected summaries in TeamCity:

![image](https://cloud.githubusercontent.com/assets/573979/14192025/cb07d018-f760-11e5-866e-54e3c3c060bd.png)

The DU types come from the documentation at the help page for [Manual Coverage Reporting] (https://confluence.jetbrains.com/display/TCD9/Manually+Configuring+Reporting+Coverage)