### PR TITLE
Remmidemmi: call 'traceEndTask' in the finally block of a try-finally, so that it is always closed, even if the task throws an exception.

### DIFF
--- a/src/app/FakeLib/FXCopHelper.fs
+++ b/src/app/FakeLib/FXCopHelper.fs
@@ -88,61 +88,63 @@ let FxCopDefaults =
 let FxCop setParams (assemblies : string seq) = 
     let param = setParams FxCopDefaults
     traceStartTask "FxCop" ""
-    let param = 
-        if param.ApplyOutXsl && param.OutputXslFileName = String.Empty then 
-            { param with OutputXslFileName = param.ToolPath @@ "Xml" @@ "FxCopReport.xsl" }
-        else param
+    try
+        let param = 
+            if param.ApplyOutXsl && param.OutputXslFileName = String.Empty then 
+                { param with OutputXslFileName = param.ToolPath @@ "Xml" @@ "FxCopReport.xsl" }
+            else param
     
-    let commandLineCommands = 
-        let args = ref (new StringBuilder())
+        let commandLineCommands = 
+            let args = ref (new StringBuilder())
         
-        let append predicate (s : string) = 
-            if predicate then args := (!args).Append(s)
+            let append predicate (s : string) = 
+                if predicate then args := (!args).Append(s)
         
-        let appendFormat (format : string) (value : string) = 
-            if value <> String.Empty then args := (!args).AppendFormat(format, value)
+            let appendFormat (format : string) (value : string) = 
+                if value <> String.Empty then args := (!args).AppendFormat(format, value)
         
-        let appendItems format items = items |> Seq.iter (appendFormat format)
-        append param.ApplyOutXsl "/aXsl "
-        append param.DirectOutputToConsole "/c "
-        append param.ForceOutput "/fo "
-        appendFormat "/cXsl:\"{0}\" " param.ConsoleXslFileName
-        appendItems "/d:\"{0}\" " param.DependencyDirectories
-        appendItems "/f:\"{0}\" " assemblies
-        appendItems "/i:\"{0}\" " param.ImportFiles
-        appendFormat "/o:\"{0}\" " param.ReportFileName
-        appendFormat "/oXsl:\"{0}\" " param.OutputXslFileName
-        appendFormat "/plat:\"{0}\" " param.PlatformDirectory
-        appendFormat "/p:\"{0}\" " param.ProjectFile
-        appendFormat "/ruleset:=\"{0}\" " param.CustomRuleset
-        for item in param.RuleLibraries do
-            appendFormat "/r:\"{0}\" " (param.ToolPath @@ "Rules" @@ item)
-        appendItems "/rid:{0} " param.Rules
-        append param.IgnoreGeneratedCode "/ignoregeneratedcode "
-        append param.IncludeSummaryReport "/s "
-        appendFormat "/t:{0} " (separated "," param.TypeList)
-        append param.SaveResultsInProjectFile "/u "
-        append param.Verbose "/v "
-        append param.UseGACSwitch "/gac "
-        appendFormat "/dic:\"{0}\" " param.CustomDictionary
-        (!args).ToString()
+            let appendItems format items = items |> Seq.iter (appendFormat format)
+            append param.ApplyOutXsl "/aXsl "
+            append param.DirectOutputToConsole "/c "
+            append param.ForceOutput "/fo "
+            appendFormat "/cXsl:\"{0}\" " param.ConsoleXslFileName
+            appendItems "/d:\"{0}\" " param.DependencyDirectories
+            appendItems "/f:\"{0}\" " assemblies
+            appendItems "/i:\"{0}\" " param.ImportFiles
+            appendFormat "/o:\"{0}\" " param.ReportFileName
+            appendFormat "/oXsl:\"{0}\" " param.OutputXslFileName
+            appendFormat "/plat:\"{0}\" " param.PlatformDirectory
+            appendFormat "/p:\"{0}\" " param.ProjectFile
+            appendFormat "/ruleset:=\"{0}\" " param.CustomRuleset
+            for item in param.RuleLibraries do
+                appendFormat "/r:\"{0}\" " (param.ToolPath @@ "Rules" @@ item)
+            appendItems "/rid:{0} " param.Rules
+            append param.IgnoreGeneratedCode "/ignoregeneratedcode "
+            append param.IncludeSummaryReport "/s "
+            appendFormat "/t:{0} " (separated "," param.TypeList)
+            append param.SaveResultsInProjectFile "/u "
+            append param.Verbose "/v "
+            append param.UseGACSwitch "/gac "
+            appendFormat "/dic:\"{0}\" " param.CustomDictionary
+            (!args).ToString()
     
