### PR TITLE
Disable NodeReuse for MSBuild on Jenkins too

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -149,7 +149,7 @@ let mutable MSBuildDefaults =
       Properties = []
       MaxCpuCount = Some None
       NoLogo = false
-      NodeReuse = not (buildServer = TeamCity || buildServer = TeamFoundation)
+      NodeReuse = not (buildServer = TeamCity || buildServer = TeamFoundation || buildServer = Jenkins)
       ToolsVersion = None
       Verbosity = None
       NoConsoleLogger = false


### PR DESCRIPTION
Disables NodeReuse in MSBuild by default if the build runs on Jenkins