### PR TITLE
Add helper function to execute Sysinternals PsExec

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="ServiceControllerHelper.fs" />
     <Compile Include="GuardedAwaitObservable.fs" />
     <Compile Include="ProcessHelper.fs" />
+    <Compile Include="PsExecHelper.fs" />
     <Compile Include="NpmHelper.fs" />
     <Compile Include="AppVeyor.fs" />
     <Compile Include="BitbucketPipelines.fs" />

--- a/src/app/FakeLib/PsExecHelper.fs
+++ b/src/app/FakeLib/PsExecHelper.fs
@@ -1,0 +1,23 @@
+﻿/// Contains functions for working with Sysinternals PsExec
+module Fake.PsExecHelper
+
+let private formatArgs host username password exe inputs =
+    sprintf @"\\%s -u %s -p %s ""%s"" %s" host username password exe inputs
+
+/// Use Sysinternals PsExec to execute a process on a remote machine.
+/// ## Parameters
+///
+/// - `host` - The hostname of the machine to connect to.
+/// - `username` - A username valid for connecting to the remote machine.
+/// - `password` - The cleartext password of the given user.
+/// - `exe` - The path to the file that is to be executed.
+/// - `inputs` - The command-line arguments to pass to the remote process.
+/// - `timeOut` - The timeout for PsExec.
+let execRemote host username password exe inputs timeout = 
+    let args = formatArgs host username password exe inputs 
+    let exitCode =
+        ExecProcess (fun info ->  
+            info.FileName <- "PsExec.exe"
+            info.Arguments <- args) timeout
+    if exitCode <> 0
+    then failwithf "Failed to execute %s as user %s on host %s with args %s" exe username host inputs


### PR DESCRIPTION
This is a small thing, so you may or may not want it, but I've found use for this helper function wrapping up a call to [Sysinternals PsExec](https://technet.microsoft.com/en-us/sysinternals/psexec.aspx).

I throw an error if it fails; maybe that is not consistent with the rest of your APIs? That's what I wanted it to do for my stuff, but feel free to suggest a change on that.

I have not added any automated tests for it, but I have used it myself in my own scripts and it works (w00t w00t manual testing).