### PR TITLE
traceStartTask / traceEndTask: use 'use' block

### DIFF
--- a/src/app/Fake.IIS/IISExpress.fs
+++ b/src/app/Fake.IIS/IISExpress.fs
@@ -65,15 +65,13 @@ let createConfigFile (name, siteId : int, templateFileName, path, hostName, port
 let HostWebsite setParams configFileName siteId = 
     let parameters = setParams IISExpressDefaults
 
-    traceStartTask "StartWebSite" configFileName
+    use __ = traceStartTaskUsing "StartWebSite" configFileName
     let args = sprintf "/config:\"%s\" /siteid:%d" configFileName siteId
     tracefn "Starting WebSite with %s %s" parameters.ToolPath args
 
     let proc = 
         ProcessStartInfo(FileName = parameters.ToolPath, Arguments = args, UseShellExecute = false) 
         |> Process.Start
-
-    traceEndTask "StartWebSite" configFileName
 
     proc
 

--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -183,7 +183,7 @@ let private getSortedAndNumberedAttributes (attrs: seq<Attribute>) =
 /// Creates a C# AssemblyInfo file with the given attributes and configuration.
 /// The generated AssemblyInfo file contains an AssemblyVersionInformation class which can be used to retrieve the current version no. from inside of an assembly.
 let CreateCSharpAssemblyInfoWithConfig outputFileName attributes (config : AssemblyInfoFileConfig) =
-    traceStartTask "AssemblyInfo" outputFileName
+    use __ = traceStartTaskUsing "AssemblyInfo" outputFileName
     let generateClass, useNamespace, emitResharperSupressions = config.GenerateClass, config.UseNamespace, config.EmitResharperSuppressions
 
     let  dependencies =
@@ -226,12 +226,11 @@ let CreateCSharpAssemblyInfoWithConfig outputFileName attributes (config : Assem
 
     attributeLines @ sourceLines
     |> writeToFile outputFileName
-    traceEndTask "AssemblyInfo" outputFileName
 
 /// Creates a F# AssemblyInfo file with the given attributes and configuration.
 /// The generated AssemblyInfo file contains an AssemblyVersionInformation class which can be used to retrieve the current version no. from inside of an assembly.
 let CreateFSharpAssemblyInfoWithConfig outputFileName attributes (config : AssemblyInfoFileConfig) =
-    traceStartTask "AssemblyInfo" outputFileName
+    use __ = traceStartTaskUsing "AssemblyInfo" outputFileName
     let generateClass, useNamespace = config.GenerateClass, config.UseNamespace
 
     let sourceLines =
@@ -257,12 +256,11 @@ let CreateFSharpAssemblyInfoWithConfig outputFileName attributes (config : Assem
         ]
 
     sourceLines |> writeToFile outputFileName
-    traceEndTask "AssemblyInfo" outputFileName
 
 /// Creates a VB AssemblyInfo file with the given attributes and configuration.
 /// The generated AssemblyInfo file contains an AssemblyVersionInformation class which can be used to retrieve the current version no. from inside of an assembly.
 let CreateVisualBasicAssemblyInfoWithConfig outputFileName attributes (config : AssemblyInfoFileConfig) =
-    traceStartTask "AssemblyInfo" outputFileName
+    use __ = traceStartTaskUsing "AssemblyInfo" outputFileName
     let generateClass, useNamespace = config.GenerateClass, config.UseNamespace
 
     let attributeLines =
@@ -284,12 +282,11 @@ let CreateVisualBasicAssemblyInfoWithConfig outputFileName attributes (config : 
 
     attributeLines @ sourceLines
     |> writeToFile outputFileName
-    traceEndTask "AssemblyInfo" outputFileName
 
 /// Creates a C++/CLI AssemblyInfo file with the given attributes and configuration.
 /// Does not generate an AssemblyVersionInformation class.
 let CreateCppCliAssemblyInfoWithConfig outputFileName attributes (config : AssemblyInfoFileConfig) =
-    traceStartTask "AssemblyInfo" outputFileName
+    use __ = traceStartTaskUsing "AssemblyInfo" outputFileName
     let generateClass, useNamespace = config.GenerateClass, config.UseNamespace
     //C++/CLI namespaces cannot be fully qualified; you must
     // namespace Namespace1 {  namespace Namespace2 { }} //etc
@@ -303,7 +300,6 @@ let CreateCppCliAssemblyInfoWithConfig outputFileName attributes (config : Assem
 
     attributeLines
     |> writeToFile outputFileName
-    traceEndTask "AssemblyInfo" outputFileName
 
 /// Creates a C# AssemblyInfo file with the given attributes.
 /// The generated AssemblyInfo file contains an AssemblyVersionInformation class which can be used to retrieve the current version no. from inside of an assembly.

--- a/src/app/FakeLib/AssemblyInfoHelper.fs
+++ b/src/app/FakeLib/AssemblyInfoHelper.fs
@@ -130,7 +130,7 @@ let generateFile param (attributes : Dictionary<string, string>) imports (writer
 [<Obsolete("Please use the new AssemblyInfoFile tasks")>]
 let AssemblyInfo setParams = 
     let param' = setParams AssemblyInfoDefaults
-    traceStartTask "AssemblyInfo" param'.OutputFileName
+    use __ = traceStartTaskUsing "AssemblyInfo" param'.OutputFileName
     let param'' = 
         if param'.AssemblyFileVersion <> String.Empty then param'
         else { param' with AssemblyFileVersion = param'.AssemblyVersion }
@@ -199,7 +199,6 @@ let AssemblyInfo setParams =
     writer.Flush()
     writer.Close()
     tracefn "Created AssemblyInfo file \"%s\"." param.OutputFileName
-    traceEndTask "AssemblyInfo" param'.OutputFileName
 
 type AssemblyInfoReplacementParams = 
     { OutputFileName : string

--- a/src/app/FakeLib/CMake.fs
+++ b/src/app/FakeLib/CMake.fs
@@ -161,14 +161,13 @@ module CMake =
         // CMake expects the binary directory to be passed as an argument.
         let arguments = if (String.IsNullOrEmpty args) then "\"" + binaryDir + "\"" else args
         let fullCommand = cmakeExe + " " + arguments
-        traceStartTask "CMake" fullCommand
+        use __ = traceStartTaskUsing "CMake" fullCommand
         let setInfo (info:ProcessStartInfo) =
             info.FileName <- cmakeExe
             info.WorkingDirectory <- binaryDir
             info.Arguments <- arguments
         let result = ExecProcess (setInfo) timeout
         if result <> 0 then failwithf "CMake failed with exit code %i." result
-        traceEndTask "CMake" fullCommand
 
     /// Calls `cmake` to generate a project.
     /// ## Parameters

--- a/src/app/FakeLib/ChocoHelper.fs
+++ b/src/app/FakeLib/ChocoHelper.fs
@@ -349,13 +349,12 @@ module Choco =
             let found = FindExe
             if found <> None then found.Value else failwith "Cannot find the choco executable."
 
-        traceStartTask "choco" args
+        use __ = traceStartTaskUsing "choco" args
         let setInfo (info:ProcessStartInfo) =
             info.FileName <- chocoExe
             info.Arguments <- args
         let result = ExecProcess (setInfo) timeout
         if result <> 0 then failwithf "choco failed with exit code %i." result
-        traceEndTask "choco" args
         
     let private getTempFolder =
         let tempFolder = directoryInfo (Path.GetTempPath() @@ "FakeChocolateyPack")

--- a/src/app/FakeLib/CscHelper.fs
+++ b/src/app/FakeLib/CscHelper.fs
@@ -113,9 +113,8 @@ let csc (setParams : CscParams -> CscParams) (inputFiles : string list) : int =
     let debug = if cscParams.Debug then [ "/debug" ] else []
     let argList =
         output @ target @ platform @ references @ debug @ cscParams.OtherParams
-    traceStartTask "Csc " taskDesc
+    use __ = traceStartTaskUsing "Csc " taskDesc
     let res = cscExe cscParams.ToolPath inputFiles argList
-    traceEndTask "Csc " taskDesc
     res
 
 /// Compiles one or more C# source files with the specified parameters.

--- a/src/app/FakeLib/DocFxHelper.fs
+++ b/src/app/FakeLib/DocFxHelper.fs
@@ -41,7 +41,7 @@ let DocFxDefaults =
 let DocFx setParams = 
     let parameters = DocFxDefaults |> setParams
     
-    traceStartTask "DocFx" parameters.DocFxJson
+    use __ = traceStartTaskUsing "DocFx" parameters.DocFxJson
     
     let serveArg = if parameters.Serve then "--serve" else ""
     let configArg = parameters.DocFxJson |> FullName
@@ -54,6 +54,4 @@ let DocFx setParams =
           info.WorkingDirectory <- parameters.WorkingDirectory
         ) parameters.Timeout
       then failwith "DocFx generation failed."
-
-    traceEndTask "DocFx" parameters.DocFxJson
     

--- a/src/app/FakeLib/DocuHelper.fs
+++ b/src/app/FakeLib/DocuHelper.fs
@@ -31,7 +31,7 @@ let DocuDefaults =
 ///  - `assemblies` - Sequence of one or more assemblies containing the XML docs.
 let Docu setParams assemblies = 
     let details = assemblies |> separated ", "
-    traceStartTask "Docu" details
+    use __ = traceStartTaskUsing "Docu" details
     let parameters = DocuDefaults |> setParams
     
     let files = 
@@ -46,4 +46,3 @@ let Docu setParams assemblies =
                 info.FileName <- parameters.ToolPath |> FullName
                 info.Arguments <- args) parameters.TimeOut
     then failwith "Documentation generation failed."
-    traceEndTask "Docu" details

--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -182,19 +182,16 @@ let DotCoverReport (setParams: DotCoverReportParams -> DotCoverReportParams) =
 let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnitParams -> NUnitParams) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverNUnit" details
+    use __ = traceStartTaskUsing "DotCoverNUnit" details
 
-    try
-        let parameters = NUnitDefaults |> setNUnitParams
-        let args = buildNUnitdArgs parameters assemblies
+    let parameters = NUnitDefaults |> setNUnitParams
+    let args = buildNUnitdArgs parameters assemblies
     
-        DotCover (fun p ->
-                      {p with
-                         TargetExecutable = parameters.ToolPath @@ parameters.ToolName
-                         TargetArguments = args
-                      } |> setDotCoverParams)
-    finally
-        traceEndTask "DotCoverNUnit" details
+    DotCover (fun p ->
+                    {p with
+                        TargetExecutable = parameters.ToolPath @@ parameters.ToolName
+                        TargetArguments = args
+                    } |> setDotCoverParams)
 
 /// Runs the dotCover "cover" command against the NUnit test runner.
 /// ## Parameters
@@ -213,19 +210,16 @@ let DotCoverNUnit (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUni
 let DotCoverNUnit3 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUnitParams: NUnit3Params -> NUnit3Params) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverNUnit3" details
+    use __ = traceStartTaskUsing "DotCoverNUnit3" details
 
-    try
-        let parameters = NUnit3Defaults |> setNUnitParams
-        let args = buildNUnit3Args parameters assemblies
+    let parameters = NUnit3Defaults |> setNUnitParams
+    let args = buildNUnit3Args parameters assemblies
     
-        DotCover (fun p ->
-                      {p with
-                         TargetExecutable = parameters.ToolPath
-                         TargetArguments = args
-                      } |> setDotCoverParams)
-    finally
-        traceEndTask "DotCoverNUnit3" details
+    DotCover (fun p ->
+                    {p with
+                        TargetExecutable = parameters.ToolPath
+                        TargetArguments = args
+                    } |> setDotCoverParams)
 
 /// Runs the dotCover "cover" command against the XUnit2 test runner.
 /// ## Parameters
@@ -242,19 +236,16 @@ let DotCoverNUnit3 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setNUn
 let DotCoverXUnit2 (setDotCoverParams: DotCoverParams -> DotCoverParams) (setXUnit2Params: XUnit2Params -> XUnit2Params) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverXUnit2" details
+    use __ = traceStartTaskUsing "DotCoverXUnit2" details
 
-    try
-        let parameters = XUnit2Defaults |> setXUnit2Params
-        let args = buildXUnit2Args assemblies parameters 
+    let parameters = XUnit2Defaults |> setXUnit2Params
+    let args = buildXUnit2Args assemblies parameters 
     
-        DotCover (fun p ->
-                      {p with
-                         TargetExecutable = parameters.ToolPath 
-                         TargetArguments = args
-                      } |> setDotCoverParams)
-    finally
-        traceEndTask "DotCoverXUnit2" details
+    DotCover (fun p ->
+                    {p with
+                        TargetExecutable = parameters.ToolPath 
+                        TargetArguments = args
+                    } |> setDotCoverParams)
 
 /// Builds the command line arguments from the given parameter record and the given assemblies.
 /// Runs all test assemblies in the same run for easier coverage management. 
@@ -290,19 +281,16 @@ let internal buildMSTestArgsForDotCover parameters assemblies =
 let DotCoverMSTest (setDotCoverParams: DotCoverParams -> DotCoverParams) (setMSTestParams: MSTestParams -> MSTestParams) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverMSTest " details
+    use __ = traceStartTaskUsing "DotCoverMSTest " details
 
-    try
-        let parameters = MSTestDefaults |> setMSTestParams
-        let args = buildMSTestArgsForDotCover parameters assemblies
+    let parameters = MSTestDefaults |> setMSTestParams
+    let args = buildMSTestArgsForDotCover parameters assemblies
     
-        DotCover (fun p ->
-                      {p with
-                         TargetExecutable = parameters.ToolPath 
-                         TargetArguments = args
-                      } |> setDotCoverParams)
-    finally
-        traceEndTask "DotCoverMSTest" details
+    DotCover (fun p ->
+                    {p with
+                        TargetExecutable = parameters.ToolPath 
+                        TargetArguments = args
+                    } |> setDotCoverParams)
 
 /// Runs the dotCover "cover" command against the MSpec test runner.
 /// ## Parameters
@@ -321,17 +309,14 @@ let DotCoverMSTest (setDotCoverParams: DotCoverParams -> DotCoverParams) (setMST
 let DotCoverMSpec (setDotCoverParams: DotCoverParams -> DotCoverParams) (setMSpecParams: MSpecParams -> MSpecParams) (assemblies: string seq) =
     let assemblies = assemblies |> Seq.toArray
     let details =  assemblies |> separated ", "
-    traceStartTask "DotCoverMSpec" details
+    use __ = traceStartTaskUsing "DotCoverMSpec" details
 
-    try
-        let parameters = MSpecDefaults |> setMSpecParams            
+    let parameters = MSpecDefaults |> setMSpecParams            
    
-        let args = buildMSpecArgs parameters assemblies
+    let args = buildMSpecArgs parameters assemblies
     
-        DotCover (fun p ->
-                      {p with
-                         TargetExecutable = parameters.ToolPath
-                         TargetArguments = args
-                      } |> setDotCoverParams)
-    finally
-        traceEndTask "DotCoverMSpec" details
+    DotCover (fun p ->
+                    {p with
+                        TargetExecutable = parameters.ToolPath
+                        TargetArguments = args
+                    } |> setDotCoverParams)

--- a/src/app/FakeLib/DotNetCLIHelper.fs
+++ b/src/app/FakeLib/DotNetCLIHelper.fs
@@ -85,19 +85,16 @@ let private DefaultCommandParams : CommandParams = {
 ///                   TimeOut = TimeSpan.FromMinutes 10. })
 ///         "restore"
 let RunCommand (setCommandParams: CommandParams -> CommandParams) args =
-    traceStartTask "DotNet" ""
+    use __ = traceStartTaskUsing "DotNet" ""
 
-    try
-        let parameters = setCommandParams DefaultCommandParams
+    let parameters = setCommandParams DefaultCommandParams
 
-        if 0 <> ExecProcess (fun info ->  
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- parameters.WorkingDir
-            info.Arguments <- args) parameters.TimeOut
-        then
-            failwithf "Pack failed on %s" args
-    finally
-        traceEndTask "DotNet" ""
+    if 0 <> ExecProcess (fun info ->  
+        info.FileName <- parameters.ToolPath
+        info.WorkingDirectory <- parameters.WorkingDir
+        info.Arguments <- args) parameters.TimeOut
+    then
+        failwithf "Pack failed on %s" args
 
 /// DotNet restore parameters
 type RestoreParams = {
@@ -141,28 +138,25 @@ let private DefaultRestoreParams : RestoreParams = {
 ///              { p with 
 ///                   NoCache = true })
 let Restore (setRestoreParams: RestoreParams -> RestoreParams) =
-    traceStartTask "DotNet.Restore" ""
+    use __ = traceStartTaskUsing "DotNet.Restore" ""
 
-    try
-        let parameters = setRestoreParams DefaultRestoreParams
-        let args =
-            new StringBuilder()
-            |> append "restore"
-            |> appendIfTrue parameters.NoCache "--no-cache"
-            |> appendWithoutQuotes (sprintf "--verbosity %s" (verbosityString parameters.Verbosity))
-            |> fun sb ->
-                parameters.AdditionalArgs
-                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-            |> toText
+    let parameters = setRestoreParams DefaultRestoreParams
+    let args =
+        new StringBuilder()
+        |> append "restore"
+        |> appendIfTrue parameters.NoCache "--no-cache"
+        |> appendWithoutQuotes (sprintf "--verbosity %s" (verbosityString parameters.Verbosity))
+        |> fun sb ->
+            parameters.AdditionalArgs
+            |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+        |> toText
 
-        if 0 <> ExecProcess (fun info ->  
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- parameters.WorkingDir
-            info.Arguments <- args) parameters.TimeOut
-        then
-            failwithf "Restore failed on %s" args
-    finally
-        traceEndTask "DotNet.Restore" ""
+    if 0 <> ExecProcess (fun info ->  
+        info.FileName <- parameters.ToolPath
+        info.WorkingDirectory <- parameters.WorkingDir
+        info.Arguments <- args) parameters.TimeOut
+    then
+        failwithf "Restore failed on %s" args
 
 /// DotNet build parameters
 type BuildParams = {
@@ -211,31 +205,28 @@ let private DefaultBuildParams : BuildParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Build (setBuildParams: BuildParams -> BuildParams) projects =
-    traceStartTask "DotNet.Build" ""
+    use __ = traceStartTaskUsing "DotNet.Build" ""
 
-    try
-        for project in projects do
-            let parameters = setBuildParams DefaultBuildParams
-            let args =
-                new StringBuilder()
-                |> append "build"
-                |> append project                
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setBuildParams DefaultBuildParams
+        let args =
+            new StringBuilder()
+            |> append "build"
+            |> append project                
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Build failed on %s" args
-    finally
-        traceEndTask "DotNet.Build" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Build failed on %s" args
 
 
 /// DotNet test parameters
@@ -285,31 +276,28 @@ let private DefaultTestParams : TestParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Test (setTestParams: TestParams -> TestParams) projects =
-    traceStartTask "DotNet.Test" ""
+    use __ = traceStartTaskUsing "DotNet.Test" ""
 
-    try
-        for project in projects do
-            let parameters = setTestParams DefaultTestParams
-            let args =
-                new StringBuilder()
-                |> append "test"
-                |> append project                
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setTestParams DefaultTestParams
+        let args =
+            new StringBuilder()
+            |> append "test"
+            |> append project                
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Test failed on %s" args
-    finally
-        traceEndTask "DotNet.Test" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Test failed on %s" args
 
 
 /// DotNet pack parameters
@@ -359,31 +347,28 @@ let private DefaultPackParams : PackParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Pack (setPackParams: PackParams -> PackParams) projects =
-    traceStartTask "DotNet.Pack" ""
+    use __ = traceStartTaskUsing "DotNet.Pack" ""
 
-    try
-        for project in projects do
-            let parameters = setPackParams DefaultPackParams
-            let args =
-                new StringBuilder()
-                |> append "pack"
-                |> append project
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.OutputPath) (sprintf "--output %s"  parameters.OutputPath)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setPackParams DefaultPackParams
+        let args =
+            new StringBuilder()
+            |> append "pack"
+            |> append project
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.OutputPath) (sprintf "--output %s"  parameters.OutputPath)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Pack failed on %s" args
-    finally
-        traceEndTask "DotNet.Pack" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Pack failed on %s" args
 
 /// DotNet publish parameters
 type PublishParams = {
@@ -440,45 +425,39 @@ let private DefaultPublishParams : PublishParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Publish (setPublishParams: PublishParams -> PublishParams) projects =
-    traceStartTask "DotNet.Publish" ""
+    use __ = traceStartTaskUsing "DotNet.Publish" ""
 
-    try
-        for project in projects do
-            let parameters = setPublishParams DefaultPublishParams
-            let args =
-                new StringBuilder()
-                |> append "publish"
-                |> append project                
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Output) (sprintf "--output %s"  parameters.Output)     
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)           
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setPublishParams DefaultPublishParams
+        let args =
+            new StringBuilder()
+            |> append "publish"
+            |> append project                
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Output) (sprintf "--output %s"  parameters.Output)     
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)           
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Test Publish on %s" args
-    finally
-        traceEndTask "DotNet.Publish" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Test Publish on %s" args
 
 
 
 /// Sets version in project.json
 let SetVersionInProjectJson (version:string) fileName = 
-    traceStartTask "DotNet.SetVersion" fileName
-    try
-        let original = File.ReadAllText fileName
-        let p = JObject.Parse(original)
-        p.["version"] <- JValue version
-        let newText = p.ToString()
-        if newText <> original then
-            File.WriteAllText(fileName,newText)
-    finally
-        traceEndTask "DotNet.SetVersion" fileName
+    use __ = traceStartTaskUsing "DotNet.SetVersion" fileName
+    let original = File.ReadAllText fileName
+    let p = JObject.Parse(original)
+    p.["version"] <- JValue version
+    let newText = p.ToString()
+    if newText <> original then
+        File.WriteAllText(fileName,newText)

--- a/src/app/FakeLib/DotNetHelper.fs
+++ b/src/app/FakeLib/DotNetHelper.fs
@@ -86,19 +86,16 @@ let private DefaultCommandParams : CommandParams = {
 ///                   TimeOut = TimeSpan.FromMinutes 10. })
 ///         "restore"
 let RunCommand (setCommandParams: CommandParams -> CommandParams) args =
-    traceStartTask "DotNet" ""
+    use __ = traceStartTaskUsing "DotNet" ""
 
-    try
-        let parameters = setCommandParams DefaultCommandParams
+    let parameters = setCommandParams DefaultCommandParams
 
-        if 0 <> ExecProcess (fun info ->  
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- parameters.WorkingDir
-            info.Arguments <- args) parameters.TimeOut
-        then
-            failwithf "Pack failed on %s" args
-    finally
-        traceEndTask "DotNet" ""
+    if 0 <> ExecProcess (fun info ->  
+        info.FileName <- parameters.ToolPath
+        info.WorkingDirectory <- parameters.WorkingDir
+        info.Arguments <- args) parameters.TimeOut
+    then
+        failwithf "Pack failed on %s" args
 
 /// DotNet restore parameters
 type RestoreParams = {
@@ -142,28 +139,25 @@ let private DefaultRestoreParams : RestoreParams = {
 ///              { p with 
 ///                   NoCache = true })
 let Restore (setRestoreParams: RestoreParams -> RestoreParams) =
-    traceStartTask "DotNet.Restore" ""
+    use __ = traceStartTaskUsing "DotNet.Restore" ""
 
-    try
-        let parameters = setRestoreParams DefaultRestoreParams
-        let args =
-            new StringBuilder()
-            |> append "restore"
-            |> appendIfTrue parameters.NoCache "--no-cache"
-            |> appendWithoutQuotes (sprintf "--verbosity %s" (verbosityString parameters.Verbosity))
-            |> fun sb ->
-                parameters.AdditionalArgs
-                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-            |> toText
+    let parameters = setRestoreParams DefaultRestoreParams
+    let args =
+        new StringBuilder()
+        |> append "restore"
+        |> appendIfTrue parameters.NoCache "--no-cache"
+        |> appendWithoutQuotes (sprintf "--verbosity %s" (verbosityString parameters.Verbosity))
+        |> fun sb ->
+            parameters.AdditionalArgs
+            |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+        |> toText
 
-        if 0 <> ExecProcess (fun info ->  
-            info.FileName <- parameters.ToolPath
-            info.WorkingDirectory <- parameters.WorkingDir
-            info.Arguments <- args) parameters.TimeOut
-        then
-            failwithf "Restore failed on %s" args
-    finally
-        traceEndTask "DotNet.Restore" ""
+    if 0 <> ExecProcess (fun info ->  
+        info.FileName <- parameters.ToolPath
+        info.WorkingDirectory <- parameters.WorkingDir
+        info.Arguments <- args) parameters.TimeOut
+    then
+        failwithf "Restore failed on %s" args
 
 /// DotNet build parameters
 type BuildParams = {
@@ -212,31 +206,28 @@ let private DefaultBuildParams : BuildParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Build (setBuildParams: BuildParams -> BuildParams) projects =
-    traceStartTask "DotNet.Build" ""
+    use __ = traceStartTaskUsing "DotNet.Build" ""
 
-    try
-        for project in projects do
-            let parameters = setBuildParams DefaultBuildParams
-            let args =
-                new StringBuilder()
-                |> append "build"
-                |> append project                
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setBuildParams DefaultBuildParams
+        let args =
+            new StringBuilder()
+            |> append "build"
+            |> append project                
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Build failed on %s" args
-    finally
-        traceEndTask "DotNet.Build" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Build failed on %s" args
 
 
 /// DotNet test parameters
@@ -286,31 +277,28 @@ let private DefaultTestParams : TestParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Test (setTestParams: TestParams -> TestParams) projects =
-    traceStartTask "DotNet.Test" ""
+    use __ = traceStartTaskUsing "DotNet.Test" ""
 
-    try
-        for project in projects do
-            let parameters = setTestParams DefaultTestParams
-            let args =
-                new StringBuilder()
-                |> append "test"
-                |> append project                
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setTestParams DefaultTestParams
+        let args =
+            new StringBuilder()
+            |> append "test"
+            |> append project                
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Framework) (sprintf "--framework %s"  parameters.Framework)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Runtime) (sprintf "--runtime %s"  parameters.Runtime)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Test failed on %s" args
-    finally
-        traceEndTask "DotNet.Test" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Test failed on %s" args
 
 
 /// DotNet pack parameters
@@ -360,41 +348,35 @@ let private DefaultPackParams : PackParams = {
 ///              { p with 
 ///                   Configuration = "Release" })
 let Pack (setPackParams: PackParams -> PackParams) projects =
-    traceStartTask "DotNet.Pack" ""
+    use __ = traceStartTaskUsing "DotNet.Pack" ""
 
-    try
-        for project in projects do
-            let parameters = setPackParams DefaultPackParams
-            let args =
-                new StringBuilder()
-                |> append "pack"
-                |> append project
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.OutputPath) (sprintf "--output %s"  parameters.OutputPath)
-                |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)
-                |> fun sb ->
-                    parameters.AdditionalArgs
-                    |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
-                |> toText
+    for project in projects do
+        let parameters = setPackParams DefaultPackParams
+        let args =
+            new StringBuilder()
+            |> append "pack"
+            |> append project
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.Configuration) (sprintf "--configuration %s"  parameters.Configuration)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.OutputPath) (sprintf "--output %s"  parameters.OutputPath)
+            |> appendIfTrueWithoutQuotes (isNotNullOrEmpty parameters.VersionSuffix) (sprintf "--version-suffix %s"  parameters.VersionSuffix)
+            |> fun sb ->
+                parameters.AdditionalArgs
+                |> List.fold (fun sb arg -> appendWithoutQuotes arg sb) sb
+            |> toText
 
-            if 0 <> ExecProcess (fun info ->  
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            then
-                failwithf "Pack failed on %s" args
-    finally
-        traceEndTask "DotNet.Pack" ""
+        if 0 <> ExecProcess (fun info ->  
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        then
+            failwithf "Pack failed on %s" args
 
 /// Sets version in project.json
 let SetVersionInProjectJson (version:string) fileName = 
-    traceStartTask "DotNet.SetVersion" fileName
-    try
-        let original = File.ReadAllText fileName
-        let p = JObject.Parse(original)
-        p.["version"] <- JValue version
-        let newText = p.ToString()
-        if newText <> original then
-            File.WriteAllText(fileName,newText)
-    finally
-        traceEndTask "DotNet.SetVersion" fileName
+    use __ = traceStartTaskUsing "DotNet.SetVersion" fileName
+    let original = File.ReadAllText fileName
+    let p = JObject.Parse(original)
+    p.["version"] <- JValue version
+    let newText = p.ToString()
+    if newText <> original then
+        File.WriteAllText(fileName,newText)

--- a/src/app/FakeLib/DynamicsCRMHelper.fs
+++ b/src/app/FakeLib/DynamicsCRMHelper.fs
@@ -105,7 +105,7 @@ let SolutionPackagerDefaults =
 ///
 ///  - `setParams` - Parameters for invoking solution exchanger
 let PublishAll (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperParams) =
-    traceStartTask "Publish All" ""
+    use __ = traceStartTaskUsing "Publish All" ""
     let parameters = setParams DynamicsCrmHelperDefaults
     let tool = parameters.ToolDirectory @@ "Dynamics.CRM.SolutionExchanger.exe"
     let args = sprintf "Publish /url:%s /user:%s /password:%s /timeout:%i" parameters.Url parameters.User parameters.Password (int parameters.TimeOut.TotalMinutes)
@@ -114,7 +114,6 @@ let PublishAll (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperParams) 
                 pInfo.WorkingDirectory <- parameters.WorkingDirectory
                 pInfo.Arguments <- args) parameters.TimeOut
     then failwithf "Publishing All %s failed." args
-    traceEndTask "Successfully finished Publish All" args
            
 /// Exports solution from Dynamics CRM and save it to file
 /// ## Parameters
@@ -150,7 +149,7 @@ let PublishAll (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperParams) 
 ///     )
 let ExportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperParams) =
     let parameters = setParams DynamicsCrmHelperDefaults
-    traceStartTask "Exporting Solution" (parameters.Solution + ": " + if parameters.Managed then "Managed" else "Unmanaged")
+    use __ = traceStartTaskUsing "Exporting Solution" (parameters.Solution + ": " + if parameters.Managed then "Managed" else "Unmanaged")
     let tool = parameters.ToolDirectory @@ "Dynamics.CRM.SolutionExchanger.exe"
     let args = sprintf "Export /url:%s /user:%s /password:%s /solution:%s /managed:%s /workingdir:%s /filename:%s /allSolutions:%s /allOrganizations:%s /timeout:%i" 
                     parameters.Url parameters.User parameters.Password parameters.Solution (parameters.Managed.ToString()) 
@@ -160,7 +159,6 @@ let ExportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperPara
                 pInfo.WorkingDirectory <- parameters.WorkingDirectory
                 pInfo.Arguments <- args) parameters.TimeOut
     then failwithf "Exporting Solution failed."
-    traceEndTask "Successfully finished Exporting Solution" args
 
 /// Imports zipped solution file to Dynamics CRM
 /// ## Parameters
@@ -168,7 +166,7 @@ let ExportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperPara
 ///  - `setParams` - Parameters for invoking solution exchanger
 let ImportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperParams) =
     let parameters = setParams DynamicsCrmHelperDefaults
