### PR TITLE
fixes >> [...] /paket-files/build/fsharp/FAKE/modules/Octokit/Octokit…

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -28,7 +28,7 @@ type private HttpClientWithTimeout(timeout : TimeSpan) as this =
     let setter = lazy(
         match typeof<HttpClientAdapter>.GetField("_http", BindingFlags.NonPublic ||| BindingFlags.Instance) with
         | null -> ()
-        | f -> 
+        | f ->
             match f.GetValue(this) with
             | :? HttpClient as http -> http.Timeout <- timeout
             | _ -> ())
@@ -173,7 +173,7 @@ let getLastRelease owner project (client : Async<GitHubClient>) =
             DraftRelease = draft }
     }
 
-let getReleaseByTag owner project tag (client : Async<GitHubClient>) =
+let getReleaseByTag (owner:string) (project:string) tag (client : Async<GitHubClient>) =
     retryWithArg 5 client <| fun client' -> async {
         let! drafts = Async.AwaitTask <| client'.Repository.Release.GetAll(owner, project)
         let matches = drafts |> Seq.filter (fun (r: Release) -> r.TagName = tag)


### PR DESCRIPTION
….fsx(178,42): error FS0041: A unique overload for method 'GetAll' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: IReleasesClient.GetAll(owner: string, name: string) : Tasks.Task<Collections.Generic.IReadOnlyList<Release>>, IReleasesClient.GetAll(repositoryId: int, options: ApiOptions) : Tasks.Task<Collections.Generic.IReadOnlyList<Release>> <<

this leads f.e. to a build error in https://github.com/fsprojects/ProjectScaffold