### PR TITLE
Include docs for all versions of combinePaths

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -19,10 +19,12 @@ let environVar name = Environment.GetEnvironmentVariable name
 
 /// Combines two path strings using Path.Combine
 let inline combinePaths path1 (path2 : string) = Path.Combine(path1, path2.TrimStart [| '\\'; '/' |])
+/// Combines two path strings using Path.Combine
 let inline combinePathsNoTrim path1 path2 = Path.Combine(path1, path2)
 
 /// Combines two path strings using Path.Combine
 let inline (@@) path1 path2 = combinePaths path1 path2
+/// Combines two path strings using Path.Combine
 let inline (</>) path1 path2 = combinePathsNoTrim path1 path2
 
 // Normalizes path for different OS


### PR DESCRIPTION
A colleague of mine looked at the hover tip for `</>` but found no information. So I've copied the doc string from `@@`.