### PR TITLE
getBranchName works language independent

### DIFF
--- a/src/app/FakeLib/Git/Information.fs
+++ b/src/app/FakeLib/Git/Information.fs
@@ -35,17 +35,13 @@ let isGitVersionHigherOrEqual referenceVersion =
 /// Gets the git branch name
 let getBranchName repositoryDir =
     try
-        let ok,msg,errors = runGitCommand repositoryDir "status"
+        let ok,msg,errors = runGitCommand repositoryDir "status -s -b"
         let s = msg |> Seq.head
-
-        let mutable replaceBranchString = "On branch "
-        let mutable replaceNoBranchString = "Not currently on any branch."
+        
+        let replaceNoBranchString = "## HEAD ("
         let noBranch = "NoBranch"
 
-        if isGitVersionHigherOrEqual "1.9" then replaceNoBranchString <- "HEAD detached"
-        if not <| isGitVersionHigherOrEqual "1.9" then replaceBranchString <- "# " + replaceBranchString
-
-        if startsWith replaceNoBranchString s then noBranch else s.Replace(replaceBranchString,"")
+        if startsWith replaceNoBranchString s then noBranch else s.Substring(3)
     with _ when (repositoryDir = "" || repositoryDir = ".") && buildServer = TeamFoundation ->
         match environVarOrNone "BUILD_SOURCEBRANCHNAME" with
         | None -> reraise()


### PR DESCRIPTION
this should make the strange situation of i10n-git installations more robust.

Tested with git 1.7 and git 2.10. 

Did not find any localized version of git. I assume the problematic installation is a git-sdk install.