-    tracefn "FxCop command\n%s %s" param.ToolPath commandLineCommands
-    let ok = 
-        0 = ExecProcess (fun info -> 
-                info.FileName <- param.ToolPath
-                if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
-                info.Arguments <- commandLineCommands) param.TimeOut
-    if param.ReportFileName <> String.Empty then sendTeamCityFXCopImport param.ReportFileName
-    // test if FxCop test failed
-    if not ok && (param.FailOnError >= FxCopErrorLevel.ToolError) then failwith "FxCop test failed."
-    if param.FailOnError <> FxCopErrorLevel.DontFailBuild && param.ReportFileName <> String.Empty then 
-        let criticalErrors, errors, criticalWarnings, warnings = checkForErrors param.ReportFileName
-        if criticalErrors <> 0 && param.FailOnError >= FxCopErrorLevel.CriticalError then 
-            failwithf "FxCop found %d critical errors." criticalErrors
-        if errors <> 0 && param.FailOnError >= FxCopErrorLevel.Error then failwithf "FxCop found %d errors." errors
-        if criticalWarnings <> 0 && param.FailOnError >= FxCopErrorLevel.CriticalWarning then 
-            failwithf "FxCop found %d critical warnings." criticalWarnings
-        if warnings <> 0 && param.FailOnError >= FxCopErrorLevel.Warning then 
-            failwithf "FxCop found %d warnings." warnings
-    traceEndTask "FxCop" ""
+        tracefn "FxCop command\n%s %s" param.ToolPath commandLineCommands
+        let ok = 
+            0 = ExecProcess (fun info -> 
+                    info.FileName <- param.ToolPath
+                    if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
+                    info.Arguments <- commandLineCommands) param.TimeOut
+        if param.ReportFileName <> String.Empty then sendTeamCityFXCopImport param.ReportFileName
+        // test if FxCop test failed
+        if not ok && (param.FailOnError >= FxCopErrorLevel.ToolError) then failwith "FxCop test failed."
+        if param.FailOnError <> FxCopErrorLevel.DontFailBuild && param.ReportFileName <> String.Empty then 
+            let criticalErrors, errors, criticalWarnings, warnings = checkForErrors param.ReportFileName
+            if criticalErrors <> 0 && param.FailOnError >= FxCopErrorLevel.CriticalError then 
+                failwithf "FxCop found %d critical errors." criticalErrors
+            if errors <> 0 && param.FailOnError >= FxCopErrorLevel.Error then failwithf "FxCop found %d errors." errors
+            if criticalWarnings <> 0 && param.FailOnError >= FxCopErrorLevel.CriticalWarning then 
+                failwithf "FxCop found %d critical warnings." criticalWarnings
+            if warnings <> 0 && param.FailOnError >= FxCopErrorLevel.Warning then 
+                failwithf "FxCop found %d warnings." warnings
+    finally
+        traceEndTask "FxCop" ""

--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -329,35 +329,37 @@ match buildServer with
 ///           |> DoNothing
 let build setParams project =
     traceStartTask "MSBuild" project
-    let args = 
-        MSBuildDefaults
-        |> setParams
-        |> serializeMSBuildParams
+    try
+        let args = 
+            MSBuildDefaults
+            |> setParams
+            |> serializeMSBuildParams
 
-    let errorLoggerParam = 
-        MSBuildLoggers
-        |> List.map (fun a -> Some ("logger", a))
-        |> serializeArgs
+        let errorLoggerParam = 
+            MSBuildLoggers
+            |> List.map (fun a -> Some ("logger", a))
+            |> serializeArgs
     
