### PR TITLE
OpenCoverHelper: Do not assume AppData and ProgramFiles exists by default

### DIFF
--- a/src/app/FakeLib/OpenCoverHelper.fs
+++ b/src/app/FakeLib/OpenCoverHelper.fs
@@ -35,8 +35,8 @@ type OpenCoverParams =
 
 /// OpenCover default parameters
 let OpenCoverDefaults = 
-    { ExePath = environVar "LOCALAPPDATA" @@ "Apps" @@ "OpenCover" @@ "OpenCover.Console.exe"
-      TestRunnerExePath = ProgramFiles @@ "NUnit" @@ "bin" @@ "nunit-console.exe"
+    { ExePath = if isMono then String.Empty else environVar "LOCALAPPDATA" @@ "Apps" @@ "OpenCover" @@ "OpenCover.Console.exe"
+      TestRunnerExePath = if isMono then String.Empty else ProgramFiles @@ "NUnit" @@ "bin" @@ "nunit-console.exe"
       Output = String.Empty
       Register = Manual
       Filter = String.Empty


### PR DESCRIPTION
This fixes calling OpenCover in Linux/MacOS environments where the
`OpenCoverDefaults` value throws a `ArgumentNullException` because the `@@`
operator will call `Path.Combine` to ProgramFiles and AppData which do not
exist in Linux/MacOS environments.

This fix falls back to the behaviour where `ExePath` and `TestRunnerExePath`
must be passed explicitly in Mono environments running Linux/MacOS.