### PR TITLE
decorated all *Params helper records with [<CLIMutable>]

### DIFF
--- a/src/app/FakeLib/AndroidPublisher.fs
+++ b/src/app/FakeLib/AndroidPublisher.fs
@@ -34,6 +34,7 @@ type AndroidPublishConfig = {
     Apk: string;
 }
 
+[<CLIMutable>]
 type AndroidPublishParams = {
     Track: string;
     Config: AndroidPublishConfig;

--- a/src/app/FakeLib/AppVeyor.fs
+++ b/src/app/FakeLib/AppVeyor.fs
@@ -188,6 +188,7 @@ let SetVariable name value =
 type ArtifactType = Auto | WebDeployPackage
 
 /// AppVeyor parameters for artifact push
+[<CLIMutable>]
 type PushArtifactParams =
     {
         /// The full local path to the artifact

--- a/src/app/FakeLib/AssemblyInfoHelper.fs
+++ b/src/app/FakeLib/AssemblyInfoHelper.fs
@@ -15,6 +15,7 @@ type CodeLanguage =
     | FSharp
     | VisualBasic
 
+[<CLIMutable>]
 type AssemblyInfoParams = 
     { OutputFileName : string
       ComVisible : bool option

--- a/src/app/FakeLib/AzureCloudServices.fs
+++ b/src/app/FakeLib/AzureCloudServices.fs
@@ -5,6 +5,7 @@ open System.IO
 open Fake
 
 /// Configuration details for packaging cloud services.
+[<CLIMutable>]
 type PackageCloudServiceParams =
     { /// The name of the Cloud Service.
       CloudService : string

--- a/src/app/FakeLib/AzureHelper.fs
+++ b/src/app/FakeLib/AzureHelper.fs
@@ -5,6 +5,7 @@ open Fake.ProcessHelper
 open System
 
 /// A type for the controlling parameter
+[<CLIMutable>]
 type AzureEmulatorParams = {
     CSRunToolPath:string
     DSInitToolPath:string

--- a/src/app/FakeLib/BowerHelper.fs
+++ b/src/app/FakeLib/BowerHelper.fs
@@ -24,6 +24,7 @@ type BowerCommand =
 | Custom of string
 
 /// The Bower parameter type
+[<CLIMutable>]
 type BowerParams =
     { Src: string
       BowerFilePath: string

--- a/src/app/FakeLib/CMake.fs
+++ b/src/app/FakeLib/CMake.fs
@@ -23,6 +23,7 @@ type CMakeVariable = {
 }
 
 /// The CMakeGenerate parameter type.
+[<CLIMutable>]
 type CMakeGenerateParams = {
     /// The location of the CMake executable. Automatically found if null or empty.
     ToolPath:string
@@ -65,6 +66,7 @@ type CMakeGenerateParams = {
 }
 
 /// The CMakeBuild parameter type.
+[<CLIMutable>]
 type CMakeBuildParams = {
     /// The location of the CMake executable. Automatically found if null or empty.
     ToolPath:string

--- a/src/app/FakeLib/ChocoHelper.fs
+++ b/src/app/FakeLib/ChocoHelper.fs
@@ -21,6 +21,7 @@ module Choco =
     | Sha512
 
     /// The choco install parameter type.
+    [<CLIMutable>]
     type ChocoInstallParams = {
         /// Version of the package
         /// Equivalent to the `--version <version>` option.
@@ -65,6 +66,7 @@ module Choco =
     }
 
     /// The choco pack parameter type.
+    [<CLIMutable>]
     type ChocoPackParams = {
         /// The version you would like to insert into the package.
         /// Equivalent to the `--version <version>` option.
@@ -194,6 +196,7 @@ module Choco =
     }
 
     /// The choco push parameter type.
+    [<CLIMutable>]
     type ChocoPushParams = {
         /// The source we are pushing the package to. Default: "https://chocolatey.org/"
         /// Equivalent to the `--source <source>` option.

--- a/src/app/FakeLib/DocFxHelper.fs
+++ b/src/app/FakeLib/DocFxHelper.fs
@@ -4,6 +4,7 @@ module Fake.DocFxHelper
 open System
 
 /// The parameter type for DocFx.
+[<CLIMutable>]
 type DocFxParams = 
     { /// The tool path - FAKE tries to find docfx.exe automatically in any sub folder.
       ToolPath : string

--- a/src/app/FakeLib/DocuHelper.fs
+++ b/src/app/FakeLib/DocuHelper.fs
@@ -5,6 +5,7 @@ module Fake.DocuHelper
 open System
 
 /// The parameter type for docu.
+[<CLIMutable>]
 type DocuParams = 
     { /// The tool path - FAKE tries to find docu.exe automatically in any sub folder.
       ToolPath : string

--- a/src/app/FakeLib/DotCover.fs
+++ b/src/app/FakeLib/DotCover.fs
@@ -16,6 +16,7 @@ type DotCoverReportType =
   | NDependXml = 3
 
 /// The dotCover parameter type for running coverage
+[<CLIMutable>]
 type DotCoverParams = 
     { ToolPath: string
       WorkingDir: string
@@ -41,6 +42,7 @@ let DotCoverDefaults =
       CustomParameters = "" 
       ErrorLevel = ErrorLevel.Error} 
 
+[<CLIMutable>]
 type DotCoverMergeParams = 
     { ToolPath: string
       WorkingDir: string
@@ -57,6 +59,7 @@ let DotCoverMergeDefaults =
        TempDir = ""
        CustomParameters = "" }
 
+[<CLIMutable>]
 type DotCoverReportParams = 
     { ToolPath: string
       WorkingDir: string

--- a/src/app/FakeLib/DotNetCLIHelper.fs
+++ b/src/app/FakeLib/DotNetCLIHelper.fs
@@ -33,6 +33,7 @@ let isInstalled() =
     with _ -> false
 
 /// DotNet parameters
+[<CLIMutable>]
 type CommandParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string
@@ -76,6 +77,7 @@ let RunCommand (setCommandParams: CommandParams -> CommandParams) args =
         failwithf "dotnet command failed on %s" args
 
 /// DotNet restore parameters
+[<CLIMutable>]
 type RestoreParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string
@@ -138,6 +140,7 @@ let Restore (setRestoreParams: RestoreParams -> RestoreParams) =
         failwithf "Restore failed on %s" args
 
 /// DotNet build parameters
+[<CLIMutable>]
 type BuildParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string
@@ -211,6 +214,7 @@ let Build (setBuildParams: BuildParams -> BuildParams) =
 
 
 /// DotNet test parameters
+[<CLIMutable>]
 type TestParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string
@@ -284,6 +288,7 @@ let Test (setTestParams: TestParams -> TestParams) =
 
 
 /// DotNet pack parameters
+[<CLIMutable>]
 type PackParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string
@@ -356,6 +361,7 @@ let Pack (setPackParams: PackParams -> PackParams) =
         failwithf "Pack failed on %s" args
 
 /// DotNet publish parameters
+[<CLIMutable>]
 type PublishParams = {
     /// ToolPath - usually just "dotnet"
     ToolPath: string

--- a/src/app/FakeLib/DynamicsCRMHelper.fs
+++ b/src/app/FakeLib/DynamicsCRMHelper.fs
@@ -26,6 +26,7 @@ type PackageType =
         | Both -> "/p:Both"
 
 /// Parameters for executing Dynamics CRM Helper functions
+[<CLIMutable>]
 type DynamicsCrmHelperParams =
     {
         /// Url of CRM Organization / Discovery Service URL if using AllOrganizations
@@ -70,6 +71,7 @@ let DynamicsCrmHelperDefaults =
     }
 
 /// Parameters for invoking Solution Packager
+[<CLIMutable>]
 type SolutionPackagerParams =
     {
         /// Action to start, either pack or extract

--- a/src/app/FakeLib/DynamicsNavHelper.fs
+++ b/src/app/FakeLib/DynamicsNavHelper.fs
@@ -65,6 +65,7 @@ type NavisionServerType =
         | NavisionServerType.NativeServer -> "NAVISION"
 
 /// A parameter type to interact with Dynamics NAV
+[<CLIMutable>]
 type DynamicsNavParams = 
     { ToolPath : string
       ServerName : string

--- a/src/app/FakeLib/FXCopHelper.fs
+++ b/src/app/FakeLib/FXCopHelper.fs
@@ -19,6 +19,7 @@ type FxCopErrorLevel =
     | DontFailBuild = 0
 
 /// Parameter type for the FxCop tool
+[<CLIMutable>]
 type FxCopParams = 
     { ApplyOutXsl : bool
       DirectOutputToConsole : bool

--- a/src/app/FakeLib/FixieHelper.fs
+++ b/src/app/FakeLib/FixieHelper.fs
@@ -6,6 +6,7 @@ open System.IO
 open System.Text
 
 /// Parameter type to configure the Fixie runner
+[<CLIMutable>]
 type FixieParams = {
     /// FileName of the Fixie runner
     ToolPath: string

--- a/src/app/FakeLib/FscHelper.fs
+++ b/src/app/FakeLib/FscHelper.fs
@@ -27,6 +27,7 @@ type FscPlatform =
 
 /// 'fsc.exe' command line parameters
 [<Obsolete "Use FscHelper.FscParam instead">]
+[<CLIMutable>]
 type FscParams = 
     { /// Specifies the output file name and path.
       Output : string

--- a/src/app/FakeLib/GACHelper.fs
+++ b/src/app/FakeLib/GACHelper.fs
@@ -8,6 +8,7 @@ let gacutilToolPath = !! (sdkBasePath + "/**/gacutil.exe")
                              |> getNewestTool
 
 /// GAC parameters
+[<CLIMutable>]
 type GACParams = 
     { /// (Required) Path to the gacutil
       ToolPath : string

--- a/src/app/FakeLib/GitVersionHelper.fs
+++ b/src/app/FakeLib/GitVersionHelper.fs
@@ -9,6 +9,7 @@ open FSharp.Data
 open Newtonsoft.Json
 open System
 
+[<CLIMutable>]
 type GitversionParams = {
     ToolPath : string
 }

--- a/src/app/FakeLib/HipChatNotificationHelper.fs
+++ b/src/app/FakeLib/HipChatNotificationHelper.fs
@@ -6,6 +6,7 @@ open System.Web
 open Fake
 
 /// The HipChat notification paramater type
+[<CLIMutable>]
 type HipChatNotificationParams = {
     /// (Required) Auth token from HipChat
     AuthToken: string

--- a/src/app/FakeLib/HockeyAppHelper.fs
+++ b/src/app/FakeLib/HockeyAppHelper.fs
@@ -71,6 +71,7 @@ type HockeyResponse = {
 
 /// The HockeyApp parameter type
 /// Based on http://support.hockeyapp.net/kb/api/api-apps#upload-app
+[<CLIMutable>]
 type HockeyAppUploadParams = {
     /// (Required) API token
     ApiToken: string

--- a/src/app/FakeLib/ILMergeHelper.fs
+++ b/src/app/FakeLib/ILMergeHelper.fs
@@ -26,6 +26,7 @@ type TargetKind =
     | WinExe
 
 /// Parameter type for ILMerge
+[<CLIMutable>]
 type ILMergeParams = 
     { /// Path to ILMerge.exe
       ToolPath : string

--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -130,6 +130,7 @@ type MSBuildDistributedLoggerConfig =
         Parameters : (string * string) list option }
 
 /// A type for MSBuild task parameters
+[<CLIMutable>]
 type MSBuildParams = 
     { Targets : string list
       Properties : (string * string) list

--- a/src/app/FakeLib/MSIHelper.fs
+++ b/src/app/FakeLib/MSIHelper.fs
@@ -5,6 +5,7 @@ module Fake.MSIHelper
 open System
 
 /// MSI parameter type
+[<CLIMutable>]
 type MSIParams =
     { ToolPath: string
       WorkingDir:string

--- a/src/app/FakeLib/MageHelper.fs
+++ b/src/app/FakeLib/MageHelper.fs
@@ -19,6 +19,7 @@ type MageCall = NewApp | UpdateApp | Sign | Deploy | UpdateDeploy | SignDeploy
 type MageTrustLevels = Internet | LocalIntranet | FullTrust
 
 /// Needed information to call MAGE
+[<CLIMutable>]
 type MageParams =
   { ToolsPath : string 
     ProjectFiles : seq<string>

--- a/src/app/FakeLib/NCoverHelper.fs
+++ b/src/app/FakeLib/NCoverHelper.fs
@@ -7,6 +7,7 @@ open System.IO
 open System.Text
 
 /// The NCover parameter type.
+[<CLIMutable>]
 type NCoverParams = 
     { ProjectName : string
       ToolPath : string

--- a/src/app/FakeLib/NDependHelper.fs
+++ b/src/app/FakeLib/NDependHelper.fs
@@ -10,6 +10,7 @@ let getWorkingDir workingDir =
     Seq.find isNotNullOrEmpty [workingDir; environVar("teamcity.build.workingDir"); "."]  // TODO: other build servers?
     |> Path.GetFullPath
     
+[<CLIMutable>]
 type NDependParams = 
     { ToolPath : string
       WorkingDir : string

--- a/src/app/FakeLib/NGenHelper.fs
+++ b/src/app/FakeLib/NGenHelper.fs
@@ -4,6 +4,7 @@ module Fake.NGenHelper
 open System
 
 /// NGen parameters
+[<CLIMutable>]
 type NGenParams = 
     { /// (Required) Path to the NGenutil
       ToolPath : string

--- a/src/app/FakeLib/NpmHelper.fs
+++ b/src/app/FakeLib/NpmHelper.fs
@@ -45,6 +45,7 @@ type NpmCommand =
 | Custom of string
 
 /// The Npm parameter type
+[<CLIMutable>]
 type NpmParams = 
     { Src: string
       NpmFilePath: string

--- a/src/app/FakeLib/NuGet/Install.fs
+++ b/src/app/FakeLib/NuGet/Install.fs
@@ -11,6 +11,7 @@ type NugetInstallVerbosity =
 | Detailed
 
 /// Nuget install parameters.
+[<CLIMutable>]
 type NugetInstallParams =
     {
       /// Path to the nuget.exe.

--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -32,6 +32,7 @@ type NugetSymbolPackage =
     | Nuspec = 2
 
 /// Nuget parameter type
+[<CLIMutable>]
 type NuGetParams = 
     { ToolPath : string
       TimeOut : TimeSpan

--- a/src/app/FakeLib/NuGet/Update.fs
+++ b/src/app/FakeLib/NuGet/Update.fs
@@ -5,6 +5,7 @@ open System
 open Fake
 
 /// Nuget update parameters.
+[<CLIMutable>]
 type NugetUpdateParams =
     {
       /// Path to the nuget.exe.

--- a/src/app/FakeLib/OctoTools.fs
+++ b/src/app/FakeLib/OctoTools.fs
@@ -110,6 +110,7 @@ type OctoCommand =
 | Push of PushOptions
 
 /// Complete Octo.exe CLI params
+[<CLIMutable>]
 type OctoParams = {
     ToolName            : string
     ToolPath            : string

--- a/src/app/FakeLib/OpenCoverHelper.fs
+++ b/src/app/FakeLib/OpenCoverHelper.fs
@@ -10,6 +10,7 @@ type RegisterType =
     | RegisterUser
 
 /// OpenCover parameters, for more details see: https://github.com/OpenCover/opencover/wiki/Usage#console-application-usage.
+[<CLIMutable>]
 type OpenCoverParams = 
     { /// (Required) Path to the OpenCover console application
       ExePath : string

--- a/src/app/FakeLib/PaketHelper.fs
+++ b/src/app/FakeLib/PaketHelper.fs
@@ -7,6 +7,7 @@ open System.Xml.Linq
 open System.Text.RegularExpressions
 
 /// Paket pack parameter type
+[<CLIMutable>]
 type PaketPackParams =
     { ToolPath : string
       TimeOut : TimeSpan
@@ -45,6 +46,7 @@ let PaketPackDefaults() : PaketPackParams =
       PinProjectReferences = false }
 
 /// Paket push parameter type
+[<CLIMutable>]
 type PaketPushParams =
     { ToolPath : string
       TimeOut : TimeSpan
@@ -65,6 +67,7 @@ let PaketPushDefaults() : PaketPushParams =
       ApiKey = null }
 
 /// Paket restore packages type
+[<CLIMutable>]
 type PaketRestoreParams =
     { ToolPath : string
       TimeOut : TimeSpan

--- a/src/app/FakeLib/PaketTemplateHelper.fs
+++ b/src/app/FakeLib/PaketTemplateHelper.fs
@@ -36,6 +36,7 @@ type PaketDependencyVersionInfo =
 type PaketDependency = string * PaketDependencyVersionInfo
 
 /// Contains the different parameters to create a paket.template file
+[<CLIMutable>]
 type PaketTemplateParams =
     { /// The file path to the `paket.template` file
       /// if omitted, a `paket.template` file will be created in the current directory

--- a/src/app/FakeLib/PicklesHelper.fs
+++ b/src/app/FakeLib/PicklesHelper.fs
@@ -60,6 +60,7 @@ type TestResultsFormat =
     | Excel
   
 /// The Pickles parameter type
+[<CLIMutable>]
 type PicklesParams =
     { /// The path to the Pickles console tool: 'pickles.exe'      
       ToolPath : string

--- a/src/app/FakeLib/ProcessHelper.fs
+++ b/src/app/FakeLib/ProcessHelper.fs
@@ -395,6 +395,7 @@ let findPath settingsName fallbackValue tool =
     | None -> tool
 
 /// Parameter type for process execution.
+[<CLIMutable>]
 type ExecParams = 
     { /// The path to the executable, without arguments. 
       Program : string

--- a/src/app/FakeLib/RegAsmHelper.fs
+++ b/src/app/FakeLib/RegAsmHelper.fs
@@ -10,6 +10,7 @@ let regAsmToolPath = !! (TargetPlatformPrefix + "/**/RegAsm.exe")
                              |> getNewestTool
 
 /// RegAsm parameter type
+[<CLIMutable>]
 type RegAsmParams = 
     { ToolPath : string
       WorkingDir : string

--- a/src/app/FakeLib/ReportGeneratorHelper.fs
+++ b/src/app/FakeLib/ReportGeneratorHelper.fs
@@ -20,6 +20,7 @@ type ReportGeneratorLogVerbosity =
     | Error = 2
 
 /// ReportGenerator parameters, for more details see: https://github.com/danielpalme/ReportGenerator.
+[<CLIMutable>]
 type ReportGeneratorParams =
     { /// (Required) Path to the ReportGenerator exe file.
       ExePath : string

--- a/src/app/FakeLib/RestorePackageHelper.fs
+++ b/src/app/FakeLib/RestorePackageHelper.fs
@@ -42,6 +42,7 @@ let findNuget defaultPath =
     | _ -> defaultPath @@ "NuGet.exe"
 
 /// RestorePackages parameter path
+[<CLIMutable>]
 type RestorePackageParams =
     { ToolPath: string
       Sources: string list
@@ -59,6 +60,7 @@ let RestorePackageDefaults =
       OutputPath = "./packages" }
 
 /// RestorePackages parameter path for single packages
+[<CLIMutable>]
 type RestoreSinglePackageParams = 
     { ToolPath: string
       Sources: string list

--- a/src/app/FakeLib/RoundhouseHelper.fs
+++ b/src/app/FakeLib/RoundhouseHelper.fs
@@ -6,6 +6,7 @@ open Fake.ProcessHelper
 open System
 
 /// Parameter type to configure the RoundhousE runner
+[<CLIMutable>]
 type RoundhouseParams = {
 
     /// The database you want to create/migrate.

--- a/src/app/FakeLib/SCPHelper.fs
+++ b/src/app/FakeLib/SCPHelper.fs
@@ -3,6 +3,7 @@
 module Fake.SCPHelper
 
 /// The SCP parameter type.
+[<CLIMutable>]
 type SCPParams = 
     { /// Path of the scp.exe 
       ToolPath : string

--- a/src/app/FakeLib/SSHHelper.fs
+++ b/src/app/FakeLib/SSHHelper.fs
@@ -3,6 +3,7 @@
 module Fake.SSHHelper
 
 /// The SSH parameter type.
+[<CLIMutable>]
 type SSHParams = 
     { /// Path of the scp.exe 
       ToolPath : string

--- a/src/app/FakeLib/SignToolHelper.fs
+++ b/src/app/FakeLib/SignToolHelper.fs
@@ -20,6 +20,7 @@ type SignCert = {
 }
 
 /// Parameters used for signing.
+[<CLIMutable>]
 type SignParams = {
     /// The dev certificate that will be used when the real certificate can not be found
     DevCertificate : SignCert

--- a/src/app/FakeLib/SlackNotificationHelper.fs
+++ b/src/app/FakeLib/SlackNotificationHelper.fs
@@ -5,6 +5,7 @@ open System.Net
 open Newtonsoft.Json
 
 /// The Slack notification attachment field parameter type
+[<CLIMutable>]
 type SlackNotificationAttachmentFieldParams = {
     /// (Required) The field title
     Title: string
@@ -15,6 +16,7 @@ type SlackNotificationAttachmentFieldParams = {
 }
 
 /// The Slack notification attachment parameter type
+[<CLIMutable>]
 type SlackNotificationAttachmentParams = {
     /// (Required) Text summary of the attachment that is shown by clients that understand attachments but choose not to show them
     Fallback: string
@@ -33,6 +35,7 @@ type SlackNotificationAttachmentParams = {
 }
 
 /// The Slack notification parameter type
+[<CLIMutable>]
 type SlackNotificationParams = {
     /// (Required) The message body
     Text: string

--- a/src/app/FakeLib/SonarQubeHelper.fs
+++ b/src/app/FakeLib/SonarQubeHelper.fs
@@ -6,6 +6,7 @@ open TraceHelper
 type SonarQubeCall = Begin | End
 
 /// Parameter type to configure the sonar qube runner.
+[<CLIMutable>]
 type SonarQubeParams =
     { /// FileName of the sonar qube runner exe. 
       ToolsPath : string

--- a/src/app/FakeLib/SpecFlowHelper.fs
+++ b/src/app/FakeLib/SpecFlowHelper.fs
@@ -7,6 +7,7 @@ open System.IO
 open System.Text
 
 /// SpecFlow execution parameter type.
+[<CLIMutable>]
 type SpecFlowParams = { 
     SubCommand:         string
     ProjectFile:        string

--- a/src/app/FakeLib/SquirrelHelper.fs
+++ b/src/app/FakeLib/SquirrelHelper.fs
@@ -9,6 +9,7 @@ open System.Text
 /// FAKE will use [SquirrelDefaults](fake-squirrel.html) for values not provided.
 ///
 /// For reference, see: [Squirrel Command Line Options](https://github.com/Squirrel/Squirrel.Windows/blob/master/docs/advanced-releasify.md)
+[<CLIMutable>]
 type SquirrelParams =
     {
         /// The output directory for the generated installer

--- a/src/app/FakeLib/StrongNamingHelper.fs
+++ b/src/app/FakeLib/StrongNamingHelper.fs
@@ -5,6 +5,7 @@ open System
 
 
 /// Strong naming parameters
+[<CLIMutable>]
 type StrongNameParams = 
     { /// (Required) Path to the sn.exe
       ToolPath : string

--- a/src/app/FakeLib/TestFlightHelper.fs
+++ b/src/app/FakeLib/TestFlightHelper.fs
@@ -5,6 +5,7 @@ open System
 open System.IO
 
 /// The TestFlight parameter type.
+[<CLIMutable>]
 type TestFlightParams = {
     /// (Required) API token from testflightapp.com/account/#api
     ApiToken: string

--- a/src/app/FakeLib/TypeScript.fs
+++ b/src/app/FakeLib/TypeScript.fs
@@ -16,6 +16,7 @@ type ModuleGeneration =
     | AMD
 
 /// TypeScript task parameter type
+[<CLIMutable>]
 type TypeScriptParams =
     { 
       /// Specifies which ECMAScript version the TypeScript compiler should generate. Default is ES3.

--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -21,6 +21,7 @@ let mstestexe =
 type ErrorLevel = TestRunnerErrorLevel
 
 /// Parameter type to configure the MSTest.exe.
+[<CLIMutable>]
 type MSTestParams = 
     { /// Test category filter  (optional). The test category filter consists of one or more test category names separated by the logical operators '&', '|', '!', '&!'. The logical operators '&' and '|' cannot be used together to create a test category filter.
       Category : string

--- a/src/app/FakeLib/UnitTest/MSpecHelper.fs
+++ b/src/app/FakeLib/UnitTest/MSpecHelper.fs
@@ -7,6 +7,7 @@ open System.IO
 open System.Text
 
 /// Parameter type to configure the MSpec runner.
+[<CLIMutable>]
 type MSpecParams = 
     { /// FileName of the mspec runner exe. Use mspec-clr4.exe if you are on .NET 4.0 or above.
       ToolPath : string

--- a/src/app/FakeLib/UnitTest/NUnit/Common.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/Common.fs
@@ -42,6 +42,7 @@ type NUnitDomainModel =
 /// FAKE will use [NUnitDefaults](fake-nunitcommon.html) for values not provided.
 ///
 /// For reference, see: [NUnit-Console Command Line Options](http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.4)
+[<CLIMutable>]
 type NUnitParams = 
     { 
       /// The [Categories](http://www.nunit.org/index.php?p=category&r=2.6.4) to be included in a test run. Multiple categories may be specified on either option, by using commas to separate them.

--- a/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
@@ -100,6 +100,7 @@ type LabelsLevel =
 /// The NUnit 3 Console Parameters type. FAKE will use [NUnit3Defaults](fake-testing-nunit3.html) for values not provided.
 ///
 /// For reference, see: [NUnit3 command line options](https://github.com/nunit/nunit/wiki/Console-Command-Line)
+[<CLIMutable>]
 type NUnit3Params =
     { /// The path to the NUnit3 console runner: `nunit3-console.exe`
       ToolPath : string

--- a/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
+++ b/src/app/FakeLib/UnitTest/ProcessTestRunner.fs
@@ -6,6 +6,7 @@ open System.IO
 open System.Text
 
 /// The ProcessTestRunner parameter type.
+[<CLIMutable>]
 type ProcessTestRunnerParams = 
     { /// The working directory (optional).
       WorkingDir : string

--- a/src/app/FakeLib/UnitTest/VSTest.fs
+++ b/src/app/FakeLib/UnitTest/VSTest.fs
@@ -19,6 +19,7 @@ let vsTestExe =
 type ErrorLevel = TestRunnerErrorLevel
 
 /// Parameter type to configure [VSTest.Console.exe](https://msdn.microsoft.com/en-us/library/jj155800.aspx)
+[<CLIMutable>]
 type VSTestParams = 
     { /// Path to the run settings file to run tests with additional settings such as data collectors (optional).
       SettingsPath : string

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit.fs
@@ -8,6 +8,7 @@ open System.Text
 open Fake
 
 /// The xUnit parameter type.
+[<CLIMutable>]
 type XUnitParams =
     { /// The path to the xUnit console runner: `xunit.console.clr4.exe`
       ToolPath : string

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -92,6 +92,7 @@ type CollectionConcurrencyMode =
         | MaxThreads count -> Some count
 
 /// The xUnit2 parameter type.
+[<CLIMutable>]
 type XUnit2Params =
     { /// The path to the xUnit console runner: `xunit.console.exe`
       ToolPath : string

--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2Helper.fs
@@ -55,6 +55,7 @@ type XUnit2ErrorLevel = TestRunnerErrorLevel // a type alias to keep backwards c
 /// DEPRECATED.
 /// The xUnit parameter type
 [<Obsolete("This type will be removed in a future version. See Fake.Testing.XUnit2.XUnit2Params")>]
+[<CLIMutable>]
 type XUnit2Params =
     { /// The path to the xunit.console.exe - FAKE will scan all subfolders to find it automatically.
       ToolPath : string

--- a/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnitHelper.fs
@@ -19,6 +19,7 @@ type XUnitErrorLevel = TestRunnerErrorLevel // a type alias to keep backwards co
 /// DEPRECATED.
 /// The xUnit parameter type
 [<Obsolete("This type will be removed in a future version. See Fake.Testing.XUnit.XUnitParams")>]
+[<CLIMutable>]
 type XUnitParams =
     { /// The path to the xunit.console.clr4.exe - FAKE will scan all subfolders to find it automatically.
       ToolPath : string

--- a/src/app/FakeLib/Vb6helper.fs
+++ b/src/app/FakeLib/Vb6helper.fs
@@ -10,6 +10,7 @@ open System
 open System.IO
 
 /// Parameters for running a VB6 build
+[<CLIMutable>]
 type Vb6BuildParams = 
     { 
         /// Path to the VB6 executable

--- a/src/app/FakeLib/WiXHelper.fs
+++ b/src/app/FakeLib/WiXHelper.fs
@@ -957,6 +957,7 @@ let setComponentsNeverOverwrite (components : string) =
 open System
 
 /// WiX parameter type
+[<CLIMutable>]
 type WiXParams = 
     { ToolDirectory : string
       TimeOut : TimeSpan

--- a/src/app/FakeLib/XamarinHelper.fs
+++ b/src/app/FakeLib/XamarinHelper.fs
@@ -19,6 +19,7 @@ let private executeCommand command args =
              if result.ExitCode <> 0 then failwithf "%s exited with error %d" command result.ExitCode
 
 /// The package restore paramater type
+[<CLIMutable>]
 type XamarinComponentRestoreParams = {
     /// Path to xamarin-component.exe, defaults to checking tools/xpkg
     ToolPath: string
@@ -41,6 +42,7 @@ let RestoreComponents setParams projectFile =
     |> restoreComponents projectFile
 
 /// The iOS build paramater type
+[<CLIMutable>]
 type iOSBuildParams = {
     /// (Required) Path to solution or project file
     ProjectPath: string
@@ -123,6 +125,7 @@ let iOSBuild setParams =
     |> buildProject
 
 /// The Android packaging parameter type
+[<CLIMutable>]
 type AndroidPackageParams = {
     /// (Required) Path to the Android project file (not the solution file!)
     ProjectPath: string
@@ -260,6 +263,7 @@ let AndroidPackage setParams =
     AndroidBuildPackages setParams |> Seq.exactlyOne
 
 // Parameters for signing and aligning an Android package
+[<CLIMutable>]
 type AndroidSignAndAlignParams = {
     /// (Required) Path to keystore used to sign the app
     KeystorePath: string
@@ -328,6 +332,7 @@ let AndroidSignAndAlignPackages setParams apkFiles =
     apkFiles |> Seq.map (fun f -> AndroidSignAndAlign setParams f)
 
 /// The iOS archive paramater type
+[<CLIMutable>]
 type iOSArchiveParams = {
     /// Path to desired solution file. If not provided, mdtool finds the first solution in the current directory.
     /// Although mdtool can take a project file, the archiving seems to fail to work without a solution.

--- a/src/app/FakeLib/XpkgHelper.fs
+++ b/src/app/FakeLib/XpkgHelper.fs
@@ -6,6 +6,7 @@ open System
 open System.Text
 
 /// Parameter type for xpkg tasks
+[<CLIMutable>]
 type xpkgParams = 
     { ToolPath : string
       WorkingDir : string


### PR DESCRIPTION
This PR annotates all `*Params` records in the `FakeLib` helpers with `[<CLIMutable>]`.

This doesn't really affect anything on the F# side, but it makes C# interoperability, and the convenience/experience of consuming `FakeLib` there infinitely better.