### PR TITLE
Add detail to API doc: Rename works on directories

### DIFF
--- a/src/app/FakeLib/FileHelper.fs
+++ b/src/app/FakeLib/FileHelper.fs
@@ -200,11 +200,11 @@ let CopyCached target cacheDir files =
            target @@ fi.Name)
     |> Seq.toList
 
-/// Renames the file to the target file name.
+/// Renames the file or directory to the target name.
 /// ## Parameters
 /// 
-///  - `target` - The target file name.
-///  - `file` - The orginal file name.
+///  - `target` - The target file or directory name.
+///  - `fileName` - The orginal file or directory name.
 let Rename target fileName = (fileInfo fileName).MoveTo target
 
 /// Copies a list of files to the specified directory without any output.


### PR DESCRIPTION
I tested the code and found that `Rename` works on directories. Also I could not find another way to rename directories so I assume this is idiomatic (particularly since the function name doesn't have the word `File` in it).