### PR TITLE
Changed the cache path to be relative to script location

### DIFF
--- a/src/app/FakeLib/FSIHelper.fs
+++ b/src/app/FakeLib/FSIHelper.fs
@@ -220,7 +220,7 @@ let private getCacheInfoFromScript printDetails fsiOptions scriptPath =
     //TODO this is only calculating the hash for the input file, not anything #load-ed
     
     let scriptFileName = Path.GetFileName(scriptPath)
-    let hashPath = "./.fake/" + scriptFileName + "_" + scriptHash
+    let hashPath = (Path.GetDirectoryName scriptPath) + "/.fake/" + scriptFileName + "_" + scriptHash
     let assemblyPath = hashPath + ".dll"
     let assemblyWarningsPath = hashPath + "_warnings.txt"
     let cacheConfigPath = hashPath + "_config.xml"


### PR DESCRIPTION
Fixes #1114 
Simply changes to cach directory by inserting the directory of the script in front of the cach path.