### PR TITLE
Semver parse fix to handle prereleases and build parts

### DIFF
--- a/src/app/FakeLib/SemVerHelper.fs
+++ b/src/app/FakeLib/SemVerHelper.fs
@@ -38,7 +38,7 @@ type PreRelease =
       Parts : PrereleaseIdent list }
     static member TryParse str = 
         // this matches any number of alpha-numeric literals separated by '.'
-        let prereleaseSpecRE = Regex("^(?<front>([0-9A-Za-z]+\.)*)(?<back>[0-9A-Za-z]+)$", RegexOptions.Compiled)
+        let prereleaseSpecRE = Regex("^(?<front>([0-9A-Za-z-]+\.)*)(?<back>[0-9A-Za-z-]+)$", RegexOptions.Compiled)
         let namedPrereleaseRE = Regex("^(?<name>[a-zA-Z]+)(?<number>\d*)$", RegexOptions.Compiled)
         let m = prereleaseSpecRE.Match(str)
         match m.Success, m.Groups.["front"].Value, m.Groups.["back"].Value with

--- a/src/app/FakeLib/SemVerHelper.fs
+++ b/src/app/FakeLib/SemVerHelper.fs
@@ -22,10 +22,10 @@ type Ident =
     interface IComparable with
         member x.CompareTo yobj =
             match yobj with
-            // spec says that alpha is always greater than numeric, alpha segments are compared lexicographically
+            // spec says that alpha is always greater than numeric, alpha segments are compared lexicographically, which in .Net is the ordinal comparer
             | :? Ident as y ->
                 match x,y with
-                | AlphaNumeric a, AlphaNumeric b -> compare a b
+                | AlphaNumeric a, AlphaNumeric b -> StringComparer.Ordinal.Compare(a, b)
                 | AlphaNumeric _, Numeric _ -> 1
                 | Numeric _, AlphaNumeric _ -> -1
                 | Numeric a, Numeric b -> compare a b

--- a/src/app/FakeLib/SemVerHelper.fs
+++ b/src/app/FakeLib/SemVerHelper.fs
@@ -4,28 +4,71 @@ module Fake.SemVerHelper
 open System
 open System.Text.RegularExpressions
 
+[<CustomEquality;CustomComparison>]
+type PrereleaseIdent = 
+    | AlphaNumeric of string | Numeric of int64
+    override x.Equals(yobj) = 
+        match yobj with
+        | :? PrereleaseIdent as y -> 
+            match x,y with
+            | AlphaNumeric a, AlphaNumeric b -> a = b
+            | AlphaNumeric _, Numeric _ -> false
+            | Numeric _, AlphaNumeric _ -> false
+            | Numeric a, Numeric b -> a = b
+        | _ -> false
+    override x.ToString() = match x with | AlphaNumeric a -> a | Numeric b -> string b
+    override x.GetHashCode() = match x with | AlphaNumeric a -> hash a | Numeric b -> hash b
+    interface IComparable with
+        member x.CompareTo yobj =
+            match yobj with
+            // spec says that alpha is always greater than numeric, alpha segments are compared lexicographically
+            | :? PrereleaseIdent as y ->
+                match x,y with
+                | AlphaNumeric a, AlphaNumeric b -> compare a b
+                | AlphaNumeric _, Numeric _ -> 1
+                | Numeric _, AlphaNumeric _ -> -1
+                | Numeric a, Numeric b -> compare a b
+            | _ -> invalidArg "yobj" "cannot compare values of different types"
+
 [<CustomEquality; CustomComparison>]
 type PreRelease = 
     { Origin: string
       Name: string
-      Number: int option }
+      Number: int option
+      Parts : PrereleaseIdent list }
     static member TryParse str = 