-    traceStartTask "Importing Solution" parameters.FileName
+    use __ = traceStartTaskUsing "Importing Solution" parameters.FileName
     let tool = parameters.ToolDirectory @@ "Dynamics.CRM.SolutionExchanger.exe"
     let args = sprintf "Import /url:%s /user:%s /password:%s /filename:%s /timeout:%i" 
                     parameters.Url parameters.User parameters.Password parameters.FileName (int parameters.TimeOut.TotalMinutes)
@@ -177,7 +175,6 @@ let ImportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperPara
                 pInfo.WorkingDirectory <- parameters.WorkingDirectory
                 pInfo.Arguments <- args) parameters.TimeOut
     then failwithf "Importing Solution failed."
-    traceEndTask "Successfully finished Importing Solution" args
     
 /// Runs the solution packager tool on the given file for extracting the zip file or packing the extracted XML representation of a solution to a zip file again
 /// ## Parameters
@@ -185,7 +182,7 @@ let ImportSolution (setParams : DynamicsCrmHelperParams -> DynamicsCrmHelperPara
 ///  - `setParams` - Parameters for invoking solution packager
 let SolutionPackager setParams = 
     let parameters = setParams SolutionPackagerDefaults
-    traceStartTask "Running Solution Packager" (parameters.Action.ToString() + ": " + parameters.ZipFile)
+    use __ = traceStartTaskUsing "Running Solution Packager" (parameters.Action.ToString() + ": " + parameters.ZipFile)
     if not (File.Exists(parameters.ZipFile)) then
         failwith (sprintf "File at path %A does not exist!" parameters.ZipFile)
     let tool = parameters.ToolDirectory @@ "SolutionPackager.exe"
@@ -196,5 +193,3 @@ let SolutionPackager setParams =
                 pInfo.Arguments <- args) parameters.TimeOut
     then 
         failwith (sprintf "SolutionPackager %s failed." args)
