### PR TITLE
expand typescript search paths on windows to cover all new typescript…

### DIFF
--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -3,6 +3,7 @@ module Fake.TypeScript
 
 open System
 open System.Text
+open System.IO
 
 /// Generated ECMAScript version
 type ECMAScript =
@@ -42,6 +43,11 @@ type TypeScriptParams =
 
 let private TypeScriptCompilerPrefix = "Microsoft SDKs" </> "TypeScript"
 
+let extractVersionNumber (di : DirectoryInfo) = 
+    match Double.TryParse di.Name with
+    | true, d -> d
+    | false, _ -> 0.0
+
 /// Default parameters for the TypeScript task
 let TypeScriptDefaultParams = 
     { ECMAScript = ES3
@@ -60,8 +66,8 @@ let TypeScriptDefaultParams =
                     [ System.Environment.GetFolderPath System.Environment.SpecialFolder.ProgramFiles; System.Environment.GetFolderPath System.Environment.SpecialFolder.ProgramFilesX86]
                     |> List.map (fun p -> p </> TypeScriptCompilerPrefix)
                     |> List.collect (fun p -> try System.IO.DirectoryInfo(p).GetDirectories() |> List.ofArray with | _ -> [])
+                    |> List.sortByDescending extractVersionNumber
                     |> List.map (fun di -> di.FullName)
-                    |> List.sortDescending
                 findPath "TypeScriptPath" (String.Join(";", paths)) "tsc.exe"
       TimeOut = TimeSpan.FromMinutes 5. }
 


### PR DESCRIPTION
… compilers, prefering most recent.

On my machine this returns the following list:

val it : string list =
  ["C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.8";
   "C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.5";
   "C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0"]

choosing tsc.exe from 1.8 at the end.  there may be underlying issues with ordering, but this is more future-proof than the current implementation. 

This fixes #1284 
