### PR TITLE
Reversed the order of actions in traceStartTarget

### DIFF
--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -134,12 +134,12 @@ let closeAllOpenTags() = Seq.iter closeTag openTags.Value
 
 /// Traces the begin of a target
 let traceStartTarget name description dependencyString = 
+    sendOpenBlock name
+    ReportProgressStart <| sprintf "Target: %s" name`
     openTag "target"
     OpenTag("target", name) |> postMessage
     tracefn "Starting Target: %s %s" name dependencyString
     if description <> null then tracefn "  %s" description
-    ReportProgressStart <| sprintf "Target: %s" name
-    sendOpenBlock name
 
 /// Traces the end of a target   
 let traceEndTarget name = 


### PR DESCRIPTION
Now traceStartTarget the opposite order of traceEndTarget and teamcity encapsulates the entire target and it's tracing inside the block