-    else
-        traceEndTask "Successfully ran Solution Packager" args

--- a/src/app/FakeLib/FXCopHelper.fs
+++ b/src/app/FakeLib/FXCopHelper.fs
@@ -87,7 +87,7 @@ let FxCopDefaults =
 /// Run FxCop on a group of assemblies.
 let FxCop setParams (assemblies : string seq) = 
     let param = setParams FxCopDefaults
-    traceStartTask "FxCop" ""
+    use __ = traceStartTaskUsing "FxCop" ""
     let param = 
         if param.ApplyOutXsl && param.OutputXslFileName = String.Empty then 
             { param with OutputXslFileName = param.ToolPath @@ "Xml" @@ "FxCopReport.xsl" }
@@ -145,4 +145,3 @@ let FxCop setParams (assemblies : string seq) =
             failwithf "FxCop found %d critical warnings." criticalWarnings
         if warnings <> 0 && param.FailOnError >= FxCopErrorLevel.Warning then 
             failwithf "FxCop found %d warnings." warnings
-    traceEndTask "FxCop" ""

--- a/src/app/FakeLib/FixieHelper.fs
+++ b/src/app/FakeLib/FixieHelper.fs
@@ -35,7 +35,7 @@ let FixieDefaults = {
 ///       |> Fixie (fun p -> { p with CustomOptions = ["custom","1"; "test",2] })
 let Fixie setParams assemblies = 
     let details = separated ", " assemblies
-    traceStartTask "Fixie" details
+    use __ = traceStartTaskUsing "Fixie" details
     let parameters = setParams FixieDefaults
     
     let args =
@@ -55,5 +55,3 @@ let Fixie setParams assemblies =
         info.Arguments <- args) parameters.TimeOut
     then
         failwithf "Fixie test failed on %s." details
-                  
-    traceEndTask "Fixie" details

--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -133,9 +133,8 @@ let fsc (setParams : FscParams -> FscParams) (inputFiles : string list) : int =
     let debug = if fscParams.Debug then [ "-g" ] else []
     let argList =
         output @ target @ platform @ references @ debug @ fscParams.OtherParams
-    traceStartTask "Fsc " taskDesc
+    use __ = traceStartTaskUsing "Fsc " taskDesc
     let res = fscList inputFiles argList
-    traceEndTask "Fsc " taskDesc
     res
 
 /// Compiles one or more F# source files with the specified parameters.
@@ -501,9 +500,8 @@ let compile (fscParams : FscParam list) (inputFiles : string list) : int =
     let taskDesc = inputFiles |> separated ", "
     let fscParams = if fscParams = [] then FscParam.Defaults else fscParams
     let argList = fscParams |> List.map string
-    traceStartTask "Fsc " taskDesc
+    use __ = traceStartTaskUsing "Fsc " taskDesc
     let res = compileFiles inputFiles argList
-    traceEndTask "Fsc " taskDesc
     res
 
 /// Compiles one or more F# source files with the specified parameters.

--- a/src/app/FakeLib/GACHelper.fs
+++ b/src/app/FakeLib/GACHelper.fs
@@ -28,7 +28,7 @@ let GACDefaults =
 /// Runs gacutil with the given command.
 let GAC setParams command = 
     let taskName = "GAC"
-    traceStartTask taskName command
+    use __ = traceStartTaskUsing taskName command
     let param = setParams GACDefaults
     
     let ok = 
@@ -37,5 +37,3 @@ let GAC setParams command =
             if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
             info.Arguments <- command) param.TimeOut
     if not ok then failwithf "gacutil reported errors."
-
-    traceEndTask taskName command

--- a/src/app/FakeLib/HTMLHelpWorkShopHelper.fs
+++ b/src/app/FakeLib/HTMLHelpWorkShopHelper.fs
@@ -10,7 +10,7 @@ open System
 ///  - `helpCompiler` - The filename of the HTML Help WorkShop tool.
 ///  - `projectFile` - The fileName of the help project.
 let CompileHTMLHelpProject helpCompiler projectFile =
-    traceStartTask "HTMLHelpWorkshop" projectFile
+    use __ = traceStartTaskUsing "HTMLHelpWorkshop" projectFile
     let fi = new IO.FileInfo(projectFile)
     if not fi.Exists then invalidArg "projectFile" "Projectfile doesn't exist."
     if ExecProcess (fun info ->
@@ -19,6 +19,5 @@ let CompileHTMLHelpProject helpCompiler projectFile =
     then failwith "Error in HTML Help Workshop"
 
     let name = fi.Name.Split('.').[0]
-    traceEndTask "HTMLHelpWorkshop" projectFile
     [ fi.Directory.FullName @@ sprintf "%s.chm" name
       fi.Directory.FullName @@ sprintf "%s.hh" name]         

--- a/src/app/FakeLib/ILMergeHelper.fs
+++ b/src/app/FakeLib/ILMergeHelper.fs
@@ -141,7 +141,7 @@ let getArguments outputFile primaryAssembly parameters =
 ///  - `outputFile` - Output file path for the merged assembly.
 ///  - `primaryAssembly` - The assembly you want ILMerge to consider as the primary.
 let ILMerge setParams outputFile primaryAssembly = 
-    traceStartTask "ILMerge" primaryAssembly
+    use __ = traceStartTaskUsing "ILMerge" primaryAssembly
     let parameters = setParams ILMergeDefaults
     let args = getArguments outputFile primaryAssembly parameters
     if 0 <> ExecProcess (fun info -> 
@@ -149,4 +149,3 @@ let ILMerge setParams outputFile primaryAssembly =
                 info.WorkingDirectory <- null
                 info.Arguments <- args) parameters.TimeOut
     then failwithf "ILMerge %s failed." args
-    traceEndTask "ILMerge" primaryAssembly

--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -328,7 +328,7 @@ match buildServer with
 ///     build setParams "./MySolution.sln"
 ///           |> DoNothing
 let build setParams project =
-    traceStartTask "MSBuild" project
+    use __ = traceStartTaskUsing "MSBuild" project
     let args = 
         MSBuildDefaults
         |> setParams
@@ -357,7 +357,6 @@ let build setParams project =
         
         let errorMessage = sprintf "Building %s failed with exitcode %d." project exitCode
         raise (BuildException(errorMessage, errors))
-    traceEndTask "MSBuild" project
 
 /// Builds the given project files and collects the output files.
 /// ## Parameters
@@ -438,7 +437,7 @@ let MSBuildReleaseExt outputPath properties targets projects =
 ///  - `configuration` - MSBuild configuration.
 ///  - `projectFile` - The project file path.
 let BuildWebsiteConfig outputPath configuration projectFile  =
-    traceStartTask "BuildWebsite" projectFile
+    use __ = traceStartTaskUsing "BuildWebsite" projectFile
     let projectName = (fileInfo projectFile).Name.Replace(".csproj", "").Replace(".fsproj", "").Replace(".vbproj", "")
 
     let slashes (dir : string) =
@@ -461,7 +460,6 @@ let BuildWebsiteConfig outputPath configuration projectFile  =
           "WebProjectOutputDir", prefix + outputPath + "/" + projectName ] [ projectFile ]
         |> ignore
     !!(projectDir + "/bin/*.*") |> Copy(outputPath + "/" + projectName + "/bin/")
