### PR TITLE
Add initial support for Fuchu tests

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -71,6 +71,7 @@
     <Compile Include="FileUtils.fs" />
     <Compile Include="UnitTest\UnitTestCommon.fs" />
     <Compile Include="UnitTest\UnitTestHelper.fs" />
+    <Compile Include="FuchuHelper.fs" />
     <Compile Include="UnitTest\NUnit\Xml.fs" />
     <Compile Include="UnitTest\NUnit\Common.fs" />
     <Compile Include="UnitTest\NUnit\Sequential.fs" />

--- a/src/app/FakeLib/FuchuHelper.fs
+++ b/src/app/FakeLib/FuchuHelper.fs
@@ -1,0 +1,19 @@
+﻿module Fake.FuchuHelper
+
+/// Execute Fuchu tests from one or more assemblies.
+/// Multiple assemblies are run concurrently.
+/// ## Parameters
+/// 
+///  - `testExes` - The paths of the executables containing Fuchu tests to run.
+let Fuchu testExes = 
+    let errorCode =
+        testExes
+        |> Seq.map (fun program -> if not isMono
+                                   then program, null
+                                   else "mono", program)
+        |> Seq.map (fun (program, args) -> asyncShellExec { defaultParams with Program = program; CommandLine = args })
+        |> Async.Parallel
+        |> Async.RunSynchronously
+        |> Array.sum
+    if errorCode <> 0
+    then failwith "Unit tests failed"


### PR DESCRIPTION
Something like this has been discussed at #234, and there is an open issue for this more specifically at #742. And while there seem to be some questions of how to do this in the best way, or to polish Fuchu itself, I am of the opinion that it is better to have something than nothing. It is rather reassuring to n00bs particularly when they see that tools are at least aware of each other, and this is one of the big draws of FAKE.

The code is derived from the example from [Fuchu itself](https://github.com/mausch/Fuchu/blob/5ef9ec303abf56f8ca5511cda3fb53bfa705007c/build.fsx#L119). Note that I have not tested this on Mono myself; I was trusting it to work correctly since it came from Fuchu. I have however tested it on Windows. If you want me to test it on Linux, I'm happy to do so.