### PR TITLE
Improve error logging in GitVersionHelper

### DIFF
--- a/src/app/FakeLib/GitVersionHelper.fs
+++ b/src/app/FakeLib/GitVersionHelper.fs
@@ -60,5 +60,5 @@ let GitVersion (setParams : GitversionParams -> GitversionParams) =
 
     let result = ExecProcessAndReturnMessages (fun info ->
         info.FileName <- parameters.ToolPath) timespan
-    if result.ExitCode <> 0 then failwithf "GitVersion.exe failed with exit code %i" result.ExitCode
+    if result.ExitCode <> 0 then failwithf "GitVersion.exe failed with exit code %i and message %s" result.ExitCode (String.concat "" result.Messages)
     result.Messages |> String.concat "" |> fun j -> JsonConvert.DeserializeObject<GitVersionProperties>(j)


### PR DESCRIPTION
While searching for a unresolved bug where gitversion would fail when running on one of your build agents I discovered that the exit code is not of any use since all errors return 1.