-    traceEndTask "BuildWebsite" projectFile
 
 /// Builds the given web project file with debug configuration and copies it to the given outputPath.
 /// ## Parameters

--- a/src/app/FakeLib/MSIHelper.fs
+++ b/src/app/FakeLib/MSIHelper.fs
@@ -28,7 +28,7 @@ let MSIDefaults =
 ///  - `setParams` - Function used to manipulate the default MSI parameters.
 ///  - `setup` - The setup file name.
 let Install setParams setup = 
-    traceStartTask "MSI-Install" setup
+    use __ = traceStartTaskUsing "MSI-Install" setup
     let parameters = setParams MSIDefaults
     let args = sprintf "%s /l* %s /i %s" (if parameters.Silent then "/qn" else "/qb") parameters.LogFile setup
 
@@ -38,8 +38,6 @@ let Install setParams setup =
         info.Arguments <- args) parameters.TimeOut && parameters.ThrowIfSetupFails 
     then
         failwithf "MSI-Install %s failed." args
-                  
-    traceEndTask "MSI-Install" setup
 
 /// Uninstalls a msi.
 /// ## Parameters
@@ -47,7 +45,7 @@ let Install setParams setup =
 ///  - `setParams` - Function used to manipulate the default MSI parameters.
 ///  - `setup` - The setup file name.
 let Uninstall setParams setup = 
-    traceStartTask "MSI-Uninstall" setup
+    use __ = traceStartTaskUsing "MSI-Uninstall" setup
     let parameters = setParams MSIDefaults
     let args = sprintf "%s /l* %s /x %s" (if parameters.Silent then "/qn" else "/qb") parameters.LogFile setup
     
@@ -57,5 +55,3 @@ let Uninstall setParams setup =
         info.Arguments <- args) parameters.TimeOut && parameters.ThrowIfSetupFails 
     then
         failwithf "MSI-Uninstall %s failed." args
-                  
-    traceEndTask "MSI-Uninstall" setup

--- a/src/app/FakeLib/MageHelper.fs
+++ b/src/app/FakeLib/MageHelper.fs
@@ -163,9 +163,8 @@ let MageSignDeploy (mp : MageParams) =
 
 /// Executes a full run of MAGE commands: first, it creates a new manifest file. Then it signs the manifest, deploys the application and finally signs the deployment.
 let MageRun (mp : MageParams) =
-  traceStartTask "Mage-Tool" mp.ApplicationFile
+  use __ = traceStartTaskUsing "Mage-Tool" mp.ApplicationFile
   MageCreateApp mp
   MageSignManifest mp
   MageDeployApp mp
   MageSignDeploy mp
-  traceEndTask "Mage-Tool" mp.ApplicationFile

--- a/src/app/FakeLib/NDependHelper.fs
+++ b/src/app/FakeLib/NDependHelper.fs
@@ -42,7 +42,7 @@ let buildNDependArgs parameters =
 ///              })
 let NDepend(setParams : NDependParams -> NDependParams) = 
     let taskName = "NDepend"
-    traceStartTask taskName ""
+    use __ = traceStartTaskUsing taskName ""
     let parameters = (NDependDefaults |> setParams)
     let args = buildNDependArgs parameters
     trace (parameters.ToolPath + " " + args)
@@ -52,4 +52,3 @@ let NDepend(setParams : NDependParams -> NDependParams) =
             info.WorkingDirectory <- getWorkingDir parameters.WorkingDir
             info.Arguments <- args) TimeSpan.MaxValue
     if result <> 0 then failwithf "Error running %s" parameters.ToolPath
-    traceEndTask taskName ""

--- a/src/app/FakeLib/NDependHelper.fs
+++ b/src/app/FakeLib/NDependHelper.fs
@@ -43,15 +43,13 @@ let buildNDependArgs parameters =
 let NDepend(setParams : NDependParams -> NDependParams) = 
     let taskName = "NDepend"
     traceStartTask taskName ""
-    try
-        let parameters = (NDependDefaults |> setParams)
-        let args = buildNDependArgs parameters
-        trace (parameters.ToolPath + " " + args)
-        let result = 
-            ExecProcess (fun info -> 
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- getWorkingDir parameters.WorkingDir
-                info.Arguments <- args) TimeSpan.MaxValue
-        if result <> 0 then failwithf "Error running %s" parameters.ToolPath
-    finally
-        traceEndTask taskName ""
+    let parameters = (NDependDefaults |> setParams)
+    let args = buildNDependArgs parameters
+    trace (parameters.ToolPath + " " + args)
+    let result = 
+        ExecProcess (fun info -> 
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- getWorkingDir parameters.WorkingDir
+            info.Arguments <- args) TimeSpan.MaxValue
+    if result <> 0 then failwithf "Error running %s" parameters.ToolPath
+    traceEndTask taskName ""

--- a/src/app/FakeLib/NGenHelper.fs
+++ b/src/app/FakeLib/NGenHelper.fs
@@ -34,14 +34,13 @@ let private ngen param command =
 /// Runs ngen.exe with the given command.
 let NGen setParams command = 
     let taskName = "NGen"
-    traceStartTask taskName command
+    use __ = traceStartTaskUsing taskName command
     ngen (setParams NGenDefaults) command
-    traceEndTask taskName command
 
 /// Runs ngen.exe install on given assemblies.
 let Install setParams assemblies = 
     let taskName = "NGen Install"
-    traceStartTask taskName ""
+    use __ = traceStartTaskUsing taskName ""
     let param = setParams NGenDefaults
     match assemblies |> Seq.toList with
     | [] -> ()
@@ -50,4 +49,3 @@ let Install setParams assemblies =
         for assembly in assemblies do
             ngen param (sprintf "install \"%s\" /queue:1 /nologo" assembly)
         ngen param "executeQueuedItems 1 /nologo"
-    traceEndTask taskName ""

--- a/src/app/FakeLib/NuGet/Install.fs
+++ b/src/app/FakeLib/NuGet/Install.fs
@@ -79,8 +79,7 @@ let buildArgs (param: NugetInstallParams) =
 ///  - `setParams` - Function used to manipulate the default parameters.
 ///  - `packagesFile` - Path to the `*.sln`, `*.*proj` or `packages.config` file, or simply a NuGet package name
 let NugetInstall setParams packageName =
-    traceStartTask "NugetInstall" packageName
+    use __ = traceStartTaskUsing "NugetInstall" packageName
     let param = NugetInstallDefaults |> setParams
     let args = sprintf "install %s %s" packageName (buildArgs param)
     runNuGetTrial param.Retries param.ToolPath param.TimeOut args (fun () -> failwithf "Package install for %s failed." packageName)
-    traceEndTask "NugetInstall" packageName

--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -338,7 +338,7 @@ let rec private publishSymbols parameters =
 ///  - `setParams` - Function used to manipulate the default NuGet parameters.
 ///  - `nuspecOrProjectFile` - The .nuspec or project file name.
 let NuGetPackDirectly setParams nuspecOrProjectFile =
-    traceStartTask "NuGetPackDirectly" nuspecOrProjectFile
+    use __ = traceStartTaskUsing "NuGetPackDirectly" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try
          pack parameters nuspecOrProjectFile
@@ -347,7 +347,6 @@ let NuGetPackDirectly setParams nuspecOrProjectFile =
          else exn.Message)
         |> replaceAccessKey parameters.AccessKey
         |> failwith
-    traceEndTask "NuGetPackDirectly" nuspecOrProjectFile
 
 /// Creates a new NuGet package based on the given .nuspec file.
 /// ## Parameters
@@ -355,7 +354,7 @@ let NuGetPackDirectly setParams nuspecOrProjectFile =
 ///  - `setParams` - Function used to manipulate the default NuGet parameters.
 ///  - `nuspecOrProjectFile` - The .nuspec or project file name.
 let NuGetPack setParams nuspecOrProjectFile =
-    traceStartTask "NuGetPack" nuspecOrProjectFile
+    use __ = traceStartTaskUsing "NuGetPack" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try
         match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
@@ -368,7 +367,6 @@ let NuGetPack setParams nuspecOrProjectFile =
          else exn.Message)
         |> replaceAccessKey parameters.AccessKey
         |> failwith
-    traceEndTask "NuGetPack" nuspecOrProjectFile
 
 /// Publishes a NuGet package to the nuget server.
 /// ## Parameters
@@ -376,9 +374,8 @@ let NuGetPack setParams nuspecOrProjectFile =
 ///  - `setParams` - Function used to manipulate the default NuGet parameters.
 let NuGetPublish setParams = 
     let parameters = NuGetDefaults() |> setParams
-    traceStartTask "NuGet-Push" (packageFileName parameters)
+    use __ = traceStartTaskUsing "NuGet-Push" (packageFileName parameters)
     publish parameters
-    traceEndTask "NuGet-Push" (packageFileName parameters)
 
 /// Creates a new NuGet package.
 /// ## Parameters
@@ -386,7 +383,7 @@ let NuGetPublish setParams =
 ///  - `setParams` - Function used to manipulate the default NuGet parameters.
 ///  - `nuspecFile` - The .nuspec file name.
 let NuGet setParams nuspecOrProjectFile = 
-    traceStartTask "NuGet" nuspecOrProjectFile
+    use __ = traceStartTaskUsing "NuGet" nuspecOrProjectFile
     let parameters = NuGetDefaults() |> setParams
     try 
         match (createNuSpecFromTemplateIfNotProjFile parameters nuspecOrProjectFile) with
@@ -403,7 +400,6 @@ let NuGet setParams nuspecOrProjectFile =
          else exn.Message)
         |> replaceAccessKey parameters.AccessKey
         |> failwith
-    traceEndTask "NuGet" nuspecOrProjectFile
 
 /// NuSpec metadata type
 type NuSpecPackage = 

--- a/src/app/FakeLib/NuGet/Update.fs
+++ b/src/app/FakeLib/NuGet/Update.fs
@@ -65,8 +65,7 @@ let buildArgs (param: NugetUpdateParams) =
 ///  - `setParams` - Function used to manipulate the default parameters.
 ///  - `packagesFile` - Path to the `*.sln`, `*.*proj` or `packages.config` file.
 let NugetUpdate setParams packagesFile =
-    traceStartTask "NugetUpdate" packagesFile
+    use __ = traceStartTaskUsing "NugetUpdate" packagesFile
     let param = NugetUpdateDefaults |> setParams
     let args = sprintf "update %s %s" packagesFile (buildArgs param)
     runNuGetTrial param.Retries param.ToolPath param.TimeOut args (fun () -> failwithf "Package update for %s failed." packagesFile)
-    traceEndTask "NugetUpdate" packagesFile

--- a/src/app/FakeLib/OctoTools.fs
+++ b/src/app/FakeLib/OctoTools.fs
@@ -247,7 +247,7 @@ let Octo setParams =
     let args = commandLine octoParams.Command |>(+)<| serverCommandLine octoParams.Server
     let traceArgs = commandLine octoParams.Command |>(+)<| serverCommandLineForTracing octoParams.Server
     
-    traceStartTask "Octo " command
+    use __ = traceStartTaskUsing "Octo " command
     trace (tool + traceArgs)
         
     let result = 
@@ -258,5 +258,5 @@ let Octo setParams =
         ) octoParams.Timeout
 
     match result with
-    | 0 -> traceEndTask "Octo " command
+    | 0 -> ()
     | _ -> failwithf "Octo %s failed. Process finished with exit code %i" command result

--- a/src/app/FakeLib/OpenCoverHelper.fs
+++ b/src/app/FakeLib/OpenCoverHelper.fs
@@ -77,7 +77,7 @@ let buildOpenCoverArgs param targetArgs =
 let OpenCover setParams targetArgs = 
     let taskName = "OpenCover"
     let description = "Gathering coverage statistics"
