### PR TITLE
added logic to allow parsing of git branch names which track

### DIFF
--- a/src/app/FakeLib/Git/Information.fs
+++ b/src/app/FakeLib/Git/Information.fs
@@ -41,7 +41,11 @@ let getBranchName repositoryDir =
         let replaceNoBranchString = "## HEAD ("
         let noBranch = "NoBranch"
 
-        if startsWith replaceNoBranchString s then noBranch else s.Substring(3)
+        if startsWith replaceNoBranchString s 
+            then noBranch
+            else match s.Contains("...") with
+                    | true  -> s.Substring(3,s.IndexOf("...")-3)
+                    | false -> s.Substring(3)
     with _ when (repositoryDir = "" || repositoryDir = ".") && buildServer = TeamFoundation ->
         match environVarOrNone "BUILD_SOURCEBRANCHNAME" with
         | None -> reraise()


### PR DESCRIPTION
PR #1409 added `-s -b` to the git status call, however when a branch is tracking another branch, this results in a string like this -> `master...origin/master` this can become problematic if anything relies on that git branch parsing.

This works around that issue :)