### PR TITLE
Call WaitForExit twice to catch all output

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -87,6 +87,8 @@ let ExecProcessWithLambdas configProcessStartInfoF (timeOut : TimeSpan) silent e
                 <| sprintf "Could not kill process %s  %s after timeout." proc.StartInfo.FileName 
                        proc.StartInfo.Arguments
             failwithf "Process %s %s timed out." proc.StartInfo.FileName proc.StartInfo.Arguments
+    // See http://stackoverflow.com/a/16095658/1149924 why WaitForExit must be called twice.
+    proc.WaitForExit()
     proc.ExitCode
 
 /// Runs the given process and returns the process result.


### PR DESCRIPTION
`Process.WaitForExit()` *must* be called after `WaitForExit(Int32)` to synchronize asynchronous output events (http://stackoverflow.com/a/16095658/1149924, https://msdn.microsoft.com/en-us/library/ty0d8k56.aspx)

This is likely why our output under AppVeyor gets truncated, X-ref fsprojects/FsLexYacc#53