### PR TITLE
Fix detection of GitLab CI with current multi-runner

### DIFF
--- a/src/app/FakeLib/BuildServerHelper.fs
+++ b/src/app/FakeLib/BuildServerHelper.fs
@@ -61,7 +61,7 @@ let travisBuildNumber = environVar "TRAVIS_BUILD_NUMBER"
 
 /// Checks if we are on GitLab CI
 /// [omit]
-let isGitlabCI = environVar "CI_SERVER_NAME" = "GitLab CI"
+let isGitlabCI = getEnvironmentVarAsBool "GITLAB_CI"
 
 /// Build number retrieved from GitLab CI
 /// [omit]


### PR DESCRIPTION
As it seems, the latest multi-runner has changed the content of the "CI_SERVER_NAME" variable to "GitLab" instead of "GitLab CI". In the docs (http://docs.gitlab.com/ce/ci/variables/README.html), they state that we should use the variable "GITLAB_CI", as it is explained with "Mark that build is executed in GitLab CI environment". It is set to the string "true", when we are in GitLab.