### PR TITLE
Bamboo buildNumber environment variable in case sensitive behavior

### DIFF
--- a/src/app/FakeLib/BuildServerHelper.fs
+++ b/src/app/FakeLib/BuildServerHelper.fs
@@ -34,7 +34,7 @@ let mutable xmlOutputFile = getBuildParamOrDefault "logfile" "./output/Results.x
 
 /// Build number retrieved from Bamboo
 /// [omit]
-let bambooBuildNumber = environVar "BAMBOO_BUILDNUMBER"
+let bambooBuildNumber = environVar "bamboo_buildNumber"
 
 /// Checks if we are on Bamboo
 /// [omit]


### PR DESCRIPTION
When using the bamboo environment variable in capital letters it won't work on our OSX (mono) buildserver. So this helper need to use the bamboo environment variable in its original form to make it work on all platforms.