### PR TITLE
[Don't merge] demonstrate #1187

### DIFF
--- a/FAKE.sln
+++ b/FAKE.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0F0488CC-2580-4C07-9E16-3997480F0221}"
 	ProjectSection(SolutionItems) = preProject
@@ -120,6 +120,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assemblyinfo", "assemblyinf
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testscripts", "testscripts", "{16D0306A-E2D0-444B-87F8-22605A1EC57C}"
 	ProjectSection(SolutionItems) = preProject
+		src\test\testscripts\fake-powershell-redirected.fsx = src\test\testscripts\fake-powershell-redirected.fsx
+		src\test\testscripts\fake-powershell-redirected.ps1 = src\test\testscripts\fake-powershell-redirected.ps1
+		src\test\testscripts\run-fake-powershell-redirected.bat = src\test\testscripts\run-fake-powershell-redirected.bat
 		src\test\testscripts\test1.fsx = src\test\testscripts\test1.fsx
 	EndProjectSection
 EndProject

--- a/build.fsx
+++ b/build.fsx
@@ -176,6 +176,9 @@ Target "RunTestScripts" (fun _ ->
     !! ("src/test/testscripts/*.*")
     |> CopyFiles testScriptDir
     
+    let absFakeExe = "build/FAKE.exe" |> Path.absolute
+    let absBuildDir = "build" |> Path.absolute
+
     !! (testScriptDir @@ "run-*.bat")
     |> Seq.iter (fun ts ->
         let currentDir = System.Environment.CurrentDirectory
@@ -185,8 +188,8 @@ Target "RunTestScripts" (fun _ ->
                 ExecProcess (fun info ->
                     info.FileName <- ts
                     info.WorkingDirectory <- "."
-                    info.EnvironmentVariables.["FAKE"] <- "build/FAKE.exe" |> Path.absolute
-                    info.EnvironmentVariables.["FAKE_DIR"] <- "build" |> Path.absolute
+                    info.EnvironmentVariables.["FAKE"] <- absFakeExe
+                    info.EnvironmentVariables.["FAKE_DIR"] <- absBuildDir
                 ) (System.TimeSpan.FromMinutes 3.0)
                 
             if result <> 0 then

--- a/src/test/testscripts/fake-powershell-redirected.fsx
+++ b/src/test/testscripts/fake-powershell-redirected.fsx
@@ -1,0 +1,7 @@
+#r @"FakeLib.dll"
+
+open Fake
+
+Target "Default" DoNothing
+
+RunTargetOrDefault "Default"

--- a/src/test/testscripts/fake-powershell-redirected.ps1
+++ b/src/test/testscripts/fake-powershell-redirected.ps1
@@ -1,0 +1,11 @@
+$fake_exe = $env:FAKE
+$fake_dir = $env:FAKE_DIR
+if ([string]::IsNullOrWhiteSpace($fake_exe)) {
+    $fake_dir = "..\..\..\build"
+    $fake_exe = "$fake_dir\fake.exe"
+}
+
+# when this is set, powershell throws an exception when any process writes to STDERR
+$ErrorActionPreference = "Stop"
+# this issue only appears if the FAKE output is redirected to a file
+&"$fake_exe" "fake-powershell-redirected.fsx" 2>&1 > out-run-fake-powershell-redirected.log

--- a/src/test/testscripts/run-fake-powershell-redirected.bat
+++ b/src/test/testscripts/run-fake-powershell-redirected.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass %cd%\fake-powershell-redirected.ps1


### PR DESCRIPTION
This demonstrates https://github.com/fsharp/FAKE/issues/1187:

If ``$ErrorActionPreference = "Stop"`` was set, powershell converts any sub-process writing to STDERR into an exception.

When the output of FAKE is redirected (either file-redirection, or just running it in ISE), it writes an empty string to STDERR after it successfully finishes.
The exit code of FAKE is 0.

My guess is that it flushes some kind of buffer before exiting.

I did a manual binary search with the package versions, and it looks like 4.14.5 is the last GOOD version, 4.14.7 is the first BAD version.

I will try to find the exact commit next week...