### PR TITLE
fix parameter split (fixes #1226)

### DIFF
--- a/src/app/FAKE/CommandlineParams.fs
+++ b/src/app/FAKE/CommandlineParams.fs
@@ -6,11 +6,14 @@ let printAllParams() = printfn "FAKE.exe [buildScript] [Target] Variable1=Value1
 
 let parseArgs cmdArgs = 
     let splitter = [| '=' |]
+    let split (arg:string) = 
+      let pos = arg.IndexOfAny splitter 
+      [| arg.Substring(0, pos); arg.Substring(pos + 1, arg.Length - pos - 1) |]
     cmdArgs
     |> Seq.skip 1
     |> Seq.mapi (fun (i : int) (arg : string) -> 
            if arg.Contains "=" then 
-               let s = arg.Split splitter
+               let s = split arg
                if s.[0] = "logfile" then addXmlListener s.[1]
                s.[0], s.[1]
            else if i = 0 then "target", arg


### PR DESCRIPTION
As in #1226 correctly said FAKE was splitting the build parameter incorrectly when in the value part an '=' existed. I just fixed the split of the param to prevent the vanishing of anything after the '=' in build parameters.
before: 

    param=value=any -> param value
    param=value=== -> param value

now: 

    param=value=any -> param value=any
    param=value=== -> param value===