### PR TITLE
Prevent false-positive in EnvironmentHelper.isMacOS on Windows

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -120,8 +120,13 @@ let isUnix = Environment.OSVersion.Platform = PlatformID.Unix
 /// Determines if the current system is a MacOs system
 let isMacOS =
     (Environment.OSVersion.Platform = PlatformID.MacOSX) ||
-      // osascript is the AppleScript interpreter on OS X
-      File.Exists "/usr/bin/osascript"
+      // Running on OSX with mono, Environment.OSVersion.Platform returns Unix
+      // rather than MacOSX, so check for osascript (the AppleScript
+      // interpreter). Checking for osascript for other platforms can cause a
+      // problem on Windows if the current-directory is on a mapped-drive
+      // pointed to a Mac's root partition; e.g., Parallels does this to give
+      // Windows virtual machines access to files on the host.
+      (Environment.OSVersion.Platform = PlatformID.Unix && (File.Exists "/usr/bin/osascript"))
 
 /// Determines if the current system is a Linux system
 let isLinux = int System.Environment.OSVersion.Platform |> fun p -> (p = 4) || (p = 6) || (p = 128)


### PR DESCRIPTION
If the current-directory is on a mapped drive, e.g. the M:\ drive, calling File.Exists with "/usr/bin/osascript" translates to "M:\usr\bin\osascript" -- this exists in some cases where Windows is running as a virtual machine on an OSX host.

Lots of code-comment to make this clear. Should still cover #1019 while also resolving #1202.