### PR TITLE
NuGetVersion: adds application/xml to request accept header

### DIFF
--- a/src/app/FakeLib/NuGet/NugetVersion.fs
+++ b/src/app/FakeLib/NuGet/NugetVersion.fs
@@ -51,7 +51,7 @@ let getLastNuGetVersion server (packageName:string) =
       sprintf "%s/Search()?$filter=IsLatestVersion&searchTerm='%s'&includePrerelease=false"
         server packageName
     let client = new WebClient()
-    client.Headers.Add("Accept", "application/json")
+    client.Headers.Add("Accept", "application/json, application/xml")
     let text = client.DownloadString url
     let hasContentType = client.ResponseHeaders.AllKeys |> Seq.contains "Content-Type"
     let version =


### PR DESCRIPTION
When trying to get the current version of a NuGet package from a private Artifactory NuGet source, we got the following exception:

	System.Net.WebException: The remote server returned an error: (406) Not Acceptable.
		at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
		at System.Net.WebClient.DownloadString(Uri address)
		at System.Net.WebClient.DownloadString(String address)
		at Fake.NuGetVersion.getLastNuGetVersion(String server, String packageName) in C:\code\fake\src\app\FakeLib\NuGet\NugetVersion.fs:line 55

It turned out that Artifactory (as of version 4.2.1) does not support the NuGet json format.
Adding "application/xml" to the accept header of the request, fixes this problem.