### PR TITLE
#1194 update fix for mono encoding in ProcessHelper.fs

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -19,10 +19,9 @@ let start (proc : Process) =
     if isMono && proc.StartInfo.FileName.ToLowerInvariant().EndsWith(".exe") then
         proc.StartInfo.Arguments <- "--debug \"" + proc.StartInfo.FileName + "\" " + proc.StartInfo.Arguments
         proc.StartInfo.FileName <- monoPath
-        if isMono then
-            proc.StartInfo.StandardOutputEncoding <- Encoding.UTF8
-            proc.StartInfo.StandardErrorEncoding  <- Encoding.UTF8
-
+    if isMono then
+        proc.StartInfo.StandardOutputEncoding <- Encoding.UTF8
+        proc.StartInfo.StandardErrorEncoding  <- Encoding.UTF8
     proc.Start() |> ignore
     startedProcesses.Add(proc.Id, proc.StartTime) |> ignore
 


### PR DESCRIPTION
to work in all scenarios.

This PR comes as fix for the incomplete pull request #1275 made by me previously.
Problem was that I made incorrect if statement inside another if and thus the encoding enforcement did not work correctly in all cases such as when called from GitHelper or HockeyAppHelper modules.

Apologies for that.