-    let args = toParam project + " " + args + " " + errorLoggerParam
-    tracefn "Building project: %s\n  %s %s" project msBuildExe args
-    let enableProcessTracingPreviousValue = enableProcessTracing
-    enableProcessTracing <- false
-    let exitCode =
-        ExecProcess (fun info ->  
-            info.FileName <- msBuildExe
-            info.Arguments <- args) TimeSpan.MaxValue
-    enableProcessTracing <- enableProcessTracingPreviousValue
-    if exitCode <> 0 then
-        let errors =
-            System.Threading.Thread.Sleep(200) // wait for the file to write
-            if File.Exists MsBuildLogger.ErrorLoggerFile then
-                File.ReadAllLines(MsBuildLogger.ErrorLoggerFile) |> List.ofArray
-            else []
+        let args = toParam project + " " + args + " " + errorLoggerParam
+        tracefn "Building project: %s\n  %s %s" project msBuildExe args
+        let enableProcessTracingPreviousValue = enableProcessTracing
+        enableProcessTracing <- false
+        let exitCode =
+            ExecProcess (fun info ->  
+                info.FileName <- msBuildExe
+                info.Arguments <- args) TimeSpan.MaxValue
+        enableProcessTracing <- enableProcessTracingPreviousValue
+        if exitCode <> 0 then
+            let errors =
+                System.Threading.Thread.Sleep(200) // wait for the file to write
+                if File.Exists MsBuildLogger.ErrorLoggerFile then
+                    File.ReadAllLines(MsBuildLogger.ErrorLoggerFile) |> List.ofArray
+                else []
         
-        let errorMessage = sprintf "Building %s failed with exitcode %d." project exitCode
-        raise (BuildException(errorMessage, errors))
-    traceEndTask "MSBuild" project
+            let errorMessage = sprintf "Building %s failed with exitcode %d." project exitCode
+            raise (BuildException(errorMessage, errors))
+    finally
+        traceEndTask "MSBuild" project
 
 /// Builds the given project files and collects the output files.
 /// ## Parameters
@@ -439,29 +441,31 @@ let MSBuildReleaseExt outputPath properties targets projects =
 ///  - `projectFile` - The project file path.
 let BuildWebsiteConfig outputPath configuration projectFile  =
     traceStartTask "BuildWebsite" projectFile
-    let projectName = (fileInfo projectFile).Name.Replace(".csproj", "").Replace(".fsproj", "").Replace(".vbproj", "")
+    try
+        let projectName = (fileInfo projectFile).Name.Replace(".csproj", "").Replace(".fsproj", "").Replace(".vbproj", "")
 
-    let slashes (dir : string) =
-        dir.Replace("\\", "/").TrimEnd('/')
-        |> Seq.filter ((=) '/')
-        |> Seq.length
+        let slashes (dir : string) =
+            dir.Replace("\\", "/").TrimEnd('/')
+            |> Seq.filter ((=) '/')
+            |> Seq.length
 
-    let currentDir = (directoryInfo ".").FullName
-    let projectDir = (fileInfo projectFile).Directory.FullName
+        let currentDir = (directoryInfo ".").FullName
+        let projectDir = (fileInfo projectFile).Directory.FullName
 
-    let diff = slashes projectDir - slashes currentDir
-    let prefix = if Path.IsPathRooted outputPath
-                 then ""
-                 else (String.replicate diff "../")
+        let diff = slashes projectDir - slashes currentDir
+        let prefix = if Path.IsPathRooted outputPath
+                     then ""
+                     else (String.replicate diff "../")
 
-    MSBuild null "Build" [ "Configuration", configuration ] [ projectFile ] |> ignore
-    MSBuild null "_CopyWebApplication;_BuiltWebOutputGroupOutput"
-        [ "Configuration", configuration
-          "OutDir", prefix + outputPath
-          "WebProjectOutputDir", prefix + outputPath + "/" + projectName ] [ projectFile ]
-        |> ignore
-    !!(projectDir + "/bin/*.*") |> Copy(outputPath + "/" + projectName + "/bin/")
-    traceEndTask "BuildWebsite" projectFile
+        MSBuild null "Build" [ "Configuration", configuration ] [ projectFile ] |> ignore
+        MSBuild null "_CopyWebApplication;_BuiltWebOutputGroupOutput"
+            [ "Configuration", configuration
+              "OutDir", prefix + outputPath
+              "WebProjectOutputDir", prefix + outputPath + "/" + projectName ] [ projectFile ]
+            |> ignore
+        !!(projectDir + "/bin/*.*") |> Copy(outputPath + "/" + projectName + "/bin/")
+    finally
+        traceEndTask "BuildWebsite" projectFile
 
 /// Builds the given web project file with debug configuration and copies it to the given outputPath.
 /// ## Parameters

