### PR TITLE
Check for npm on path variable in NpmHelper on Windows

### DIFF
--- a/src/app/FakeLib/NpmHelper.fs
+++ b/src/app/FakeLib/NpmHelper.fs
@@ -7,8 +7,16 @@ open System.Diagnostics
 
 /// Default paths to Npm
 let private npmFileName =
-    match isUnix with
+    match isWindows with
     | true -> 
+        System.Environment.GetEnvironmentVariable("PATH")
+        |> fun path -> path.Split ';'
+        |> Seq.tryFind (fun p -> p.Contains "nodejs")
+        |> fun res ->
+            match res with
+            | Some npm when File.Exists (sprintf @"%s\npm.cmd" npm) -> (sprintf @"%s\npm.cmd" npm)
+            | _ -> "./packages/Npm.js/tools/npm.cmd"
+    | _ -> 
         let info = new ProcessStartInfo("which","npm")
         info.StandardOutputEncoding <- System.Text.Encoding.UTF8
         info.RedirectStandardOutput <- true
@@ -20,7 +28,8 @@ let private npmFileName =
             | 0 when not proc.StandardOutput.EndOfStream ->
               proc.StandardOutput.ReadLine()
             | _ -> "/usr/bin/npm"
-    | _ -> "./packages/Npm.js/tools/npm.cmd"
+        
+
 
 /// Arguments for the Npm install command
 type InstallArgs =


### PR DESCRIPTION
People on a team have `npm` in different locations, and the easiest way for the `NpmHelpe` to work out of the box would be to pick the location of the `path`-variable. It is painful to handle this manually when we have several projects.

In our projects we do it like this at the moment, but I could not get file globbing to work inside `NpmHelper.fs`:

````
System.Environment.GetEnvironmentVariable("PATH")
|> fun path -> path.Split ';'
|> Seq.append [ @"c:/programdata/scoop/apps/nodejs/"
                @"c:/program Files/nodejs/"
                @"c:/program Files (x86)/nodejs/"
                @"./packages/Npm.js/" ]
|> Seq.map (findToolInSubPath "npm.cmd")
|> Seq.tryFind fileExists
|> function
    | Some r -> r
    | None -> failwith "Unable to locate npm.cmd - if you have npm.cmd in a weird location you'll have to add it to the list in build.fsx. We tried looking in your PATH and some standard locations."
```

Some input would be greatly appreciated!

cc @mastoj 