### PR TITLE
Hint shown in for ArgumentException #1355 instead of trying to set it directly

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -31,8 +31,6 @@ let printEnvironment cmdArgs args =
     traceFAKE "FSI-Path: %s" fsiPath
     traceFAKE "MSBuild-Path: %s" msBuildExe
 
-let hostBasedEnvArgs = seq { if isMono then yield "TERM", "xterm-256color" } // avoid problem with unsupported colored terminal output
-
 let containsParam param = Seq.map toLower >> Seq.exists ((=) (toLower param))
 
 let paramIsHelp param = containsParam param ["help"; "?"; "/?"; "-h"; "--help"; "/h"; "/help"]
@@ -89,7 +87,6 @@ try
                           yield! fakeArgs.GetResults <@ Cli.EnvVar @>
                           if fakeArgs.Contains <@ Cli.Single_Target @> then yield "single-target", "true"
                           if args.Target.IsSome then yield "target", args.Target.Value }
-                    |> Seq.append hostBasedEnvArgs
 
                 //Get our fsiargs from somewhere!
                 let fsiArgs = 
@@ -137,7 +134,7 @@ try
                 let buildScriptArg = if cmdArgs.Length > 1 && cmdArgs.[1].EndsWith ".fsx" then cmdArgs.[1] else Seq.head buildScripts
                 let fakeArgs = cmdArgs |> Array.filter (fun x -> x.StartsWith "-d:" = false)
                 let fsiArgs = cmdArgs |> Array.filter (fun x -> x.StartsWith "-d:") |> Array.toList
-                let args = Seq.toList hostBasedEnvArgs @ CommandlineParams.parseArgs (fakeArgs |> Seq.filter ((<>) buildScriptArg) |> Seq.filter ((<>) "details"))
+                let args = CommandlineParams.parseArgs (fakeArgs |> Seq.filter ((<>) buildScriptArg) |> Seq.filter ((<>) "details"))
 
                 traceStartBuild()
                 let printDetails = containsParam "details" cmdArgs

--- a/src/app/FakeLib/TraceListener.fs
+++ b/src/app/FakeLib/TraceListener.fs
@@ -58,14 +58,20 @@ type ConsoleTraceListener(importantMessagesToStdErr, colorMap) =
     let writeText toStdErr color newLine text = 
         let curColor = Console.ForegroundColor
         try
-          if curColor <> color then Console.ForegroundColor <- color
-          let printer =
-            match toStdErr, newLine with
-            | true, true -> eprintfn
-            | true, false -> eprintf
-            | false, true -> printfn
-            | false, false -> printf
-          printer "%s" text
+          try
+            if curColor <> color then Console.ForegroundColor <- color
+            let printer =
+              match toStdErr, newLine with
+              | true, true -> eprintfn
+              | true, false -> eprintf
+              | false, true -> printfn
+              | false, false -> printf
+            printer "%s" text
+          with
+            | :? ArgumentException when EnvironmentHelper.isMono -> 
+              printfn "* Color output has been disabled because of a bug in GNOME Terminal."
+              printfn "* Hint: To workaround this bug, please set environment property TERM=xterm-256color"
+              reraise()
         finally
           if curColor <> color then Console.ForegroundColor <- curColor
     


### PR DESCRIPTION
As mentioned in discussion in #1355, it is not possible to properly set TERM variable for colored output error. We should at least tell user what is really wrong and how to fix it.