-    traceStartTask taskName description
+    use __ = traceStartTaskUsing taskName description
     let param = setParams OpenCoverDefaults
     
     let processArgs = buildOpenCoverArgs param targetArgs
@@ -88,4 +88,3 @@ let OpenCover setParams targetArgs =
             if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
             info.Arguments <- processArgs) param.TimeOut
     if not ok then failwithf "OpenCover reported errors."
-    traceEndTask taskName description

--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -87,7 +87,7 @@ let PaketRestoreDefaults() : PaketRestoreParams =
 ///  - `setParams` - Function used to manipulate the default parameters.
 let Pack setParams =
     let parameters : PaketPackParams = PaketPackDefaults() |> setParams
-    traceStartTask "PaketPack" parameters.WorkingDir
+    use __ = traceStartTaskUsing "PaketPack" parameters.WorkingDir
 
     let xmlEncode (notEncodedText : string) =
         if String.IsNullOrWhiteSpace notEncodedText then ""
@@ -114,7 +114,6 @@ let Pack setParams =
                 info.Arguments <- sprintf "pack output \"%s\" %s" parameters.OutputPath cmdArgs) parameters.TimeOut
 
     if packResult <> 0 then failwithf "Error during packing %s." parameters.WorkingDir
-    traceEndTask "PaketPack" parameters.WorkingDir
 
 /// Pushes all NuGet packages in the working dir to the server by using Paket push.
 /// ## Parameters
@@ -128,7 +127,7 @@ let Push setParams =
     let endpoint = if String.IsNullOrWhiteSpace parameters.EndPoint then "" else " endpoint " + toParam parameters.EndPoint
     let key = if String.IsNullOrWhiteSpace parameters.ApiKey then "" else " apikey " + toParam parameters.ApiKey
 
-    traceStartTask "PaketPush" (separated ", " packages)
+    use __ = traceStartTaskUsing "PaketPush" (separated ", " packages)
 
     if parameters.DegreeOfParallelism > 0 then
         /// Returns a sequence that yields chunks of length n.
@@ -166,8 +165,6 @@ let Push setParams =
                     info.WorkingDirectory <- parameters.WorkingDir
                     info.Arguments <- sprintf "push %s%s%s file %s" url endpoint key (toParam package)) parameters.TimeOut
             if pushResult <> 0 then failwithf "Error during pushing %s." package
-
-    traceEndTask "PaketPush" (separated ", " packages)
 
 /// Returns the dependencies from specified paket.references file
 let GetDependenciesForReferencesFile (referencesFile:string) =
@@ -219,7 +216,7 @@ let Restore setParams =
         then (sprintf " --references-files %s " (System.String.Join(" ", parameters.ReferenceFiles)))
         else ""
     
-    traceStartTask "PaketRestore" parameters.WorkingDir 
+    use __ = traceStartTaskUsing "PaketRestore" parameters.WorkingDir 
 
     let restoreResult = 
         ExecProcess (fun info ->
@@ -228,4 +225,3 @@ let Restore setParams =
             info.Arguments <- sprintf "restore %s%s%s%s" forceRestore onlyReferenced groupArg referencedFiles) parameters.TimeOut
 
     if restoreResult <> 0 then failwithf "Error during restore %s." parameters.WorkingDir
-    traceEndTask "PaketRestore" parameters.WorkingDir

--- a/src/app/FakeLib/PaketTemplateHelper.fs
+++ b/src/app/FakeLib/PaketTemplateHelper.fs
@@ -272,11 +272,10 @@ module internal Rendering =
 ///        )
 ///    )
 let PaketTemplate setParams =
-    traceStartTask "PaketTemplate" ""
+    use __ = traceStartTaskUsing "PaketTemplate" ""
     let parameters = setParams DefaultPaketTemplateParams
     let filePath = match parameters.TemplateFilePath with
                    | Some v -> v
                    | _ -> "paket.template"
 
     WriteStringToFile false filePath (Rendering.createLines parameters)
-    traceEndTask "PaketTemplate" ""

--- a/src/app/FakeLib/PicklesHelper.fs
+++ b/src/app/FakeLib/PicklesHelper.fs
@@ -198,7 +198,7 @@ module internal ResultHandling =
 ///                            OutputDirectory = currentDirectory @@ "SpecDocs" })
 ///     )
 let Pickles setParams =
-    traceStartTask "Pickles" ""
+    use __ = traceStartTaskUsing "Pickles" ""
     let parameters = setParams PicklesDefaults
     let result = 
         ExecProcess (fun info ->
@@ -207,5 +207,3 @@ let Pickles setParams =
             info.Arguments <- parameters |> buildPicklesArgs) parameters.TimeOut
     
     ResultHandling.failBuildIfPicklesReportedError parameters.ErrorLevel result
-    
-    traceEndTask "Pickles" ""

--- a/src/app/FakeLib/RaygunHelper.fs
+++ b/src/app/FakeLib/RaygunHelper.fs
@@ -99,11 +99,10 @@ let private serialize data = JsonConvert.SerializeObject(data)
 /// * settings : Function that sets the raygun connection settings.
 /// * data : Function that sets the deployment data
 let ReportDeployment (settings:RaygunConnectionSettings->RaygunConnectionSettings) (data:RaygunDeploymentData->RaygunDeploymentData) =
-    traceStartTask "Raygun.io" "Report new deployment"
+    use __ = traceStartTaskUsing "Raygun.io" "Report new deployment"
     let settings = defaultSettings |> settings
     let data = defaultData |> data
     use client = (new WebClient())
     client.Headers.Add(HttpRequestHeader.ContentType, "application/json")
     client.QueryString <- createQueryStringCollection settings.externalToken
     client.UploadString(settings.endPoint,"POST", (serialize data)) |> ignore
-    traceEndTask "Raygun.io" "Report new deployment"

--- a/src/app/FakeLib/RegAsmHelper.fs
+++ b/src/app/FakeLib/RegAsmHelper.fs
@@ -29,7 +29,7 @@ let RegAsmDefaults =
 ///  - `setParams` - Function used to manipulate the default RegAsm parameters.
 ///  - `lib` - The assembly file name.
 let RegAsm setParams lib = 
-    traceStartTask "RegAsm" lib
+    use __ = traceStartTaskUsing "RegAsm" lib
     let parameters = setParams RegAsmDefaults
     let args = if parameters.ExportTypeLibrary then
                     sprintf "\"%s\" /tlb:\"%s\"" lib (replace ".dll" ".tlb" lib)
@@ -40,14 +40,13 @@ let RegAsm setParams lib =
                 info.WorkingDirectory <- parameters.WorkingDir
                 info.Arguments <- args) parameters.TimeOut
     then failwithf "RegAsm %s failed." args
-    traceEndTask "RegAsm" lib
 
 /// Executes `RegAsm.exe` with the `/codebase` `/tlb` option
 ///
 /// Used to temporarily register any .net dependencies before running 
 /// a VB6 build
 let public RegisterAssembliesWithCodebase workingDir (assemblies:string seq) =
-    traceStartTask "Regasm with codebase" "Registering assemblies with codebase, expect warnings"
+    use __ = traceStartTaskUsing "Regasm with codebase" "Registering assemblies with codebase, expect warnings"
     let registerAssemblyWithCodebase assembly =
         async {
             let! regAsmResult = 
@@ -64,14 +63,13 @@ let public RegisterAssembliesWithCodebase workingDir (assemblies:string seq) =
     |> Async.Parallel
     |> Async.RunSynchronously
     |> ignore
-    traceEndTask "Regasm with codebase" "Registering assemblies with codebase, expect warnings"
 
 /// Executes `Regasm.exe` with the `/codebase /tlb /unregister` options
 ///
 /// Used to unregegister any temporarily registerd .net dependencies
 /// _after_ running a VB6 build
 let public UnregisterAssemblies workingDir (assemblies:string seq) =
-    traceStartTask "Regasm /unregister with codebase" "Registering assemblies with codebase, expect warnings"
+    use __ = traceStartTaskUsing "Regasm /unregister with codebase" "Registering assemblies with codebase, expect warnings"
     let registerAssemblyWithCodebase assembly =
         async {
             let! regAsmResult = 
@@ -88,4 +86,3 @@ let public UnregisterAssemblies workingDir (assemblies:string seq) =
     |> Async.Parallel
     |> Async.RunSynchronously
     |> ignore
-    traceEndTask "Regasm /unregister with codebase" "Registering assemblies with codebase, expect warnings"

--- a/src/app/FakeLib/ReportGeneratorHelper.fs
+++ b/src/app/FakeLib/ReportGeneratorHelper.fs
@@ -84,7 +84,7 @@ let buildReportGeneratorArgs parameters (reports : string seq) =
 let ReportGenerator setParams (reports : string list) =
     let taskName = "ReportGenerator"
     let description = "Generating reports"
-    traceStartTask taskName description
+    use __ = traceStartTaskUsing taskName description
     let param = setParams ReportGeneratorDefaultParams
 
     let processArgs = buildReportGeneratorArgs param reports
@@ -95,4 +95,3 @@ let ReportGenerator setParams (reports : string list) =
             if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
             info.Arguments <- processArgs) param.TimeOut
     if not ok then failwithf "ReportGenerator reported errors."
-    traceEndTask taskName description

--- a/src/app/FakeLib/RestorePackageHelper.fs
+++ b/src/app/FakeLib/RestorePackageHelper.fs
@@ -117,13 +117,11 @@ let buildNuGetArgs setParams packageId =
 
 /// Restores the given package from NuGet
 let RestorePackageId setParams packageId = 
-    traceStartTask "RestorePackageId" packageId
+    use __ = traceStartTaskUsing "RestorePackageId" packageId
     let parameters = RestoreSinglePackageDefaults |> setParams
 
     let args = buildNuGetArgs setParams packageId
     runNuGetTrial parameters.Retries parameters.ToolPath parameters.TimeOut args (fun () -> failwithf "Package installation of package %s failed." packageId)
-  
-    traceEndTask "RestorePackageId" packageId
 
 /// Restores the packages in the given packages.config file from NuGet.
 /// ## Parameters
@@ -142,7 +140,7 @@ let RestorePackageId setParams packageId =
 ///                  Retries = 4 })
 ///      )
 let RestorePackage setParams packageFile = 
-    traceStartTask "RestorePackage" packageFile
+    use __ = traceStartTaskUsing "RestorePackage" packageFile
     let (parameters:RestorePackageParams) = RestorePackageDefaults |> setParams
 
     let sources = parameters.Sources |> buildSources
@@ -152,8 +150,6 @@ let RestorePackage setParams packageFile =
         " \"-OutputDirectory\" \"" + (parameters.OutputPath |> FullName) + "\"" + sources
 
     runNuGetTrial parameters.Retries parameters.ToolPath parameters.TimeOut args (fun () -> failwithf "Package installation of %s generation failed." packageFile)
-                    
-    traceEndTask "RestorePackage" packageFile
 
 /// Restores all packages from NuGet to the default directories by scanning for packages.config files in any subdirectory.
 let RestorePackages() = 
@@ -177,7 +173,7 @@ let RestorePackages() =
 ///                  Retries = 4 })
 ///      )
 let RestoreMSSolutionPackages setParams solutionFile =
-    traceStartTask "RestoreSolutionPackages" solutionFile
+    use __ = traceStartTaskUsing "RestoreSolutionPackages" solutionFile
     let (parameters:RestorePackageParams) = RestorePackageDefaults |> setParams
 
     let sources = parameters.Sources |> buildSources
@@ -187,5 +183,3 @@ let RestoreMSSolutionPackages setParams solutionFile =
         " \"-OutputDirectory\" \"" + (parameters.OutputPath |> FullName) + "\"" + sources
 
     runNuGetTrial parameters.Retries parameters.ToolPath parameters.TimeOut args (fun () -> failwithf "Package restore of %s failed" solutionFile)
-
-    traceEndTask "RestoreSolutionPackages" solutionFile

--- a/src/app/FakeLib/RoundhouseHelper.fs
+++ b/src/app/FakeLib/RoundhouseHelper.fs
@@ -240,7 +240,7 @@ let Roundhouse setParams =
 
     let args = parameters |> getParamPairs |> serializeArgs
 
-    traceStartTask "Roundhouse" args
+    use __ = traceStartTaskUsing "Roundhouse" args
 
     if 0 <> ExecProcess (fun info ->  
         info.FileName <- parameters.ToolPath
@@ -248,5 +248,3 @@ let Roundhouse setParams =
         info.Arguments <- args) parameters.TimeOut
     then
         failwithf "Roundhouse failed on %s" args
-                  
-    traceEndTask "Roundhouse" args

--- a/src/app/FakeLib/SemVerHelper.fs
+++ b/src/app/FakeLib/SemVerHelper.fs
@@ -159,7 +159,6 @@ let parse version =
         | maj::min::[] -> Int32.Parse maj, Int32.Parse min, 0
         | maj::[] -> Int32.Parse maj, 0, 0
         | [] -> 0,0,0
-        | _ -> failwith "unknown semver format"
     
     
     let buildParts = Option.map (fun b -> splitRemove '.' b) build

--- a/src/app/FakeLib/SignToolHelper.fs
+++ b/src/app/FakeLib/SignToolHelper.fs
@@ -32,7 +32,7 @@ type SignParams = {
 /// Signs assemblies according to the settings specified in the parameters using signtool.exe.
 /// This will be looked up using the toolsPath parameter.
 let Sign (toolsPath : string) (parameters : SignParams) (filesToSign : seq<string>) = 
-    traceStartTask "SignTool" "Trying to sign the specified assemblies"
+    use __ = traceStartTaskUsing "SignTool" "Trying to sign the specified assemblies"
   
     let signPath = toolsPath @@ "signtool.exe"
 
@@ -60,13 +60,11 @@ let Sign (toolsPath : string) (parameters : SignParams) (filesToSign : seq<strin
                 info.Arguments <- withFileToSign) System.TimeSpan.MaxValue
         if result <> 0 then failwithf "Error during sign call ")
 
-    traceEndTask "SignTool" "Successfully signed the specified assemblies"
-
 
 /// Appends a SHA 256 signature to assemblies according to the settings specified in the parameters using signtool.exe.
 /// This will be looked up using the toolsPath parameter.
 let AppendSignature (toolsPath : string) (parameters : SignParams) (filesToSign : seq<string>) = 
-    traceStartTask "SignTool" "Trying to dual sign the specified assemblies"
+    use __ = traceStartTaskUsing "SignTool" "Trying to dual sign the specified assemblies"
       
     let signPath = toolsPath @@ "signtool.exe"
 
@@ -95,8 +93,6 @@ let AppendSignature (toolsPath : string) (parameters : SignParams) (filesToSign 
                 info.FileName <- signPath
                 info.Arguments <- withFileToSign) System.TimeSpan.MaxValue
         if result <> 0 then failwithf "Error during sign call ")
