### PR TITLE
improve default npm path handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 if test "$OS" = "Windows_NT"
 then
   # use .Net
@@ -6,33 +7,33 @@ then
   .paket/paket.bootstrapper.exe
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
+    exit $exit_code
   fi
 
   .paket/paket.exe restore
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
+    exit $exit_code
   fi
-  
+
   [ ! -e build.fsx ] && .paket/paket.exe update
   [ ! -e build.fsx ] && packages/build/FAKE/tools/FAKE.exe init.fsx
-  packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
+  packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
 else
   # use mono
   mono .paket/paket.bootstrapper.exe
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
+    exit $exit_code
   fi
 
   mono .paket/paket.exe restore
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
+    exit $exit_code
   fi
 
   [ ! -e build.fsx ] && mono .paket/paket.exe update
   [ ! -e build.fsx ] && mono packages/build/FAKE/tools/FAKE.exe init.fsx
-  mono packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
+  mono packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
 fi

--- a/src/app/FakeLib/NpmHelper.fs
+++ b/src/app/FakeLib/NpmHelper.fs
@@ -3,11 +3,23 @@ module Fake.NpmHelper
 open Fake
 open System
 open System.IO
+open System.Diagnostics
 
 /// Default paths to Npm
 let private npmFileName =
     match isUnix with
-    | true -> "/usr/local/bin/npm"
+    | true -> 
+        let info = new ProcessStartInfo("which","npm")
+        info.StandardOutputEncoding <- System.Text.Encoding.UTF8
+        info.RedirectStandardOutput <- true
+        info.UseShellExecute        <- false
+        info.CreateNoWindow         <- true
+        use proc = Process.Start info
+        proc.WaitForExit()
+        match proc.ExitCode with
+            | 0 when not proc.StandardOutput.EndOfStream ->
+              proc.StandardOutput.ReadLine()
+            | _ -> "/usr/bin/npm"
     | _ -> "./packages/Npm.js/tools/npm.cmd"
 
 /// Arguments for the Npm install command


### PR DESCRIPTION
I added a test to check whether `npm` exists in `/usr/bin` as a standard location in addition to the existing default `/usr/local/bin`. Also, I changed the shebang of `build.sh` such that it uses `/usr/bin/env bash` instead of hard-coding the path to bash (which does not work on systems like NixOS).