### PR TITLE
Use UTF-8 encoding for process output on Mono

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -7,6 +7,7 @@ open System.ComponentModel
 open System.Diagnostics
 open System.IO
 open System.Threading
+open System.Text
 open System.Collections.Generic
 open System.ServiceProcess
 
@@ -65,6 +66,9 @@ let ExecProcessWithLambdas configProcessStartInfoF (timeOut : TimeSpan) silent e
     if silent then 
         proc.StartInfo.RedirectStandardOutput <- true
         proc.StartInfo.RedirectStandardError <- true
+        if isMono then
+            proc.StartInfo.StandardOutputEncoding <- Encoding.UTF8
+            proc.StartInfo.StandardErrorEncoding  <- Encoding.UTF8
         proc.ErrorDataReceived.Add(fun d -> 
             if d.Data <> null then errorF d.Data)
         proc.OutputDataReceived.Add(fun d -> 


### PR DESCRIPTION
The original pull request was indeed too intrusive: I wasn't aware that this will lead to an runtime error, if stdout/stderr is a terminal. 

This is a revised version of commit 2d63a45a8ab2479234856434c6ab5549b8880017,
which broke external processes when standard error/output is not redirected: Refs #1213

This commit only sets the encoding when output is redirected.