### PR TITLE
Fixed broken project introduced in #1268

### DIFF
--- a/src/app/FakeLib/FakeLib.fsproj
+++ b/src/app/FakeLib/FakeLib.fsproj
@@ -69,9 +69,9 @@
     <Compile Include="Globbing\FileSystem.fs" />
     <Compile Include="FileHelper.fs" />
     <Compile Include="FileUtils.fs" />
+    <Compile Include="FuchuHelper.fs" />
     <Compile Include="UnitTest\UnitTestCommon.fs" />
     <Compile Include="UnitTest\UnitTestHelper.fs" />
-    <Compile Include="FuchuHelper.fs" />
     <Compile Include="UnitTest\NUnit\Xml.fs" />
     <Compile Include="UnitTest\NUnit\Common.fs" />
     <Compile Include="UnitTest\NUnit\Sequential.fs" />


### PR DESCRIPTION
`FakeLib.fsproj` was failing to open in Visual Studio 2015 with this comment:

> The project 'FakeLib.fsproj could not be opened because opening it would cause a folder to be rendered multiple times in the solution explorer.

More details on the issue [here](http://marcinjuraszek.com/2014/03/folders-in-f-projects-how-to-do-it-what-to-avoid.html)