### PR TITLE
add TeamCity to the list of build servers that fails on error stream output

### DIFF
--- a/src/app/FakeLib/TraceListener.fs
+++ b/src/app/FakeLib/TraceListener.fs
@@ -84,7 +84,7 @@ type ConsoleTraceListener(importantMessagesToStdErr, colorMap) =
             | FinishedMessage -> ()
 
 // If we write the stderr on those build servers the build will fail.
-let importantMessagesToStdErr = buildServer <> CCNet && buildServer <> AppVeyor
+let importantMessagesToStdErr = buildServer <> CCNet && buildServer <> AppVeyor && buildServer <> TeamCity
 
 /// The default TraceListener for Console.
 let defaultConsoleTraceListener =


### PR DESCRIPTION
The default FAKE boostrap writes a few lines at Important severity to StdOut, resulting in a failed build even before we get a chance to set the default console trace listener.

This breaks my build :(
![image](https://cloud.githubusercontent.com/assets/573979/14435628/7c0cafac-ffde-11e5-8249-57678ba883e1.png)

So this PR just adds TeamCity to the list of build servers that would prefer that you not write important message to StdErr. Error messages do still write to StdErr, though.