-
-    traceEndTask "SignTool" "Successfully dual signed the specified assemblies"
 
 [<Obsolete>]
 /// Signs all files in filesToSign with the certification file certFile, 

--- a/src/app/FakeLib/SonarQubeHelper.fs
+++ b/src/app/FakeLib/SonarQubeHelper.fs
@@ -66,10 +66,9 @@ let SonarQubeCall (call: SonarQubeCall) (parameters : SonarQubeParams) =
 ///      Version = "1.0 })
 ///
 let SonarQube (call: SonarQubeCall) setParams = 
-    traceStartTask "SonarQube" (call.ToString())
+    use __ = traceStartTaskUsing "SonarQube" (call.ToString())
     let parameters = setParams SonarQubeDefaults
     SonarQubeCall call parameters
-    traceEndTask "SonarQube" (call.ToString())
 
 /// This task can be used to run the end command of [Sonar Qube](http://sonarqube.org/) on a project.
 ///

--- a/src/app/FakeLib/SpecFlowHelper.fs
+++ b/src/app/FakeLib/SpecFlowHelper.fs
@@ -47,7 +47,7 @@ let SpecFlowDefaults = {
 let SpecFlow setParams =    
     let parameters = setParams SpecFlowDefaults
 
-    traceStartTask "SpecFlow " parameters.SubCommand
+    use __ = traceStartTaskUsing "SpecFlow " parameters.SubCommand
 
     let tool = parameters.ToolPath @@ parameters.ToolName
 
@@ -77,5 +77,5 @@ let SpecFlow setParams =
             info.Arguments <- args) System.TimeSpan.MaxValue
 
     match result with
-    | 0 -> traceEndTask "SpecFlow " parameters.SubCommand
+    | 0 -> ()
     | _ -> failwithf "SpecFlow %s failed. Process finished with exit code %i" parameters.SubCommand result

--- a/src/app/FakeLib/SquirrelHelper.fs
+++ b/src/app/FakeLib/SquirrelHelper.fs
@@ -122,7 +122,7 @@ module internal ResultHandling =
 ///         SquirrelPack (fun p -> { p with WorkingDir = Some "./tmp" }) "./my.nupkg"
 ///     )
 let SquirrelPack setParams nugetPackage =
-    traceStartTask "Squirrel" ""
+    use __ = traceStartTaskUsing "Squirrel" ""
     let parameters = SquirrelDefaults |> setParams
     let args = buildSquirrelArgs parameters nugetPackage
     trace args
@@ -134,5 +134,3 @@ let SquirrelPack setParams nugetPackage =
             info.Arguments <- args) parameters.TimeOut
 
     ResultHandling.failBuildIfSquirrelReportedError result
-
-    traceEndTask "Squirrel" ""

--- a/src/app/FakeLib/StrongNamingHelper.fs
+++ b/src/app/FakeLib/StrongNamingHelper.fs
@@ -25,7 +25,7 @@ let StrongNameDefaults =
 /// Runs sn.exe with the given command.
 let StrongName setParams command = 
     let taskName = "StrongName"
-    traceStartTask taskName command
+    use __ = traceStartTaskUsing taskName command
     let param = setParams StrongNameDefaults
     
     let ok = 
@@ -34,8 +34,6 @@ let StrongName setParams command =
             if param.WorkingDir <> String.Empty then info.WorkingDirectory <- param.WorkingDir
             info.Arguments <- command) param.TimeOut
     if not ok then failwithf "SN.exe reported errors."
-
-    traceEndTask taskName command
 
 /// Registers the given assembly for verification skipping.
 let DisableVerification assembly key =

--- a/src/app/FakeLib/Sxshelper.fs
+++ b/src/app/FakeLib/Sxshelper.fs
@@ -128,7 +128,7 @@ let private embedManiFestAsync workingDir (asyncData: Async<string*string>) =
 /// difficult to create through other means.
 /// The important info is then put into a valid base manifest and embedded into the assembly as a resource.
 let AddEmbeddedAssemblyManifest workingDir (assemblies: string seq) =
-     traceStartTask "AddEmbeddedAssemblyManifest" (sprintf "Adding assembly manifests to %i assemlbies" (assemblies |> Seq.length)) 
+     use __ = traceStartTaskUsing "AddEmbeddedAssemblyManifest" (sprintf "Adding assembly manifests to %i assemlbies" (assemblies |> Seq.length)) 
      let createManifestPath assembly =
             workingDir @@ ((Path.GetFileNameWithoutExtension assembly) + ".manifest")
 
@@ -169,7 +169,6 @@ let AddEmbeddedAssemblyManifest workingDir (assemblies: string seq) =
      |> Async.Parallel
      |> Async.RunSynchronously
      |> ignore
-     traceEndTask "AddEmbeddedAssemblyManifest" (sprintf "Adding assembly manifests to %i assemlbies" (assemblies |> Seq.length)) 
 
 /// Gets `name`, `path', `version` and interop `Guid` for those of the provided assemblies that have 
 /// all of the required information.
@@ -284,7 +283,7 @@ let GetInteropAssemblyData workingDir assemblies =
 ///  - `workingdir` - somewhere to put any temporary files
 ///  - `applications` - Metadata about executables to create manifests for.
 let public AddEmbeddedApplicationManifest workingDir (applications: InteropApplicationData seq) = 
