### PR TITLE
[Fix #1187] Only write to STDERR if an error happened

### DIFF
--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -472,7 +472,9 @@ let private runScriptUncached (useCache, scriptPath, fsiOptions) printDetails ca
             false
     finally
         // Write Script Warnings & Errors at the end
-        traceFAKE "%O" fsiErrorOutput
+        let strFsiErrorOutput = fsiErrorOutput.ToString()
+        if strFsiErrorOutput <> "" then
+            traceFAKE "%O" strFsiErrorOutput
         // Cache in the error case as well.
         if useCache && not cacheInfo.IsValid then
             handleCaching printDetails session fsiErrorOutput cacheDir cacheInfo


### PR DESCRIPTION
Fixes https://github.com/fsharp/FAKE/issues/1187

Before: If the build was successfull, it would still write an empty line to STDERR, causing issues with powershell.

Now: it only writes if the error message is not empty.