### PR TITLE
Correct waiting for android packaging and fix for mono processes encoding

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -19,6 +19,9 @@ let start (proc : Process) =
     if isMono && proc.StartInfo.FileName.ToLowerInvariant().EndsWith(".exe") then
         proc.StartInfo.Arguments <- "--debug \"" + proc.StartInfo.FileName + "\" " + proc.StartInfo.Arguments
         proc.StartInfo.FileName <- monoPath
+        if isMono then
+            proc.StartInfo.StandardOutputEncoding <- Encoding.UTF8
+            proc.StartInfo.StandardErrorEncoding  <- Encoding.UTF8
 
     proc.Start() |> ignore
     startedProcesses.Add(proc.Id, proc.StartTime) |> ignore
@@ -66,9 +69,6 @@ let ExecProcessWithLambdas configProcessStartInfoF (timeOut : TimeSpan) silent e
     if silent then 
         proc.StartInfo.RedirectStandardOutput <- true
         proc.StartInfo.RedirectStandardError <- true
-        if isMono then
-            proc.StartInfo.StandardOutputEncoding <- Encoding.UTF8
-            proc.StartInfo.StandardErrorEncoding  <- Encoding.UTF8
         proc.ErrorDataReceived.Add(fun d -> 
             if d.Data <> null then errorF d.Data)
         proc.OutputDataReceived.Add(fun d -> 

--- a/src/app/FakeLib/XamarinHelper.fs
+++ b/src/app/FakeLib/XamarinHelper.fs
@@ -9,8 +9,14 @@ open System.Xml
 open System.Text
 
 let private executeCommand command args =
-    Shell.Exec(command, args)
-    |> fun result -> if result <> 0 then failwithf "%s exited with error %d" command result
+    ExecProcessAndReturnMessages (fun p ->
+        p.FileName <- command
+        p.Arguments <- args
+    ) TimeSpan.MaxValue
+    |>  fun result ->
+             let output = String.Join (Environment.NewLine, result.Messages)
+             tracefn "Process output: \r\n%A" output
+             if result.ExitCode <> 0 then failwithf "%s exited with error %d" command result.ExitCode
 
 /// The package restore paramater type
 type XamarinComponentRestoreParams = {


### PR DESCRIPTION
#1213 processes started on mono now always use utf-8 for input/output

Regarding #1194 
I've updated process start function in XamarinHelper to correctly wait for the process to complete and then trace all the output. Unfortunately, I was not able to find out why asyncShellExec is not working as expected. My gut feeling is that the problem is somehow related with Mono 4.4.0 release (before I had no problem with build processes.

Regarding #1213 
I had *sometimes* problem with the encoding of some of the tools output (curl, jarsigner, zipalign). 
Started to look into this because of the #1194 issue I had and found out that fix for #1213 didn't cover all the process start functions and `XamarinHelper.fs` was not using the correct one.

Appreciate any feedback and suggestions how to make the PR better.