-    traceStartTask "AddEmbeddedApplicationManifest" (sprintf "Adding embedded application manifest to %i applications" (applications |> Seq.length))
+    use __ = traceStartTaskUsing "AddEmbeddedApplicationManifest" (sprintf "Adding embedded application manifest to %i applications" (applications |> Seq.length))
     let applicationManifestBase = 
         """
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -336,4 +335,3 @@ let public AddEmbeddedApplicationManifest workingDir (applications: InteropAppli
     |> Async.Parallel
     |> Async.RunSynchronously
     |> ignore
-    traceEndTask "AddEmbeddedApplicationManifest" (sprintf "Adding embedded application manifest to %i applications" (applications |> Seq.length))

--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -149,13 +149,15 @@ let traceEndTarget name =
     sendCloseBlock name
 
 /// Traces the begin of a task
-let private traceStartTask task description = 
+[<Obsolete("use 'traceStartTaskUsing' with the 'use' pattern instead of traceStartTask / traceEndTask")>]
+let traceStartTask task description = 
     openTag "task"
     OpenTag("task", task) |> postMessage
     ReportProgressStart <| sprintf "Task: %s %s" task description
 
 /// Traces the end of a task
-let private traceEndTask task description = 
+[<Obsolete("use 'traceStartTaskUsing' with the 'use' pattern instead of traceStartTask / traceEndTask")>]
+let traceEndTask task description = 
     closeTag "task"
     ReportProgressFinish <| sprintf "Task: %s %s" task description
 

--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -149,15 +149,21 @@ let traceEndTarget name =
     sendCloseBlock name
 
 /// Traces the begin of a task
-let traceStartTask task description = 
+let private traceStartTask task description = 
     openTag "task"
     OpenTag("task", task) |> postMessage
     ReportProgressStart <| sprintf "Task: %s %s" task description
 
 /// Traces the end of a task
-let traceEndTask task description = 
+let private traceEndTask task description = 
     closeTag "task"
     ReportProgressFinish <| sprintf "Task: %s %s" task description
+
+/// Traces the begin of a task and closes it again after disposing of the return value
+/// (call it with 'use')
+let traceStartTaskUsing task description = 
+    traceStartTask task description
+    { new IDisposable with member x.Dispose() = traceEndTask task description }
 
 let console = new ConsoleTraceListener(false, colorMap) :> ITraceListener
 

--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -110,7 +110,7 @@ let private buildArguments parameters file =
 ///         !! "src/**/*.ts"
 ///             |> TypeScriptCompiler (fun p -> { p with TimeOut = TimeSpan.MaxValue }) 
 let TypeScriptCompiler setParams files = 
-    traceStartTask "TypeScript" ""
+    use __ = traceStartTaskUsing "TypeScript" ""
     let parameters = setParams TypeScriptDefaultParams
     
     let callResults = 
@@ -128,4 +128,3 @@ let TypeScriptCompiler setParams files =
        |> not
     then Seq.iter traceError errors
     Seq.collect (fun x -> x.Messages) callResults |> Seq.iter trace
-    traceEndTask "TypeScript" ""

--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -86,7 +86,7 @@ let buildMSTestArgs parameters assembly =
 ///     )
 let MSTest (setParams : MSTestParams -> MSTestParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
-    traceStartTask "MSTest" details
+    use __ = traceStartTaskUsing "MSTest" details
     let parameters = MSTestDefaults |> setParams
     let assemblies = assemblies |> Seq.toArray
     if Array.isEmpty assemblies then failwith "MSTest: cannot run tests (the assembly list is empty)."
@@ -102,4 +102,3 @@ let MSTest (setParams : MSTestParams -> MSTestParams) (assemblies : string seq) 
             info.WorkingDirectory <- parameters.WorkingDir
             info.Arguments <- args) parameters.TimeOut
         |> failIfError assembly
-    traceEndTask "MSTest" details

--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -87,21 +87,19 @@ let buildMSTestArgs parameters assembly =
 let MSTest (setParams : MSTestParams -> MSTestParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
     traceStartTask "MSTest" details
-    try
-        let parameters = MSTestDefaults |> setParams
-        let assemblies = assemblies |> Seq.toArray
-        if Array.isEmpty assemblies then failwith "MSTest: cannot run tests (the assembly list is empty)."
-        let failIfError assembly exitCode = 
-            if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
-                let message = sprintf "%sMSTest test run failed for %s" Environment.NewLine assembly
-                traceError message
-                failwith message
-        for assembly in assemblies do
-            let args = buildMSTestArgs parameters assembly
-            ExecProcess (fun info -> 
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            |> failIfError assembly
-    finally
-        traceEndTask "MSTest" details
+    let parameters = MSTestDefaults |> setParams
+    let assemblies = assemblies |> Seq.toArray
+    if Array.isEmpty assemblies then failwith "MSTest: cannot run tests (the assembly list is empty)."
+    let failIfError assembly exitCode = 
+        if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
+            let message = sprintf "%sMSTest test run failed for %s" Environment.NewLine assembly
+            traceError message
+            failwith message
+    for assembly in assemblies do
+        let args = buildMSTestArgs parameters assembly
+        ExecProcess (fun info -> 
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        |> failIfError assembly
+    traceEndTask "MSTest" details

--- a/src/app/FakeLib/UnitTest/MSpecHelper.fs
+++ b/src/app/FakeLib/UnitTest/MSpecHelper.fs
@@ -83,17 +83,15 @@ let buildMSpecArgs parameters assemblies =
 let MSpec setParams assemblies = 
     let details = separated ", " assemblies
     traceStartTask "MSpec" details
-    try
-        let parameters = setParams MSpecDefaults
-        let args = buildMSpecArgs parameters assemblies
-        trace (parameters.ToolPath + " " + args)
-        if 0 <> ExecProcess (fun info -> 
-                    info.FileName <- parameters.ToolPath
-                    info.WorkingDirectory <- parameters.WorkingDir
-                    info.Arguments <- args) parameters.TimeOut
-        then 
-            sprintf "MSpec test failed on %s." details |> match parameters.ErrorLevel with
-                                                          | Error | FailOnFirstError -> failwith
-                                                          | DontFailBuild -> traceImportant
-    finally
-        traceEndTask "MSpec" details
+    let parameters = setParams MSpecDefaults
+    let args = buildMSpecArgs parameters assemblies
+    trace (parameters.ToolPath + " " + args)
+    if 0 <> ExecProcess (fun info -> 
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- parameters.WorkingDir
+                info.Arguments <- args) parameters.TimeOut
+    then 
+        sprintf "MSpec test failed on %s." details |> match parameters.ErrorLevel with
+                                                      | Error | FailOnFirstError -> failwith
+                                                      | DontFailBuild -> traceImportant
+    traceEndTask "MSpec" details

--- a/src/app/FakeLib/UnitTest/MSpecHelper.fs
+++ b/src/app/FakeLib/UnitTest/MSpecHelper.fs
@@ -82,7 +82,7 @@ let buildMSpecArgs parameters assemblies =
 /// XmlOutputPath expects a full file path whereas the HtmlOutputDir expects a directory name
 let MSpec setParams assemblies = 
     let details = separated ", " assemblies
-    traceStartTask "MSpec" details
+    use __ = traceStartTaskUsing "MSpec" details
     let parameters = setParams MSpecDefaults
     let args = buildMSpecArgs parameters assemblies
     trace (parameters.ToolPath + " " + args)
@@ -92,6 +92,5 @@ let MSpec setParams assemblies =
                 info.Arguments <- args) parameters.TimeOut
     then 
         sprintf "MSpec test failed on %s." details |> match parameters.ErrorLevel with
-                                                      | Error | FailOnFirstError -> failwith
-                                                      | DontFailBuild -> traceImportant
-    traceEndTask "MSpec" details
+                                                        | Error | FailOnFirstError -> failwith
+                                                        | DontFailBuild -> traceImportant

--- a/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
@@ -269,7 +269,7 @@ let buildNUnit3Args parameters assemblies =
 
 let NUnit3 (setParams : NUnit3Params -> NUnit3Params) (assemblies : string seq) =
     let details = assemblies |> separated ", "
-    traceStartTask "NUnit" details
+    use __ = traceStartTaskUsing "NUnit" details
     let parameters = NUnit3Defaults |> setParams
     let assemblies = assemblies |> Seq.toArray
     if Array.isEmpty assemblies then failwith "NUnit: cannot run tests (the assembly list is empty)."
@@ -291,9 +291,9 @@ let NUnit3 (setParams : NUnit3Params -> NUnit3Params) (assemblies : string seq) 
     match parameters.ErrorLevel with
     | DontFailBuild -> 
         match result with
-        | OK | TestsFailed -> traceEndTask "NUnit" details
+        | OK | TestsFailed -> ()
         | _ -> raise (FailedTestsException(errorDescription result))
     | Error | FailOnFirstError -> 
         match result with
-        | OK -> traceEndTask "NUnit" details
+        | OK -> ()
         | _ -> raise (FailedTestsException(errorDescription result))

--- a/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Parallel.fs
@@ -36,7 +36,7 @@ type private AggFailedResult =
 ///     )
 let NUnitParallel (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
-    traceStartTask "NUnitParallel" details
+    use __ = traceStartTaskUsing "NUnitParallel" details
     let parameters = NUnitDefaults |> setParams
     let tool = parameters.ToolPath @@ parameters.ToolName
     
@@ -90,7 +90,7 @@ let NUnitParallel (setParams : NUnitParams -> NUnitParams) (assemblies : string 
               yield sprintf "NUnit test run for %s reported failed tests, check output file %s for details." 
                         r.AssemblyName parameters.OutputFile ]
     match List.filter (fun r -> r.ReturnCode <> 0) testRunResults with
-    | [] -> traceEndTask "NUnitParallel" details
+    | [] -> ()
     | failedResults -> 
         let aggResult = 
             List.fold (fun acc x -> 
@@ -105,9 +105,9 @@ let NUnitParallel (setParams : NUnitParams -> NUnitParams) (assemblies : string 
         match parameters.ErrorLevel with
         | DontFailBuild -> 
             match aggResult.WorseReturnCode with
-            | OK | TestsFailed -> traceEndTask "NUnit" details
+            | OK | TestsFailed -> ()
             | _ -> fail()
         | Error | FailOnFirstError -> 
             match aggResult.WorseReturnCode with
-            | OK -> traceEndTask "NUnit" details
+            | OK -> ()
             | _ -> fail()

--- a/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Sequential.fs
@@ -16,7 +16,7 @@ module Fake.NUnitSequential
 ///     )
 let NUnit (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) =
     let details = assemblies |> separated ", "
-    traceStartTask "NUnit" details
+    use __ = traceStartTaskUsing "NUnit" details
     let parameters = NUnitDefaults |> setParams
     let assemblies = assemblies |> Seq.toArray
     if Array.isEmpty assemblies then failwith "NUnit: cannot run tests (the assembly list is empty)."
@@ -37,9 +37,9 @@ let NUnit (setParams : NUnitParams -> NUnitParams) (assemblies : string seq) =
     match parameters.ErrorLevel with
     | DontFailBuild -> 
         match result with
-        | OK | TestsFailed -> traceEndTask "NUnit" details
+        | OK | TestsFailed -> ()
         | _ -> raise (FailedTestsException(errorDescription result))
     | Error | FailOnFirstError -> 
         match result with
-        | OK -> traceEndTask "NUnit" details
+        | OK -> ()
         | _ -> raise (FailedTestsException(errorDescription result))

--- a/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
+++ b/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
@@ -62,22 +62,20 @@ let runConsoleTests parameters processes =
 ///     )
 let RunConsoleTests setParams processes = 
     traceStartTask "RunConsoleTests" ""
-    try
-        let parameters = setParams ProcessTestRunnerDefaults
+    let parameters = setParams ProcessTestRunnerDefaults
     
-        let execute() = 
-            runConsoleTests parameters processes
-            |> Seq.map (fun (f, a, m) -> sprintf "Process %s %s terminated with %s" f a m)
-            |> toLines
-        match parameters.ErrorLevel with
-        | TestRunnerErrorLevel.DontFailBuild -> execute() |> trace
-        | TestRunnerErrorLevel.Error -> 
-            let msg = execute()
-            if msg <> "" then failwith msg
-        | TestRunnerErrorLevel.FailOnFirstError -> 
-            for fileName, args in processes do
-                match RunConsoleTest parameters fileName args with
-                | Some error -> failwithf "Process %s %s terminated with %s" fileName args error
-                | _ -> ()
-    finally
-        traceEndTask "RunConsoleTests" ""
+    let execute() = 
+        runConsoleTests parameters processes
+        |> Seq.map (fun (f, a, m) -> sprintf "Process %s %s terminated with %s" f a m)
+        |> toLines
+    match parameters.ErrorLevel with
+    | TestRunnerErrorLevel.DontFailBuild -> execute() |> trace
+    | TestRunnerErrorLevel.Error -> 
+        let msg = execute()
+        if msg <> "" then failwith msg
+    | TestRunnerErrorLevel.FailOnFirstError -> 
+        for fileName, args in processes do
+            match RunConsoleTest parameters fileName args with
+            | Some error -> failwithf "Process %s %s terminated with %s" fileName args error
+            | _ -> ()
+    traceEndTask "RunConsoleTests" ""

--- a/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
+++ b/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
@@ -61,7 +61,7 @@ let runConsoleTests parameters processes =
 ///           |> RunConsoleTests (fun p -> {p with TimeOut = TimeSpan.FromMinutes 1. })
 ///     )
 let RunConsoleTests setParams processes = 
-    traceStartTask "RunConsoleTests" ""
+    use __ = traceStartTaskUsing "RunConsoleTests" ""
     let parameters = setParams ProcessTestRunnerDefaults
     
     let execute() = 
@@ -78,4 +78,3 @@ let RunConsoleTests setParams processes =
             match RunConsoleTest parameters fileName args with
             | Some error -> failwithf "Process %s %s terminated with %s" fileName args error
             | _ -> ()
-    traceEndTask "RunConsoleTests" ""

--- a/src/app/FakeLib/UnitTest/VSTest.fs
+++ b/src/app/FakeLib/UnitTest/VSTest.fs
@@ -125,23 +125,21 @@ let buildVSTestArgs (parameters : VSTestParams) assembly =
 let VSTest (setParams : VSTestParams -> VSTestParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
     traceStartTask "VSTest" details
-    try
-        let parameters = VSTestDefaults |> setParams
-        if isNullOrEmpty parameters.ToolPath then failwith "VSTest: No tool path specified, or it could not be found automatically."
-        let assemblies = assemblies |> Seq.toArray
-        if Array.isEmpty assemblies then failwith "VSTest: cannot run tests (the assembly list is empty)."
-        let failIfError assembly exitCode = 
-            if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
-                let message = sprintf "%sVSTest test run failed for %s" Environment.NewLine assembly
-                traceError message
-                failwith message
-        for assembly in assemblies do
-            let args = buildVSTestArgs parameters assembly
-            ExecProcess (fun info -> 
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- parameters.WorkingDir
-                info.Arguments <- args) parameters.TimeOut
-            |> failIfError assembly
-    finally
-        traceEndTask "VSTest" details
+    let parameters = VSTestDefaults |> setParams
+    if isNullOrEmpty parameters.ToolPath then failwith "VSTest: No tool path specified, or it could not be found automatically."
+    let assemblies = assemblies |> Seq.toArray
+    if Array.isEmpty assemblies then failwith "VSTest: cannot run tests (the assembly list is empty)."
+    let failIfError assembly exitCode = 
+        if exitCode > 0 && parameters.ErrorLevel <> ErrorLevel.DontFailBuild then 
+            let message = sprintf "%sVSTest test run failed for %s" Environment.NewLine assembly
+            traceError message
+            failwith message
+    for assembly in assemblies do
+        let args = buildVSTestArgs parameters assembly
+        ExecProcess (fun info -> 
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- parameters.WorkingDir
+            info.Arguments <- args) parameters.TimeOut
+        |> failIfError assembly
+    traceEndTask "VSTest" details
 

--- a/src/app/FakeLib/UnitTest/VSTest.fs
+++ b/src/app/FakeLib/UnitTest/VSTest.fs
@@ -124,7 +124,7 @@ let buildVSTestArgs (parameters : VSTestParams) assembly =
 ///     )
 let VSTest (setParams : VSTestParams -> VSTestParams) (assemblies : string seq) = 
     let details = assemblies |> separated ", "
-    traceStartTask "VSTest" details
+    use __ = traceStartTaskUsing "VSTest" details
     let parameters = VSTestDefaults |> setParams
     if isNullOrEmpty parameters.ToolPath then failwith "VSTest: No tool path specified, or it could not be found automatically."
     let assemblies = assemblies |> Seq.toArray
@@ -141,5 +141,4 @@ let VSTest (setParams : VSTestParams -> VSTestParams) (assemblies : string seq) 
             info.WorkingDirectory <- parameters.WorkingDir
             info.Arguments <- args) parameters.TimeOut
         |> failIfError assembly
-    traceEndTask "VSTest" details
 

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
@@ -151,10 +151,10 @@ let xUnitSingle setParams assembly =
     traceStartTask "xUnit" assembly
 
     let parameters = XUnitDefaults |> setParams
-    try
-        runXUnitForOneAssembly parameters assembly |> ignore
-    finally
-        traceEndTask "xUnit" assembly
+
+    runXUnitForOneAssembly parameters assembly |> ignore
+
+    traceEndTask "xUnit" assembly
 
 let internal overrideAssemblyReportParams assembly p =
     let prependAssemblyName path =
@@ -194,13 +194,13 @@ let internal overrideAssemblyReportParams assembly p =
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit" details
-    try
-        let parameters = XUnitDefaults |> setParams
 
-        let assemblyResults =
-            assemblies
-            |> Seq.map (fun a -> a, runXUnitForOneAssembly (parameters |> overrideAssemblyReportParams a) a)
+    let parameters = XUnitDefaults |> setParams
 
-        ResultHandling.failBuildIfXUnitReportedErrors parameters.ErrorLevel assemblyResults
-    finally
-        traceEndTask "xUnit" details
+    let assemblyResults =
+        assemblies
+        |> Seq.map (fun a -> a, runXUnitForOneAssembly (parameters |> overrideAssemblyReportParams a) a)
+
+    ResultHandling.failBuildIfXUnitReportedErrors parameters.ErrorLevel assemblyResults
+
+    traceEndTask "xUnit" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
@@ -148,13 +148,10 @@ let internal runXUnitForOneAssembly parameters assembly =
 ///         xUnit (fun p -> {p with HtmlOutputPath = testDir @@ "xunit.html"}) "xUnit.Test.dll"
 ///     )
 let xUnitSingle setParams assembly =
-    traceStartTask "xUnit" assembly
+    use __ = traceStartTaskUsing "xUnit" assembly
 
     let parameters = XUnitDefaults |> setParams
-
     runXUnitForOneAssembly parameters assembly |> ignore
-
-    traceEndTask "xUnit" assembly
 
 let internal overrideAssemblyReportParams assembly p =
     let prependAssemblyName path =
@@ -193,8 +190,7 @@ let internal overrideAssemblyReportParams assembly p =
 ///     )
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
-    traceStartTask "xUnit" details
-
+    use __ = traceStartTaskUsing "xUnit" details
     let parameters = XUnitDefaults |> setParams
 
     let assemblyResults =
@@ -202,5 +198,3 @@ let xUnit setParams assemblies =
         |> Seq.map (fun a -> a, runXUnitForOneAssembly (parameters |> overrideAssemblyReportParams a) a)
 
     ResultHandling.failBuildIfXUnitReportedErrors parameters.ErrorLevel assemblyResults
-
-    traceEndTask "xUnit" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -261,20 +261,19 @@ module internal ResultHandling =
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit2" details
-    try
-        let parametersFirst = setParams XUnit2Defaults
+    let parametersFirst = setParams XUnit2Defaults
 
-        let parameters =
-            if parametersFirst.NoAppDomain
-            then discoverNoAppDomainExists parametersFirst
-            else parametersFirst
+    let parameters =
+        if parametersFirst.NoAppDomain
+        then discoverNoAppDomainExists parametersFirst
+        else parametersFirst
 
-        let result =
-            ExecProcess (fun info ->
-                info.FileName <- parameters.ToolPath
-                info.WorkingDirectory <- defaultArg parameters.WorkingDir "."
-                info.Arguments <- parameters |> buildXUnit2Args assemblies) parameters.TimeOut
+    let result =
+        ExecProcess (fun info ->
+            info.FileName <- parameters.ToolPath
+            info.WorkingDirectory <- defaultArg parameters.WorkingDir "."
+            info.Arguments <- parameters |> buildXUnit2Args assemblies) parameters.TimeOut
 
-        ResultHandling.failBuildIfXUnitReportedError parameters.ErrorLevel result
-    finally
-        traceEndTask "xUnit2" details
+    ResultHandling.failBuildIfXUnitReportedError parameters.ErrorLevel result
+
+    traceEndTask "xUnit2" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -260,7 +260,7 @@ module internal ResultHandling =
 ///     )
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
-    traceStartTask "xUnit2" details
+    use __ = traceStartTaskUsing "xUnit2" details
     let parametersFirst = setParams XUnit2Defaults
 
     let parameters =
@@ -275,5 +275,3 @@ let xUnit2 setParams assemblies =
             info.Arguments <- parameters |> buildXUnit2Args assemblies) parameters.TimeOut
 
     ResultHandling.failBuildIfXUnitReportedError parameters.ErrorLevel result
-
-    traceEndTask "xUnit2" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
@@ -190,24 +190,22 @@ let buildXUnit2Args parameters assembly =
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit2" details
-    try
-        let parameters = setParams XUnit2Defaults
+    let parameters = setParams XUnit2Defaults
 
-        let runTests assembly =
-            let args = buildXUnit2Args parameters assembly
-            0 = ExecProcess (fun info ->
-                    info.FileName <- parameters.ToolPath
-                    info.WorkingDirectory <- parameters.WorkingDir
-                    info.Arguments <- args) parameters.TimeOut
+    let runTests assembly =
+        let args = buildXUnit2Args parameters assembly
+        0 = ExecProcess (fun info ->
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- parameters.WorkingDir
+                info.Arguments <- args) parameters.TimeOut
 
-        let failedTests =
-            [ for asm in List.ofSeq assemblies do
-                  if runTests asm |> not then yield asm ]
+    let failedTests =
+        [ for asm in List.ofSeq assemblies do
+              if runTests asm |> not then yield asm ]
 
-        if not (List.isEmpty failedTests) then
-            sprintf "xUnit2 failed for the following assemblies: %s" (separated ", " failedTests)
-            |> match parameters.ErrorLevel with
-               | Error | FailOnFirstError -> failwith
-               | DontFailBuild -> traceImportant
-    finally
-        traceEndTask "xUnit2" details
+    if not (List.isEmpty failedTests) then
+        sprintf "xUnit2 failed for the following assemblies: %s" (separated ", " failedTests)
+        |> match parameters.ErrorLevel with
+           | Error | FailOnFirstError -> failwith
+           | DontFailBuild -> traceImportant
+    traceEndTask "xUnit2" details

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
@@ -189,7 +189,7 @@ let buildXUnit2Args parameters assembly =
 [<Obsolete("Deprecated. This task will be removed in a future version. Open Fake.Testing to use the latest xUnit2 task.")>]
 let xUnit2 setParams assemblies =
     let details = separated ", " assemblies
-    traceStartTask "xUnit2" details
+    use __ = traceStartTaskUsing "xUnit2" details
     let parameters = setParams XUnit2Defaults
 
     let runTests assembly =
@@ -201,11 +201,10 @@ let xUnit2 setParams assemblies =
 
     let failedTests =
         [ for asm in List.ofSeq assemblies do
-              if runTests asm |> not then yield asm ]
+                if runTests asm |> not then yield asm ]
 
     if not (List.isEmpty failedTests) then
         sprintf "xUnit2 failed for the following assemblies: %s" (separated ", " failedTests)
         |> match parameters.ErrorLevel with
-           | Error | FailOnFirstError -> failwith
-           | DontFailBuild -> traceImportant
-    traceEndTask "xUnit2" details
+            | Error | FailOnFirstError -> failwith
+            | DontFailBuild -> traceImportant

--- a/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
@@ -122,7 +122,7 @@ let buildXUnitArgs parameters assembly =
 [<Obsolete("Deprecated. This task will be removed in a future version. Open Fake.Testing to use the latest xUnit task.")>]
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
-    traceStartTask "xUnit" details
+    use __ = traceStartTaskUsing "xUnit" details
     let parameters = setParams XUnitDefaults
 
     let runTests assembly =
@@ -134,11 +134,10 @@ let xUnit setParams assemblies =
 
     let failedTests =
         [ for asm in List.ofSeq assemblies do
-              if runTests asm |> not then yield asm ]
+                if runTests asm |> not then yield asm ]
 
     if not (List.isEmpty failedTests) then
         sprintf "xUnit failed for the following assemblies: %s" (separated ", " failedTests)
         |> match parameters.ErrorLevel with
-           | Error | FailOnFirstError -> failwith
-           | DontFailBuild -> traceImportant
-    traceEndTask "xUnit" details
+            | Error | FailOnFirstError -> failwith
+            | DontFailBuild -> traceImportant

--- a/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
@@ -123,24 +123,22 @@ let buildXUnitArgs parameters assembly =
 let xUnit setParams assemblies =
     let details = separated ", " assemblies
     traceStartTask "xUnit" details
-    try
-        let parameters = setParams XUnitDefaults
+    let parameters = setParams XUnitDefaults
 
-        let runTests assembly =
-            let args = buildXUnitArgs parameters assembly
-            0 = ExecProcess (fun info ->
-                    info.FileName <- parameters.ToolPath
-                    info.WorkingDirectory <- parameters.WorkingDir
-                    info.Arguments <- args) parameters.TimeOut
+    let runTests assembly =
+        let args = buildXUnitArgs parameters assembly
+        0 = ExecProcess (fun info ->
+                info.FileName <- parameters.ToolPath
+                info.WorkingDirectory <- parameters.WorkingDir
+                info.Arguments <- args) parameters.TimeOut
 
-        let failedTests =
-            [ for asm in List.ofSeq assemblies do
-                  if runTests asm |> not then yield asm ]
+    let failedTests =
+        [ for asm in List.ofSeq assemblies do
+              if runTests asm |> not then yield asm ]
 
-        if not (List.isEmpty failedTests) then
-            sprintf "xUnit failed for the following assemblies: %s" (separated ", " failedTests)
-            |> match parameters.ErrorLevel with
-               | Error | FailOnFirstError -> failwith
-               | DontFailBuild -> traceImportant
-    finally
-        traceEndTask "xUnit" details
+    if not (List.isEmpty failedTests) then
+        sprintf "xUnit failed for the following assemblies: %s" (separated ", " failedTests)
+        |> match parameters.ErrorLevel with
+           | Error | FailOnFirstError -> failwith
+           | DontFailBuild -> traceImportant
+    traceEndTask "xUnit" details

--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -1777,7 +1777,7 @@ let generateMajorUpgradeVersion setParams =
 
 /// Runs the [Candle tool](http://wixtoolset.org/documentation/manual/v3/overview/candle.html) on the given WiX script with the given parameters
 let Candle (parameters : WiXParams) wixScript = 
-    traceStartTask "Candle" wixScript
+    use __ = traceStartTaskUsing "Candle" wixScript
     let fi = fileInfo wixScript
     let wixObj = fi.Directory.FullName @@ sprintf @"%s.wixobj" fi.Name
     let tool = parameters.ToolDirectory @@ "candle.exe"
@@ -1789,12 +1789,11 @@ let Candle (parameters : WiXParams) wixScript =
                 info.WorkingDirectory <- null
                 info.Arguments <- args) parameters.TimeOut
     then failwithf "Candle %s failed." args
-    traceEndTask "Candle" wixScript
     wixObj
 
 /// Runs the [Light tool](http://wixtoolset.org/documentation/manual/v3/overview/light.html) on the given WiX script with the given parameters
 let Light (parameters : WiXParams) outputFile wixObj = 
-    traceStartTask "Light" wixObj
+    use __ = traceStartTaskUsing "Light" wixObj
     let tool = parameters.ToolDirectory @@ "light.exe"
     let args = 
         sprintf "\"%s\" -spdb -dcl:high -out \"%s\" %s" (wixObj |> FullName) (outputFile |> FullName) 
@@ -1805,7 +1804,6 @@ let Light (parameters : WiXParams) outputFile wixObj =
                 info.WorkingDirectory <- null
                 info.Arguments <- args) parameters.TimeOut
     then failwithf "Light %s failed." args
-    traceEndTask "Light" wixObj
 
 /// Uses the WiX tools [Candle](http://wixtoolset.org/documentation/manual/v3/overview/candle.html) and [Light](http://wixtoolset.org/documentation/manual/v3/overview/light.html) to create an msi.
 /// ## Parameters
@@ -1898,7 +1896,7 @@ let HeatDefaulParams =
 ///  - `outputFile` - The output file path given to Heat.
 ///
 let HarvestDirectory (setParams : HeatParams -> HeatParams) directory outputFile = 
-    traceStartTask "Heat" directory
+    use __ = traceStartTaskUsing "Heat" directory
     let conditionalArgument condition arg args =
         match condition with
             | true ->  arg :: args
@@ -1928,6 +1926,5 @@ let HarvestDirectory (setParams : HeatParams -> HeatParams) directory outputFile
                 info.WorkingDirectory <- null
                 info.Arguments <- args) parameters.TimeOut
     then failwithf "Heat %s failed." args
-    traceEndTask "Heat" directory
 
 

--- a/src/app/FakeLib/XpkgHelper.fs
+++ b/src/app/FakeLib/XpkgHelper.fs
@@ -76,7 +76,7 @@ let private getPackageFileName parameters = sprintf "%s-%s.xam" parameters.Packa
 let xpkgPack setParams = 
     let parameters = XpkgDefaults() |> setParams
     let packageFileName = getPackageFileName parameters
-    traceStartTask "xpkgPack" packageFileName
+    use __ = traceStartTaskUsing "xpkgPack" packageFileName
     let fullPath = parameters.OutputPath @@ packageFileName
     
     let commandLineBuilder = 
@@ -106,14 +106,14 @@ let xpkgPack setParams =
             info.FileName <- parameters.ToolPath
             info.WorkingDirectory <- parameters.WorkingDir
             info.Arguments <- args) parameters.TimeOut
-    if result = 0 then traceEndTask "xpkgPack" packageFileName
+    if result = 0 then ()
     else failwithf "Create xpkg package failed. Process finished with exit code %d." result
 
 /// Validates a xpkg package based on the package file name
 let xpkgValidate setParams = 
     let parameters = XpkgDefaults() |> setParams
     let packageFileName = getPackageFileName parameters
-    traceStartTask "xpkgValidate" packageFileName
+    use __ = traceStartTaskUsing "xpkgValidate" packageFileName
     let fullPath = parameters.OutputPath @@ packageFileName
     
     let commandLineBuilder = 
@@ -128,5 +128,5 @@ let xpkgValidate setParams =
             info.FileName <- parameters.ToolPath
             info.WorkingDirectory <- parameters.WorkingDir
             info.Arguments <- args) parameters.TimeOut
-    if result = 0 then traceEndTask "xpkgValidate" packageFileName
+    if result = 0 then ()
     else failwithf "Validate xpkg package failed. Process finished with exit code %d." result


### PR DESCRIPTION
So it seems in my previous PR (https://github.com/fsharp/FAKE/pull/1379) I missed a few cases ...

The whole try / finally stuff just adds noise (in my opinion), what do you think about this IDisposable approach?

If you like it, I will go through all files (a full text search for traceStartTask found 114 lines in 59 files, so totally manageable).