### PR TITLE
Add !!+ (include multiple) and !!! (include only one)

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,6 @@ nuget FSharp.Core redirects:force
 nuget Knockout
 nuget RavenDB.Server
 nuget serilog.sinks.nlog
-nuget xunit.runners
 nuget Argu
 nuget FsCheck < 2.1
 nuget FsCheck.Xunit < 2.1

--- a/src/app/FakeLib/Globbing/FileSystem.fs
+++ b/src/app/FakeLib/Globbing/FileSystem.fs
@@ -87,6 +87,28 @@ let inline (--) (x : FileIncludes) pattern = x.ButNot pattern
 /// Includes a single pattern and scans the files - !! x = AllFilesMatching x
 let inline (!!) x = Include x
 
+let private couldNotMatch =
+    failwithf "Could not find anything matching %s"
+
+/// Include a single pattern, throwing an exception if there are no matches
+let (!!+) glob =
+    let files = !! glob
+    if Seq.isEmpty files
+    then couldNotMatch glob
+    else files
+
+let private tooManymatches =
+    failwithf "Found %i files matching %s; expected exactly one"
+
+/// Include a single pattern and return a single match, throwing an exception
+/// otherwise if there are zero or multiple matches.
+let (!!!) glob =
+    let files = !!+ glob
+    let count = Seq.length files
+    if count > 1
+    then tooManymatches count glob
+    else Seq.head files
+
 /// Looks for a tool first in its default path, if not found the in ./packages/ and then
 /// in all subfolders of the root folder - returns the tool file name.
 let findToolInSubPath toolname defaultPath =


### PR DESCRIPTION
I have found use in these two prefix operators: sometimes I want to match a pattern (glob), but ensure that if it matches nothing, the build fails (rather than vacuously passing throwing failing to apply the `Seq.map` or `Seq.iter`, etc). For this, I have defined `!!+`.

At other times, I want to select a single file, but don't know the exact path, nor do I care about the exact path; but I want to make sure that I haven't accidentally matched something wrong by having too promiscuous a glob, that matches more than one thing. For this, I have defined `!!!`. It does not return a sequence, because for this purpose, you are generally not going to be adding it to further things, but want one string only; however, if you were matching multiple things, you could always use the (perhaps slightly awkward) `++ (!!! glob)`.

(Note: I have been reading too many old books, by people who were better at writing Latin than English, and that is what I blame on my odd and rambling sentence construction.)

Consider this a suggestion; feel free to turn down this PR if you don't find these generally useful. I imagine that other people may have these same situations, though.

I also removed a duplicate `xunit.runners` line (the one without the version specified) from `paket.dependencies` so it will build.