-        let m = Regex("^(?<name>[a-zA-Z]+)(?<number>\d*)$").Match(str)
-        match m.Success, m.Groups.["name"].Value, m.Groups.["number"].Value with
-        | true, name, "" -> Some { Origin = str; Name = name; Number = None }
-        | true, name, number -> Some { Origin = str; Name = name; Number = Some (int number) }
-        | _ -> None
+        // this matches any number of alpha-numeric literals separated by '.'
+        let prereleaseSpecRE = Regex("^(?<front>([0-9A-Za-z]+\.)*)(?<back>[0-9A-Za-z]+)$", RegexOptions.Compiled)
+        let namedPrereleaseRE = Regex("^(?<name>[a-zA-Z]+)(?<number>\d*)$", RegexOptions.Compiled)
+        let m = prereleaseSpecRE.Match(str)
+        match m.Success, m.Groups.["front"].Value, m.Groups.["back"].Value with
+        | false, _ , _  -> None
+        | true, front, back -> 
+            let m' = namedPrereleaseRE.Match(str)
+            let parts = split '.' (front + back) |> List.map (fun part -> match Int64.TryParse part with | true, i -> Numeric i | false, _ -> AlphaNumeric part)
+            match m.Success, m.Groups.["name"].Value, m.Groups.["number"].Value with
+            | true, name, "" -> Some { Origin = str; Name = name; Number = None; Parts = parts }
+            | true, name, number -> Some { Origin = str; Name = name; Number = Some (int number); Parts = parts }
+            | false, _, _ when front = "" -> 
+                Some { Origin = back; Name = ""; Parts = parts; Number = match Int32.TryParse back with | true, n -> Some n | false, _ -> None; }
+            | false, _, _ -> 
+                Some { Origin = front + back; Name = ""; Number = None; Parts = parts}
+    override x.ToString() = String.Join(".", x.Parts |> List.map string)
     override x.Equals(yobj) =
         match yobj with
         | :? PreRelease as y -> x.Origin = y.Origin
         | _ -> false
     override x.GetHashCode() = hash x.Origin
-    interface System.IComparable with
+    interface IComparable with
         member x.CompareTo yobj =
             match yobj with
+            // spec says that longer prereleases are bigger
             | :? PreRelease as y ->
-                if x.Name <> y.Name then compare x.Name y.Name else
-                compare x.Number y.Number
+                if x.Parts.Length <> y.Parts.Length then compare x.Parts.Length y.Parts.Length
+                else 
+                    List.zip x.Parts y.Parts
+                    |> List.fold (fun cmp (x,y) -> if cmp <> 0 then cmp else compare x y) 0
+                    
             | _ -> invalidArg "yobj" "cannot compare values of different types"
 
 /// Contains the version information.
@@ -42,12 +85,11 @@ type SemVerInfo =
       /// The optional build no.
       Build: string }
     override x.ToString() =
-        sprintf "%d.%d.%d" x.Major x.Minor x.Patch +
-         (match x.PreRelease, isNotNullOrEmpty x.Build with
-          | Some preRelease, _ -> "-" + preRelease.Name 
-          | None, true -> "-"
-          | _ -> "") +
-         (if isNotNullOrEmpty x.Build then "." + x.Build else "")
+        sprintf "%d.%d.%d%s%s" x.Major x.Minor x.Patch 
+         (match x.PreRelease with
+          | Some preRelease -> "-" + string preRelease 
+          | None -> "")
+         (if isNotNullOrEmpty x.Build then "+" + x.Build else "")
 
     override x.Equals(yobj) =
         match yobj with
@@ -57,7 +99,7 @@ type SemVerInfo =
         | _ -> false
  
     override x.GetHashCode() = hash (x.Minor,x.Minor,x.Patch,x.PreRelease,x.Build)
-    interface System.IComparable with
+    interface IComparable with
         member x.CompareTo yobj =
             match yobj with
             | :? SemVerInfo as y ->
@@ -67,11 +109,8 @@ type SemVerInfo =
                 if x.PreRelease = y.PreRelease && x.Build = y.Build  then 0 else
                 if x.PreRelease.IsNone && x.Build = "" then 1 else
                 if y.PreRelease.IsNone && y.Build = "" then -1 else
-                if x.PreRelease <> y.PreRelease then compare x.PreRelease y.PreRelease else
-                if x.Build <> y.Build then 
-                    match Int32.TryParse x.Build, Int32.TryParse y.Build with
-                    | (true,b1),(true,b2) -> compare b1 b2
-                    | _ -> compare x.Build y.Build 
+                if x.PreRelease <> y.PreRelease then compare x.PreRelease y.PreRelease
+                // spec says that build should have no impact on comparisons
                 else
                     0
             | _ -> invalidArg "yobj" "cannot compare values of different types"
@@ -91,23 +130,36 @@ let isValidSemVer input =
 ///
 ///     parse "1.0.0-rc.1"     < parse "1.0.0"          // true
 ///     parse "1.2.3-alpha"    > parse "1.2.2"          // true
