### PR TITLE
Perf tuning to prevent extra iteration

### DIFF
--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -394,8 +394,7 @@ type FscParam =
         | Reference dllPath -> sargp "r" dllPath
         | References dllPaths -> 
             dllPaths 
-            |> List.map (sargp "r") 
-            |> List.map (fun x -> sprintf "\"%s\"" x)
+            |> List.map (sargp "r" >> sprintf "\"%s\"") 
             |> String.concat (sprintf "; %s" Environment.NewLine)
             |> (fun x -> x.Substring(1, x.Length - 2))
         | Win32res file -> argp "win32res" file


### PR DESCRIPTION
Prevent extra iteration by composing the two functions when passed into `List.map`.