### PR TITLE
Use latest TypeScript compiler version automatically

### DIFF
--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -34,6 +34,7 @@ type TypeScriptParams =
       /// Specifies if the TypeScript compiler should remove comments. Default is false.
       RemoveComments : bool
       /// Specifies the TypeScript compiler path.
+      /// If unspecified, will use the latest version found in [Program Files/x86]\Microsoft SDKs\TypeScript
       ToolPath : string
       /// Specifies the TypeScript compiler output path.
       OutputPath : string

--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -41,7 +41,7 @@ type TypeScriptParams =
       TimeOut : TimeSpan }
 
 let private TypeScriptCompilerPath = 
-    @"[ProgramFilesX86]\Microsoft SDKs\TypeScript\1.0\;[ProgramFiles]\Microsoft SDKs\TypeScript\1.0\;[ProgramFilesX86]\Microsoft SDKs\TypeScript\0.9\;[ProgramFiles]\Microsoft SDKs\TypeScript\0.9\"
+    @"[ProgramFilesX86]\Microsoft SDKs\TypeScript\[v]\;[ProgramFiles]\Microsoft SDKs\TypeScript\[v]\"
 
 /// Default parameters for the TypeScript task
 let TypeScriptDefaultParams = 


### PR DESCRIPTION
This small feature addresses #1284 by allowing a version wildcard in `tryFindFile`. When given a path containing the wildcard `[v]`, the algorithm will search the the parent directory for subdirectories matching a regular expression which identifies digits separated by dots (e.g. `1.8`)

The `TypeScriptCompilerPath` has been updated to use the feature: 

```FSharp
let private TypeScriptCompilerPath = 
    @"[ProgramFilesX86]\Microsoft SDKs\TypeScript\[v]\;[ProgramFiles]\Microsoft SDKs\TypeScript\[v]\"
```

I have not written any tests for this method, as it is difficult to mock the filesystem, which the `tryFindFile` method relies on. Perhaps a configurable proxy module could be created to provide `Directory.GetDirectories`, `Directory.Exists` and `File.Exists` and provide override methods in test code... But I think this is overkill.