### PR TITLE
Replace process cache with safe alternative

### DIFF
--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -9,10 +9,17 @@ open System.IO
 open System.Threading
 open System.Text
 open System.Collections.Generic
+open System.Collections.Concurrent
 open System.ServiceProcess
 
 /// [omit]
-let startedProcesses = HashSet()
+type internal ConcurrentBag<'T> with
+    member internal this.Clear() = 
+        while not(this.IsEmpty) do
+            this.TryTake() |> ignore
+
+/// [omit]
+let startedProcesses = ConcurrentBag()
 
 /// [omit]
 let start (proc : Process) = 


### PR DESCRIPTION
ProcessHelper contains a HashSet that is used to capture process id's of all executed processes for later termination.  Starting processes up in a parallel fashion can corrupt this HashSet.  Replacing it with a ConcurrentBag fixes the issue.

This fixes fsharp/FAKE#1374