### PR TITLE
Add registry support in WiXHelper

### DIFF
--- a/help/wix.md
+++ b/help/wix.md
@@ -13,7 +13,9 @@ FAKE provides you with support for creating MSI setups using the WiX Toolset (ht
             else 
                 false
             
-        // Collect Files which should be shipped. Pass directory with your deployment output for deployDir, along with the targeted architecture.
+        // Collect Files which should be shipped. Pass directory with your deployment output for deployDir
+        // along with the targeted architecture.
+        
         let components = bulkComponentCreation fileFilter (DirectoryInfo deployDir) Architecture.X86
                  
         // Collect component references for usage in features
@@ -102,3 +104,75 @@ You can use the attachServiceToControlComponents function for attaching service 
                                 false) (DirectoryInfo deployDir))
                         componentSelector 
                         [serviceControl]
+      
+                        
+## Registry
+If you need your installer to modify the registry, you can achieve this by creating a component containing `RegistryKey` and `RegistryValue` elements. A `RegistryKey` can have further keys and values nested as children.
+
+### Example
+
+First, define the desired registry layout and add it to a new component:
+
+    let registryDefinition = generateRegistryKey (fun f -> {f with
+                                                              Root = Some WiXRegistryRootType.HKCU
+                                                              Key = "Some key name"
+                                                              Values = [
+                                                                generateRegistryValue(fun v -> 
+                                                                                        {v with
+                                                                                           Name = "Something"
+                                                                                           Type = WiXRegistryValueType.Integer
+                                                                                           Value = "1"
+                                                                                        })
+                                                              ]
+                                                              Keys = [
+                                                                //Could nest more keys here
+                                                              ]
+                                                           })
+                                                          
+    let regComponent = C (generateComponent (fun c -> {c with
+                                                         Id = "RegistryEntries"
+                                                         RegistryKeys = [registryDefinition]
+                                                      }))
+                                                      
+This component needs to be attached to the `TARGETDIR` directory. This effectively means the registry entries should be installed to the target user's machine. For this we will use a `DirectoryRef` pointing to `TARGETDIR`.
+
+    let targetDirRef = generateDirectoryRef (fun r -> {r with
+                                                         Id = "TARGETDIR"
+                                                         Components = [regComponent]
+                                                      })
+    
+The directory reference should be included in the `DirectoryRefs` sequence when calling `FillInWixTemplate`, and a reference to `regComponent` should be added to the relevant feature.
+              
+    let componentRefs = (Seq.append components [regComponent]) |> Seq.map(fun comp -> comp.ToComponentRef())
+    
+    let completeFeature = generateFeatureElement (fun f -> 
+                                                    {f with  
+                                                        Id = "Complete"
+                                                        Title = "Complete Feature"
+                                                        Level = 1 
+                                                        Description = "Installs all features"
+                                                        Components = componentRefs
+                                                        Display = Expand 
+                                                    })
+  
+    FillInWiXTemplate "" (fun f ->
+                            {f with
+                                // Guid which should be generated on every build
+                                ProductCode = Guid.NewGuid()
+                                ProductName = "Test Setup"
+                                Description = "Description of Test Setup"
+                                ProductLanguage = 1033
+                                ProductVersion = "1.0.0"
+                                ProductPublisher = "YouOrYourCompany"
+                                // Set fixed upgrade guid, this should never change for this project!
+                                UpgradeGuid = WixProductUpgradeGuid
+                                MajorUpgrade = [MajorUpgrade]
+                                UIRefs = [WiXUIMondo; WiXUIError]
+                                ProgramFilesFolder = ProgramFiles32
+                                Components = components
+                                BuildNumber = "Build number"
+                                Features = [completeFeature]
+                                DirectoryRefs = [targetDirRef]
+                            })
+
+    


### PR DESCRIPTION
With this change, `WiXHelper` is now capable of generating installers which modify the registry.