-///     parse "1.2.3-alpha2"   > parse "1.2.3-alpha"    // true
-///     parse "1.2.3-alpha002" > parse "1.2.3-alpha1"   // true
-///     parse "1.5.0-beta.2"   > parse "1.5.0-rc.1"     // false
+///     parse "1.2.3-alpha2"   > parse "1.2.3-alpha"    // true, but only because of lexical compare
+///     parse "1.2.3-alpha002" > parse "1.2.3-alpha1"   // false, due to lexical compare
+///     parse "1.5.0-beta.2"   > parse "1.5.0-rc.1"     // false, due to lexical compare of first prerelease identitifer
+///     parse "1.5.0-beta.2"   > parse "1.5.0-beta.3"   // true, due to numeric compare of second prerelease identitifer
+///     parse "1.5.0-0123.001" < parse "1.5.0-0123.002" // true, due to numeric compare of second prerelease identifier
+///     parse "1.0.0+lol"      = parse "1.0.0"          // true, because build identifiers do not influence comparison
 let parse version =
-    let splitted = split '.' version
-    let l = splitted.Length
-    let patch,preRelease =
-        if l <= 2 then 0,"" else
-        let splitted' = split '-' splitted.[2]
-        Int32.Parse splitted'.[0], if splitted'.Length > 1 then splitted'.[1] else ""
+    let startPos (c : char) (s :string) = match s.IndexOf(c) with | -1 -> None | n -> Some n
+    let buildPartStart = startPos '+' version
+    let prereleasePartStart = startPos '-' version
+    let main, pre, build = 
+        match prereleasePartStart, buildPartStart with
+        | None, None -> version, "", ""
+        | Some n, None -> version.[0..n-1], version.[n+1..], ""
+        | None, Some n -> version.[0..n-1], "", version.[n+1..]
+        | Some n, Some m -> version.[0..n-1], version.[n+1..m-1], version.[m+1..]
+    
+    let maj, minor, patch = 
+        match split '.' main with
+        | maj::min::pat::[] -> Int32.Parse maj, Int32.Parse min, Int32.Parse pat
+        | maj::min::[] -> Int32.Parse maj, Int32.Parse min, 0
+        | maj::[] -> Int32.Parse maj, 0, 0
+        | [] -> 0,0,0
+        | _ -> failwith "unknown semver format"
 
-
-    { Major = if l > 0 then Int32.Parse splitted.[0] else 0
-      Minor = if l > 1 then Int32.Parse splitted.[1] else 0
+    { Major = maj
+      Minor = minor
       Patch = patch
-      PreRelease = PreRelease.TryParse preRelease
-      Build = if l > 3 then splitted.[3] else "" 
+      PreRelease = PreRelease.TryParse pre
+      Build = build
     }
 
 

--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -31,6 +31,8 @@ let inline trimSlash (s : string) = s.TrimEnd('\\')
 /// Splits the given string at the given char delimiter
 let inline split (delimiter : char) (text : string) = text.Split [| delimiter |] |> Array.toList
 
+let inline splitRemove (delimiter : char) (text : string) = text.Split ([|delimiter|], StringSplitOptions.RemoveEmptyEntries) |> Array.toList
+
 /// Splits the given string at the given string delimiter
 let inline splitStr (delimiterStr : string) (text : string) = 
     text.Split([| delimiterStr |], StringSplitOptions.None) |> Array.toList

--- a/src/test/Test.FAKECore/ReleaseNotesSpecs.cs
+++ b/src/test/Test.FAKECore/ReleaseNotesSpecs.cs
@@ -132,7 +132,7 @@ namespace Test.FAKECore
 #### 2.0.0-alpha001 - December 15 2013
 * A";
         static readonly ReleaseNotesHelper.ReleaseNotes expected =
-            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-rc007", null, new[] { "A" }.ToFSharpList());
+            ReleaseNotesHelper.ReleaseNotes.New("2.0.0", "2.0.0-rc2", null, new[] { "A" }.ToFSharpList());
 
         It should_parse =
            () => ReleaseNotesHelper.parseReleaseNotes(Notes.FromString(input)).ShouldEqual(expected);

--- a/src/test/Test.FAKECore/SemVerHelperSpecs.cs
+++ b/src/test/Test.FAKECore/SemVerHelperSpecs.cs
@@ -66,7 +66,7 @@ namespace Test.FAKECore
         It should_parse_minor = () => semVer.Minor.ShouldEqual(2);
         It should_parse_patch = () => semVer.Patch.ShouldEqual(3);
         It should_parse_prerelease = () => semVer.PreRelease.ShouldEqual(
-            FSharpOption<SemVerHelper.PreRelease>.Some(new SemVerHelper.PreRelease("alpha", "alpha", FSharpOption<int>.None, new[] { SemVerHelper.PrereleaseIdent.NewAlphaNumeric("alpha") }.ToFSharpList())));
+            FSharpOption<SemVerHelper.PreRelease>.Some(new SemVerHelper.PreRelease("alpha", "alpha", FSharpOption<int>.None, new[] { SemVerHelper.Ident.NewAlphaNumeric("alpha") }.ToFSharpList())));
         It should_parse_build = () => semVer.Build.ShouldEqual("beta");
     }
 

