### PR TITLE
Fix Fake.Deploy downloadString

### DIFF
--- a/help/deploy.md
+++ b/help/deploy.md
@@ -69,11 +69,11 @@ Fake deployment packages can be run manually on the current machine or they can 
 
 To run a package on the local machine located at C:\Appdev\MyDeployment.nupkg you would run the following command:
 
-    Fake.Deploy /deploy C:\Appdev\MyDeployment.nupkg
+    Fake.Deploy /deploy C:/Appdev/MyDeployment.nupkg
 
 To run the same package on a remote computer (e.g. integration-1) you can run:
 
-    Fake.Deploy /deployRemote http://integration-1:8080 C:\Appdev\MyDeployment.nupkg
+    Fake.Deploy /deployRemote http://integration-1:8080/fake C:/Appdev/MyDeployment.nupkg
 
 It's also possible to just make a HTTP-POST with the package to http://integration-1:8080/fake
 

--- a/src/app/Fake.Deploy.Lib/FakeDeployAgentHelper.fs
+++ b/src/app/Fake.Deploy.Lib/FakeDeployAgentHelper.fs
@@ -76,7 +76,7 @@ let private webRequest (url : Url) (action : Action) (timeout : TimeSpan) =
     req
 
 let private downloadString (request : HttpWebRequest) = 
-    use responseStream = request.GetRequestStream()
+    use responseStream = request.GetResponse().GetResponseStream()
     use ms = new MemoryStream()
     responseStream.CopyTo ms
     Encoding.UTF8.GetString(ms.ToArray())


### PR DESCRIPTION
Switch from incorrect `GetRequestStream()` to
`GetResponse().GetResponseStream()` to read results of `GET` requests.  Also
adjusted docs to make it clear that the server URL you should provide to
the command line tools is `http://localhost:8080/fake`, not
`http://localhost:8080/`