### PR TITLE
type annotations for overload resolution

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -173,9 +173,9 @@ let getLastRelease owner project (client : Async<GitHubClient>) =
             DraftRelease = draft }
     }
 
-let getReleaseByTag owner project tag (client : Async<GitHubClient>) =
+let getReleaseByTag (owner:string) (project:string) (tag:string) (client : Async<GitHubClient>) =
     retryWithArg 5 client <| fun client' -> async {
-        let! drafts = Async.AwaitTask <| client'.Repository.Release.GetAll(owner, project)
+        let! drafts = client'.Repository.Release.GetAll(owner, project) |> Async.AwaitTask
         let matches = drafts |> Seq.filter (fun (r: Release) -> r.TagName = tag)
 
         if Seq.isEmpty matches then


### PR DESCRIPTION
ensures the unique overload for 'GetAll' is determined, preventing
```
Error:

        paket-files\build\fsharp\FAKE\modules\Octokit\Octokit.fsx(178,42): 
             error FS0041: A unique overload for method 'GetAll' could not be determined based on type information prior to this program point. 
           A type annotation may be needed. 
           Candidates: 
              IReleasesClient.GetAll(owner: string, name: string) : Tasks.Task<Collections.Generic.IReadOnlyList<Release>>, 
              IReleasesClient.GetAll(repositoryId: int, options: ApiOptions) : Tasks.Task<Collections.Generic.IReadOnlyList<Release>>


Output: [Loading C:\Users\Jared\Github\Forks\VisualFSharpPowerTools\paket-files\build\fsharp\FAKE\modules\Octokit\Octokit.fsx
         Loading C:\Users\Jared\Github\Forks\VisualFSharpPowerTools\build.fsx]
```

