### PR TITLE
Update FscHelper doc

### DIFF
--- a/help/fsc.md
+++ b/help/fsc.md
@@ -11,94 +11,81 @@ The `Fsc` task can be used in standard FAKE targets:
 
     #r "/path/to/FakeLib.dll"
     open Fake
-    open Fake.FscHelper
 
     Target "Otherthing.dll" (fun _ ->
-      ["Otherthing.fs"; "Otherthing2.fs"]
-      |> Fsc (fun p -> { p with FscTarget = Library })
-	)
-
-    Target "Main.exe" (fun _ ->
-      ["Main.fs"]
-      |> Fsc (fun p ->
-               { p with References =
-                          [ "Something.dll"
-                            "Otherthing.dll" ] })
+        ["Otherthing.fs"; "Otherthing2.fs"]
+        |> FscHelper.compile [
+            FscHelper.Target FscHelper.TargetType.Library
+        ]
+        |> function 0 -> () | c -> failwithf "F# compiler return code: %i" c
     )
 
-    "Something.dll"
-      ==> "Otherthing.dll"
-      ==> "Main.exe"
-    RunTargetOrDefault "Main.exe"
+    Target "Main.exe" (fun _ ->
+        ["Main.fs"]
+        |> FscHelper.compile [
+            FscHelper.References ["Something.dll"; "Otherthing.dll"]
+        ]
+        |> function 0 -> () | c -> failwithf "F# compiler return code: %i" c
+    )
 
-The `Fsc` task takes two arguments: 
+The `FscHelper.compile` task takes two arguments: 
 
-  1. a function which overrides the default compile parameters, and 
+  1. a list of compile parameters (`FscParam`), and
   2. a list of source files.
 
-We start with the list of source files, and send it into the `Fsc` task using F#'s
-`|>` operator. The parameter override function takes the default compile parameters and 
-needs to return the parameters with any, all, or no parameters overridden.
+We start with the list of source files, and send it into the `FscHelper.compile` task using F#'s
+`|>` operator. The list of parameters included in the first argument will override the
+default parameters.
 
 In the above examples, notice that we don't always override the output
-file name. By default `Fsc` will behave exactly the same way as
+file name. By default `FscHelper.compile` will behave exactly the same way as
 `fsc.exe`. If you don't specify an output file: it will use the name of
 the first input file, and the appropriate filename extension.
 
-The `FscTarget` slot also behaves in the same way as the `fsc.exe`
+`FscParam.Target` also behaves in the same way as the `fsc.exe`
 `--target:` switch: if you don't override it, it defaults to an
 executable output type.
 
-You can override all `fsc.exe` compile parameters using the override
-function. Several of them, like `Output`, `References`, etc., are made
-directly available; the others can all be set inside the `OtherParams`
-slot as a list of strings:
+You can override all `fsc.exe` default compile parameters by explicitly passing the values
+you want to use. All F# compiler parameters are available as `FscParam` union cases:
 
-    Target "Something.dll" (fun _ ->    
+    Target "Something.dll" (fun _ ->
         ["Something.fs"]
-        |> Fsc (fun p ->
-                 { p with Output = "Something.dll"
-                          FscTarget = Library
-                          OtherParams =
-                             [ "--nooptimizationdata"
-                               "--checked+" ] })
-	)
+        |> FscHelper.compile [
+            FscHelper.Out "Something.dll"
+            FscHelper.Target FscHelper.TargetType.Library
+            FscHelper.NoOptimizationData
+            FscHelper.Checked true
+        ]
+        |> function 0 -> () | c -> failwithf "F# compiler return code: %i" c
+    )
 
-See the [API docs for Fsc](apidocs/fake-fschelper.html) for details of
+See the [API docs for FscHelper](apidocs/fake-fschelper.html) for details of
 the available parameters.
 
-The `Fsc` task will print any compile warnings or errors. If there's any
-compile error, it will notify you and immediately quit.
-
-## The fsc task
-
-The next task that can compile F# sources starts with a lowercase 'f'.
-It takes exactly the same arguments and can be called in exactly the
-same way as the `Fsc` task. The only difference is that `fsc` _doesn't
-raise any error_--instead, it returns the exit status of the compile
-process. It still does print warnings and errors, though.
+The `FscHelper.compile` task will print any compile warnings or errors. If there's any
+compile error, it won't raise any error to interrupt the build process,
+instead, it returns the exit status of the compile process.
 
 Having an exit status code returned can be useful when you're trying to
 integrate FAKE with other build management tools, e.g. your own CI
 server or a test runner.
 
-## The fscList helper
+## FscHelper.compileFiles
 
-This task is lower level than the previous two. It takes a list of
+This task is lower level than the previous one. It takes a list of
 source files and a list of strings which contains the same arguments
-you'd pass in to the `fsc.exe` command-line tool. Think of it as exactly
-like the `OtherParams` slot shown above, only here it's used to specify
-_all_ the parameters. It too prints warnings and errors, and returns a
-compile exit status code. E.g.:
+you'd pass in to the `fsc.exe` command-line tool. It too prints warnings
+and errors, and returns a compile exit status code. E.g.:
 
-    Target "Something.dll" (fun _ ->
-        ["Something.fs"]
-        |> fscList ["-o"; "Something.dll"; "--target:library"]
-        |> ignore
-	)
+  Target "Something.dll" (fun _ ->
+      ["Something.fs"]
+      |> FscHelper.compileFiles ["-o"; "Something.dll"; "--target:library"]
+      |> ignore
+  )
 
 This task may be useful when you already have compile options in string
 format and just need to pass them in to your build tool. You'd just need
 to split the string on whitespace, and pass the resulting list into
-`fscList`.
+`FscHelper.compileFiles`.
 


### PR DESCRIPTION
When I try the FscHelper it says all methods in the guide are obsolete so this updates the doc to use the new recommended methods. To avoid problems with `Target` I’m not opening the `Fake.FscHelper` module.