### PR TITLE
Make GitVersionHelper PreReleaseNumber Nullable

### DIFF
--- a/src/app/FakeLib/GitVersionHelper.fs
+++ b/src/app/FakeLib/GitVersionHelper.fs
@@ -24,7 +24,7 @@ type GitVersionProperties = {
                                 PreReleaseTag : string;
                                 PreReleaseTagWithDash : string;
                                 PreReleaseLabel : string;
-                                PreReleaseNumber : int;
+                                PreReleaseNumber : Nullable<int>;
                                 BuildMetaData : string;
                                 BuildMetaDataPadded : string;
                                 FullBuildMetaData : string;


### PR DESCRIPTION
In GitVersionHelper, when PreReleaseNumber is empty (null), it results in the cast error below. This pull request fixes the problem by changing PreReleaseNumber from an `int` to a `Nullable<int>`.

```
FsiEvaluationException:

Error: Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Int32'. Path 'PreReleaseNumber', line 1, position 133. ---> System.InvalidCastException: Null object cannot be converted to a value type.
	  at System.Convert.ChangeType (System.Object value, System.Type conversionType, IFormatProvider provider) <0x1073dce90 + 0x007da> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType (Newtonsoft.Json.JsonReader reader, System.Object value, System.Globalization.CultureInfo culture, Newtonsoft.Json.Serialization.JsonContract contract, System.Type targetType) <0x1144c5110 + 0x002c5> in <filename unknown>:0 
	  --- End of inner exception stack trace ---
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType (Newtonsoft.Json.JsonReader reader, System.Object value, System.Globalization.CultureInfo culture, Newtonsoft.Json.Serialization.JsonContract contract, System.Type targetType) <0x1144c5110 + 0x003a5> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) <0x1144ba260 + 0x002a9> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolvePropertyAndCreatorValues (Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, Newtonsoft.Json.JsonReader reader, System.Type objectType) <0x1144c0000 + 0x00458> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObjectUsingCreatorWithParameters (Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract contract, Newtonsoft.Json.Serialization.JsonProperty containerProperty, Newtonsoft.Json.Serialization.ObjectConstructor`1 creator, System.String id) <0x1144bdd10 + 0x004a8> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateNewObject (Newtonsoft.Json.JsonReader reader, Newtonsoft.Json.Serialization.JsonObjectContract objectContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, Newtonsoft.Json.Serialization.JsonProperty containerProperty, System.String id, System.Boolean& createdFromNonDefaultCreator) <0x1144bd9b0 + 0x00199> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) <0x1144ba810 + 0x004ec> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal (Newtonsoft.Json.JsonReader reader, System.Type objectType, Newtonsoft.Json.Serialization.JsonContract contract, Newtonsoft.Json.Serialization.JsonProperty member, Newtonsoft.Json.Serialization.JsonContainerContract containerContract, Newtonsoft.Json.Serialization.JsonProperty containerMember, System.Object existingValue) <0x1144ba260 + 0x000d5> in <filename unknown>:0 
	  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize (Newtonsoft.Json.JsonReader reader, System.Type objectType, Boolean checkAdditionalContent) <0x114498e50 + 0x00223> in <filename unknown>:0 
```