### PR TITLE
correct NuGet install verbosity parameter

### DIFF
--- a/src/app/FakeLib/NuGet/Install.fs
+++ b/src/app/FakeLib/NuGet/Install.fs
@@ -64,7 +64,7 @@ let buildArgs (param: NugetInstallParams) =
     [   param.Sources |> argList "source"
         (if param.Version <> "" then sprintf "-version \"%s\""  param.Version else "")
         (if param.OutputDirectory <> "" then sprintf "-outputdirectory \"%s\"" param.OutputDirectory else "")
-        (match param.Verbosity with | Quiet -> "quiet" | Detailed -> "detailed" | Normal -> "")
+        (match param.Verbosity with | Quiet -> "quiet" | Detailed -> "detailed" | Normal -> "normal") |> sprintf "-verbosity %s"
         (if param.ExcludeVersion then "-excludeversion" else "")
         (if param.Prerelease then "-prerelease" else "")
         (if param.NoCache then "-nocache" else "")


### PR DESCRIPTION
When the verbosity option to the NuGet Install command is set to `NugetInstallVerbosity.Quiet` the following message is shown:

```
C:\...\tools\NuGet\nuget.exe install C:\...\packages.config -outputdirectory "./packages/" quiet -prerelease -nocache -nonInteractive -configFile "./tools/nuget/nuget.config"
install: invalid arguments.
usage: NuGet install packageId|pathToPackagesConfig [options]
```

The problem is that instead of the word `quiet` there should be written `-verbosity quiet`. This is corrected in this pull request. One of the following three options is now added to the NuGet Install command:
```
-verbosity detailed
-verbosity normal
-verbosity quiet
```