### PR TITLE
Allow to pass parameter to sonarqube end

### DIFF
--- a/FAKE.sln
+++ b/FAKE.sln
@@ -52,6 +52,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "help", "help", "{564BD198-0
 		help\nuget.md = help\nuget.md
 		help\octopusdeploy.md = help\octopusdeploy.md
 		help\slacknotification.md = help\slacknotification.md
+		help\sonarcube.md = help\sonarcube.md
 		help\specifictargets.md = help\specifictargets.md
 		help\teamcity.md = help\teamcity.md
 		help\templates\template-project.html = help\templates\template-project.html

--- a/help/sonarcube.md
+++ b/help/sonarcube.md
@@ -15,21 +15,17 @@ compilation has finished. Then the result is collected and send to the SonarQube
 ## Minimal working example
 
     Target "BeginSonarQube" (fun _ ->
-
       SonarQube Begin (fun p ->
         {p with
          Key = "MyProject"
          Name = "Main solution"
          Version = "1.0.0" }
         )
+      )
 
     Target "EndSonarQube" (fun _ ->
-      SonarQube End (fun p ->
-        {p with
-         Key = "MyProject"
-         Name = "Main solution"
-         Version = "1.0.0" }
-        )
+      SonarQubeEnd()
+    )
 
     Target "Default" DoNothing
 

--- a/src/app/FakeLib/SonarQubeHelper.fs
+++ b/src/app/FakeLib/SonarQubeHelper.fs
@@ -34,17 +34,16 @@ let SonarQubeDefaults =
 let SonarQubeCall (call: SonarQubeCall) (parameters : SonarQubeParams) =
   let sonarPath = parameters.ToolsPath 
   let setArgs = parameters.Settings |> List.fold (fun acc x -> acc + "/d:"+x+" ") ""
-    //match parameters.Settings with
-    //| Some(x) -> (" /d:"+x)
-    //| None -> ""
+
   let cfgArgs = 
     match parameters.Config with
     | Some(x) -> (" /s:"+x) 
     | None -> ""
+  
   let args = 
     match call with
     | Begin -> "begin /k:\"" + parameters.Key + "\" /n:\"" + parameters.Name + "\" /v:\"" + parameters.Version + "\" " + setArgs + cfgArgs
-    | End -> "end"
+    | End -> "end " + setArgs + cfgArgs
 
   let result =
     ExecProcess (fun info ->
@@ -52,7 +51,7 @@ let SonarQubeCall (call: SonarQubeCall) (parameters : SonarQubeParams) =
       info.Arguments <- args) System.TimeSpan.MaxValue
   if result <> 0 then failwithf "Error during sonar qube call %s" (call.ToString())
 
-/// This task to can be used to run [Sonar Qube](http://conarqube.org/) on a project.
+/// This task to can be used to run [Sonar Qube](http://sonarqube.org/) on a project.
 /// ## Parameters
 ///
 ///  - `call` - Begin or End, to start analysis or finish it
@@ -71,3 +70,12 @@ let SonarQube (call: SonarQubeCall) setParams =
     let parameters = setParams SonarQubeDefaults
     SonarQubeCall call parameters
     traceEndTask "SonarQube" (call.ToString())
+
+/// This task can be used to run the end command of [Sonar Qube](http://sonarqube.org/) on a project.
+///
+/// ## Sample
+
+///   SonarQubeEnd
+///
+let SonarQubeEnd() =
+    SonarQube End (fun p -> { p with Settings = [] })


### PR DESCRIPTION
Useful when using SonarQube public server with token.
And add simple method for SonarQubeEnd without arguments.