### PR TITLE
Fixed failure to handle spaces or other special characters when running mono exes.

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -147,7 +147,7 @@ let mutable monoArguments = ""
 /// Modifies the ProcessStartInfo according to the platform semantics
 let platformInfoAction (psi : ProcessStartInfo) = 
     if isMono && psi.FileName.EndsWith ".exe" then 
-        psi.Arguments <- monoArguments + " " + psi.FileName + " " + psi.Arguments
+        psi.Arguments <- monoArguments + " \"" + psi.FileName + "\" " + psi.Arguments
         psi.FileName <- monoPath
 
 /// The path of the current target platform


### PR DESCRIPTION
In EnvironmentHelper.platformInfoAction, psi.FileName needs to be surrounded in quotes so that if the filename of the exe has a space in it, the call to "mono " does not fail.

Simply surrounded psi.FileName with double quotes, which should handle all special characters and whitespace.