--- a/src/app/FakeLib/NDependHelper.fs
+++ b/src/app/FakeLib/NDependHelper.fs
@@ -43,13 +43,15 @@ let buildNDependArgs parameters =
 let NDepend(setParams : NDependParams -> NDependParams) = 
     let taskName = "NDepend"
     traceStartTask taskName ""
-    let parameters = (NDependDefaults |> setParams)
-    let args = buildNDependArgs parameters
-    trace (parameters.ToolPath + " " + args)
-    let result = 
-        ExecProcess (fun info -> 
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- getWorkingDir parameters.WorkingDir
-            info.Arguments <- args) TimeSpan.MaxValue
-    if result <> 0 then failwithf "Error running %s" parameters.ToolPath
-    traceEndTask taskName ""
+    try
+        let parameters = (NDependDefaults |> setParams)
+        let args = buildNDependArgs parameters
+        trace (parameters.ToolPath + " " + args)
+        let result = 
+            ExecProcess (fun info -> 
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- getWorkingDir parameters.WorkingDir
+                info.Arguments <- args) TimeSpan.MaxValue
+        if result <> 0 then failwithf "Error running %s" parameters.ToolPath
+    finally
+        traceEndTask taskName ""

--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -87,19 +87,21 @@ let buildMSTestArgs parameters assembly =
 let MSTest (setParams : MSTestParams -> MSTestParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
     traceStartTask "MSTest" details
-    let parameters = MSTestDefaults |> setParams
-    let assemblies = assemblies |> Seq.toArray
-    if Array.isEmpty assemblies then failwith "MSTest: cannot run tests (the assembly list is empty)."
-    let failIfError assembly exitCode = 
-        if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
-            let message = sprintf "%sMSTest test run failed for %s" Environment.NewLine assembly
-            traceError message
-            failwith message
-    for assembly in assemblies do
-        let args = buildMSTestArgs parameters assembly
-        ExecProcess (fun info -> 
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- parameters.WorkingDir
-            info.Arguments <- args) parameters.TimeOut
-        |> failIfError assembly
-    traceEndTask "MSTest" details
+    try
+        let parameters = MSTestDefaults |> setParams
+        let assemblies = assemblies |> Seq.toArray
+        if Array.isEmpty assemblies then failwith "MSTest: cannot run tests (the assembly list is empty)."
+        let failIfError assembly exitCode = 
+            if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
+                let message = sprintf "%sMSTest test run failed for %s" Environment.NewLine assembly
+                traceError message
+                failwith message
+        for assembly in assemblies do
+            let args = buildMSTestArgs parameters assembly
+            ExecProcess (fun info -> 
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- parameters.WorkingDir
+                info.Arguments <- args) parameters.TimeOut
+            |> failIfError assembly
+    finally
+        traceEndTask "MSTest" details

--- a/src/app/FakeLib/UnitTest/MSpecHelper.fs
+++ b/src/app/FakeLib/UnitTest/MSpecHelper.fs
@@ -83,15 +83,17 @@ let buildMSpecArgs parameters assemblies =
 let MSpec setParams assemblies = 
     let details = separated ", " assemblies
     traceStartTask "MSpec" details
-    let parameters = setParams MSpecDefaults
-    let args = buildMSpecArgs parameters assemblies
-    trace (parameters.ToolPath + " " + args)
-    if 0 <> ExecProcess (fun info -> 
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-    then 
-        sprintf "MSpec test failed on %s." details |> match parameters.ErrorLevel with
-                                                      | Error | FailOnFirstError -> failwith
-                                                      | DontFailBuild -> traceImportant
-    traceEndTask "MSpec" details
+    try
+        let parameters = setParams MSpecDefaults
+        let args = buildMSpecArgs parameters assemblies
+        trace (parameters.ToolPath + " " + args)
+        if 0 <> ExecProcess (fun info -> 
+                    info.FileName <- parameters.ToolPath
+                    info.WorkingDirectory <- parameters.WorkingDir
+                    info.Arguments <- args) parameters.TimeOut
+        then 
+            sprintf "MSpec test failed on %s." details |> match parameters.ErrorLevel with
+                                                          | Error | FailOnFirstError -> failwith
+                                                          | DontFailBuild -> traceImportant
+    finally
+        traceEndTask "MSpec" details

--- a/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
+++ b/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
@@ -62,20 +62,22 @@ let runConsoleTests parameters processes =
 ///     )
 let RunConsoleTests setParams processes = 
     traceStartTask "RunConsoleTests" ""
-    let parameters = setParams ProcessTestRunnerDefaults
+    try
+        let parameters = setParams ProcessTestRunnerDefaults
     
-    let execute() = 
-        runConsoleTests parameters processes
-        |> Seq.map (fun (f, a, m) -> sprintf "Process %s %s terminated with %s" f a m)
-        |> toLines
-    match parameters.ErrorLevel with
-    | TestRunnerErrorLevel.DontFailBuild -> execute() |> trace
-    | TestRunnerErrorLevel.Error -> 
-        let msg = execute()
-        if msg <> "" then failwith msg
-    | TestRunnerErrorLevel.FailOnFirstError -> 
-        for fileName, args in processes do
-            match RunConsoleTest parameters fileName args with
-            | Some error -> failwithf "Process %s %s terminated with %s" fileName args error
-            | _ -> ()
-    traceEndTask "RunConsoleTests" ""
+        let execute() = 
+            runConsoleTests parameters processes
+            |> Seq.map (fun (f, a, m) -> sprintf "Process %s %s terminated with %s" f a m)
+            |> toLines
+        match parameters.ErrorLevel with
+        | TestRunnerErrorLevel.DontFailBuild -> execute() |> trace
+        | TestRunnerErrorLevel.Error -> 
+            let msg = execute()
+            if msg <> "" then failwith msg
+        | TestRunnerErrorLevel.FailOnFirstError -> 
+            for fileName, args in processes do
+                match RunConsoleTest parameters fileName args with
+                | Some error -> failwithf "Process %s %s terminated with %s" fileName args error
+                | _ -> ()
+    finally
+        traceEndTask "RunConsoleTests" ""

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
@@ -151,10 +151,10 @@ let xUnitSingle setParams assembly =
     traceStartTask "xUnit" assembly
 
     let parameters = XUnitDefaults |> setParams
-
-    runXUnitForOneAssembly parameters assembly |> ignore
-
-    traceEndTask "xUnit" assembly
+    try
+        runXUnitForOneAssembly parameters assembly |> ignore
+    finally
+        traceEndTask "xUnit" assembly
 
 let internal overrideAssemblyReportParams assembly p =
     let prependAssemblyName path =
@@ -194,13 +194,13 @@ let internal overrideAssemblyReportParams assembly p =
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit" details
+    try
+        let parameters = XUnitDefaults |> setParams
 
-    let parameters = XUnitDefaults |> setParams
+        let assemblyResults =
+            assemblies
+            |> Seq.map (fun a -> a, runXUnitForOneAssembly (parameters |> overrideAssemblyReportParams a) a)
 
-    let assemblyResults =
-        assemblies
-        |> Seq.map (fun a -> a, runXUnitForOneAssembly (parameters |> overrideAssemblyReportParams a) a)
-
-    ResultHandling.failBuildIfXUnitReportedErrors parameters.ErrorLevel assemblyResults
-
-    traceEndTask "xUnit" details
+        ResultHandling.failBuildIfXUnitReportedErrors parameters.ErrorLevel assemblyResults
+    finally
+        traceEndTask "xUnit" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -261,19 +261,20 @@ module internal ResultHandling =
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit2" details
-    let parametersFirst = setParams XUnit2Defaults
+    try
+        let parametersFirst = setParams XUnit2Defaults
 
-    let parameters =
-        if parametersFirst.NoAppDomain
-        then discoverNoAppDomainExists parametersFirst
-        else parametersFirst
+        let parameters =
+            if parametersFirst.NoAppDomain
+            then discoverNoAppDomainExists parametersFirst
+            else parametersFirst
 
-    let result =
-        ExecProcess (fun info ->
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- defaultArg parameters.WorkingDir "."
-            info.Arguments <- parameters |> buildXUnit2Args assemblies) parameters.TimeOut
+        let result =
+            ExecProcess (fun info ->
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- defaultArg parameters.WorkingDir "."
+                info.Arguments <- parameters |> buildXUnit2Args assemblies) parameters.TimeOut
 
-    ResultHandling.failBuildIfXUnitReportedError parameters.ErrorLevel result
-
-    traceEndTask "xUnit2" details
+        ResultHandling.failBuildIfXUnitReportedError parameters.ErrorLevel result
+    finally
+        traceEndTask "xUnit2" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
@@ -190,22 +190,24 @@ let buildXUnit2Args parameters assembly =
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit2" details
-    let parameters = setParams XUnit2Defaults
+    try
+        let parameters = setParams XUnit2Defaults
 
-    let runTests assembly =
-        let args = buildXUnit2Args parameters assembly
-        0 = ExecProcess (fun info ->
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
+        let runTests assembly =
+            let args = buildXUnit2Args parameters assembly
+            0 = ExecProcess (fun info ->
+                    info.FileName <- parameters.ToolPath
+                    info.WorkingDirectory <- parameters.WorkingDir
+                    info.Arguments <- args) parameters.TimeOut
 
-    let failedTests =
-        [ for asm in List.ofSeq assemblies do
-              if runTests asm |> not then yield asm ]
+        let failedTests =
+            [ for asm in List.ofSeq assemblies do
+                  if runTests asm |> not then yield asm ]
 
-    if not (List.isEmpty failedTests) then
-        sprintf "xUnit2 failed for the following assemblies: %s" (separated ", " failedTests)
-        |> match parameters.ErrorLevel with
-           | Error | FailOnFirstError -> failwith
-           | DontFailBuild -> traceImportant
-    traceEndTask "xUnit2" details
+        if not (List.isEmpty failedTests) then
+            sprintf "xUnit2 failed for the following assemblies: %s" (separated ", " failedTests)
+            |> match parameters.ErrorLevel with
+               | Error | FailOnFirstError -> failwith
+               | DontFailBuild -> traceImportant
+    finally
+        traceEndTask "xUnit2" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
@@ -123,22 +123,24 @@ let buildXUnitArgs parameters assembly =
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit" details
-    let parameters = setParams XUnitDefaults
+    try
+        let parameters = setParams XUnitDefaults
 
-    let runTests assembly =
-        let args = buildXUnitArgs parameters assembly
-        0 = ExecProcess (fun info ->
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
+        let runTests assembly =
+            let args = buildXUnitArgs parameters assembly
+            0 = ExecProcess (fun info ->
+                    info.FileName <- parameters.ToolPath
+                    info.WorkingDirectory <- parameters.WorkingDir
+                    info.Arguments <- args) parameters.TimeOut
 
-    let failedTests =
-        [ for asm in List.ofSeq assemblies do
-              if runTests asm |> not then yield asm ]
+        let failedTests =
+            [ for asm in List.ofSeq assemblies do
+                  if runTests asm |> not then yield asm ]
 
-    if not (List.isEmpty failedTests) then
-        sprintf "xUnit failed for the following assemblies: %s" (separated ", " failedTests)
-        |> match parameters.ErrorLevel with
-           | Error | FailOnFirstError -> failwith
-           | DontFailBuild -> traceImportant
-    traceEndTask "xUnit" details
+        if not (List.isEmpty failedTests) then
+            sprintf "xUnit failed for the following assemblies: %s" (separated ", " failedTests)
+            |> match parameters.ErrorLevel with
+               | Error | FailOnFirstError -> failwith
+               | DontFailBuild -> traceImportant
+    finally
+        traceEndTask "xUnit" details


### PR DESCRIPTION
should fix all / most issues similar to this: https://github.com/fsharp/FAKE/issues/1079

Script

[FakeTestTests.zip](https://github.com/fsharp/FAKE/files/478621/FakeTestTests.zip)

```
Target "Test" (fun _ ->
  System.Diagnostics.Debugger.Launch() |> ignore
  try
    [ @"C:\Users\lr\Documents\visual studio 2015\Projects\FakeTestTests\test\FakeTestTests.exe" ]
    |> Fake.Testing.XUnit2.xUnit2 (fun p ->
        {p with
                XmlOutputPath = Some <| testDir + "TestResults.xml" })
  with
  | _ -> printfn "Got an Exception!"
)
```

Before
![image](https://cloud.githubusercontent.com/assets/4236651/18614693/fa6667ac-7d93-11e6-8044-35fc37938610.png)

after
![image](https://cloud.githubusercontent.com/assets/4236651/18614697/056fad7a-7d94-11e6-80fc-eeb42516272c.png)

I have only tested the XUnit tasks, but since the same pattern was appliead in other places, I also wrapped these in try-finally.