--- a/src/test/Test.FAKECore/SemVerHelperSpecs.cs
+++ b/src/test/Test.FAKECore/SemVerHelperSpecs.cs
@@ -60,13 +60,13 @@ namespace Test.FAKECore
     public class when_parsing_semver_strings
     {
         static SemVerHelper.SemVerInfo semVer;
-        Because of = () => semVer = SemVerHelper.parse("1.2.3-alpha.beta");
+        Because of = () => semVer = SemVerHelper.parse("1.2.3-alpha+beta");
 
         It should_parse_major = () => semVer.Major.ShouldEqual(1);
         It should_parse_minor = () => semVer.Minor.ShouldEqual(2);
         It should_parse_patch = () => semVer.Patch.ShouldEqual(3);
         It should_parse_prerelease = () => semVer.PreRelease.ShouldEqual(
-            FSharpOption<SemVerHelper.PreRelease>.Some(new SemVerHelper.PreRelease("alpha", "alpha", FSharpOption<int>.None)));
+            FSharpOption<SemVerHelper.PreRelease>.Some(new SemVerHelper.PreRelease("alpha", "alpha", FSharpOption<int>.None, new[] { SemVerHelper.PrereleaseIdent.NewAlphaNumeric("alpha") }.ToFSharpList())));
         It should_parse_build = () => semVer.Build.ShouldEqual("beta");
     }
 
@@ -96,9 +96,9 @@ namespace Test.FAKECore
             () => SemVerHelper.parse("1.0.0-alpha.1")
                 .ShouldBeLessThan(SemVerHelper.parse("1.0.0-alpha.beta"));
 
-        It should_assume_alpha_is_smaller_tha_beta =
+        It should_assume_that_longer_prereleases_are_greater =
             () => SemVerHelper.parse("1.0.0-alpha.beta")
-                .ShouldBeLessThan(SemVerHelper.parse("1.0.0-beta"));
+                .ShouldBeGreaterThan(SemVerHelper.parse("1.0.0-beta"));
 
         It should_assume_empty_build_no_in_beta_build_is_smaller_than_text_in_build =
             () => SemVerHelper.parse("1.0.0-beta")
@@ -128,9 +128,9 @@ namespace Test.FAKECore
             () => SemVerHelper.parse("2.3.4-alpha2")
                 .ShouldBeGreaterThan(SemVerHelper.parse("2.3.4-alpha"));
 
-        It should_assume_alpha003_is_greater_than_alpha2 =
+        It should_assume_alpha003_is_less_than_alpha2_because_lexicalsort =
             () => SemVerHelper.parse("2.3.4-alpha003")
-                .ShouldBeGreaterThan(SemVerHelper.parse("2.3.4-alpha2"));
+                .ShouldBeLessThan(SemVerHelper.parse("2.3.4-alpha2"));
 
         It should_assume_rc_is_greater_than_beta2 =
             () => SemVerHelper.parse("2.3.4-rc")


### PR DESCRIPTION
Fixes #1324 by rewriting the prerelease and build parsing sections to adhere to spec, while maintaining the Origin, Name, and Number portions of the current logic.

This has implications for existing uses of this code, because the prior code wasn't up to spec.  This code implements proper comparison for prerelease identifiers, and now discards the build portion in order to compare.

Thoughts?  We hit this when a git sha that we used for stamping prerelease information on a nupkg started with a number and the semver info helper broke :(

Also touches #522 around build information.