### PR TITLE
changed typo in continuous web job path

### DIFF
--- a/src/app/FakeLib/AzureKudu.fs
+++ b/src/app/FakeLib/AzureKudu.fs
@@ -37,7 +37,7 @@ let stageFolder source shouldInclude =
 
 /// Gets the path for deploying a web job to.
 let getWebJobPath webJobType webJobName =
-    let webJobType = match webJobType with Scheduled -> "scheduled" | Continuous -> "continous"
+    let webJobType = match webJobType with Scheduled -> "scheduled" | Continuous -> "continuous" 
     sprintf @"%s\app_data\jobs\%s\%s\" deploymentTemp webJobType webJobName
 
 /// Stages a set of files into a WebJob folder in the temp deployment area, ready for deployment into the website as a webjob.


### PR DESCRIPTION
it used to be "continous" but it needs to be "continuous"

I pulled my hair out why kudu in azure would not run my web job, until I noticed this typo!