### PR TITLE
Update XUnit2 module to fail gracefully

### DIFF
--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -235,7 +235,7 @@ module internal ResultHandling =
 
     let failBuildWithMessage = function
         | DontFailBuild -> traceImportant
-        | _ -> failwith
+        | _ -> (fun m -> raise(FailedTestsException m))
 
     let failBuildIfXUnitReportedError errorLevel =
         buildErrorMessage


### PR DESCRIPTION
As discussed on twitter the current `XUnit2` library module does not fail gracefully as show in the comparison below;

![xunitteamcity](https://cloud.githubusercontent.com/assets/185776/16821006/e51f6938-494b-11e6-837b-900b58fd617f.png)

This change mirrors the approach taken by the `NUnit3` module (I believe).

**Edit:** It's worth noting this in fact changes the current (and perhaps 'expected') behaviour 🎱 