### PR TITLE
Better Old-Style Arg Parsing

### DIFF
--- a/src/app/FAKE/CommandlineParams.fs
+++ b/src/app/FAKE/CommandlineParams.fs
@@ -4,18 +4,35 @@ open Fake
 
 let printAllParams() = printfn "FAKE.exe [buildScript] [Target] Variable1=Value1 Variable2=Value2 ... "
 
+(* 
+    This is a set of flags that exist in code lower in the target processing that MUST be normalized to a certain form. This is necessary because
+    If any old styole variables are present in the FAKE invocation, Argu parsing will fail and we will not have parsed out those commands correctly
+    from the overall command line.
+
+    You can typically find usages of 'hasBuildParam' in this codebase to find places where these values are required.
+*)
+let specialFlags = 
+    [
+        "-st", "single-target"
+        "--single-target", "single-target" 
+        "-pd", "details"
+        "--print-details", "details"
+    ] |> Map.ofList
+
 let parseArgs cmdArgs = 
-    let splitter = [| '=' |]
-    let split (arg:string) = 
-      let pos = arg.IndexOfAny splitter 
-      [| arg.Substring(0, pos); arg.Substring(pos + 1, arg.Length - pos - 1) |]
+    let (|KeyValue|Flag|TargetName|) ((i,arg) : int * string) =
+        if i = 0 then TargetName arg
+        else
+            match arg.IndexOf '=' with
+            | -1 -> Flag arg
+            | i -> KeyValue (arg.Substring(0, i), arg.Substring(i + 1, arg.Length - i - 1))
+
     cmdArgs
     |> Seq.skip 1
-    |> Seq.mapi (fun (i : int) (arg : string) -> 
-           if arg.Contains "=" then 
-               let s = split arg
-               if s.[0] = "logfile" then addXmlListener s.[1]
-               s.[0], s.[1]
-           else if i = 0 then "target", arg
-           else arg, "true")
+    |> Seq.mapi (fun i a -> match (i, a) with 
+                            | TargetName t -> "target", t
+                            | Flag f when Map.containsKey f specialFlags -> Map.find f specialFlags, "true"
+                            | Flag f -> f, "true"
+                            | KeyValue (k,v) when k = "logfile" -> addXmlListener v; (k,v)
+                            | KeyValue kvp -> kvp )
     |> Seq.toList


### PR DESCRIPTION
Imagine a command line Fake invocation like so:
`fake.exe ./build.fsx package --single-target variable=foo`

In this case, Fake parses the single-target flag incorrectly and so the `package` target is run along all dependencies.

I took a look and this is due to the way we process old vs new-style arguments.  Specifically, as soon as there is an old-style argument in the args the parser breaks and the special handling of `--single-target`, `--print-details` and other internal arguments that is done by the Choice1Of2 branch in Program.fs is skipped over by the old-style argument parsing.

So to correct this, I've added a bit of logic to the Cli.parseArgs function that normalizes various forms of the flags that are valid for new-style args into the versions of those flags that are expected later in the pipeline.

In the command line above, Fake results in the following list of arguments: `[("target", "package"); ("--single-target", "true"); ("variable", "foo")]`
Inside the codebase, Fake is using hasBuildParam to look for "single-target", which is not found in the list above.
With my changes, Fake results in the following list of arguments: `[("target", "package"); ("single-target", "true"); ("variable", "foo")]`, which contains the key looked for.