### PR TITLE
Display original server response when failing to parse JSON in Fake.Deploy

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -37,6 +37,7 @@ nuget FluentMigrator.Runner
 nuget HashLib
 nuget FSharp.Compiler.Service
 nuget Octokit
+nuget Microsoft.Net.Http
 
 github matthid/Yaaf.FSharp.Scripting src/source/Yaaf.FSharp.Scripting/YaafFSharpScripting.fs
 

--- a/src/app/Fake.Deploy.Lib/Fake.Deploy.Lib.fsproj
+++ b/src/app/Fake.Deploy.Lib/Fake.Deploy.Lib.fsproj
@@ -146,6 +146,53 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\..\packages\Microsoft.Bcl\lib\net40\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\..\packages\Microsoft.Bcl\lib\net40\System.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Threading.Tasks">
+          <HintPath>..\..\..\packages\Microsoft.Bcl\lib\net40\System.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.WebRequest">
+          <HintPath>..\..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">

--- a/src/app/Fake.Deploy.Lib/Json.fs
+++ b/src/app/Fake.Deploy.Lib/Json.fs
@@ -14,3 +14,12 @@ let deserialize<'a> text : 'a = JsonConvert.DeserializeObject<'a>(text)
 
 /// Deserializes a file into a object of type 'a
 let deserializeFile<'a> = ReadFileAsString >> deserialize<'a>
+
+exception ParsingException of string * exn
+
+/// Tryes to deserialize a text into a object of type 'a and returns either instance of 'a or parsing error
+let tryDeserialize<'a> (s: string) : Choice<'a, exn> =
+    try
+        deserialize<'a> s |> Choice1Of2
+    with exn -> ParsingException(s, exn) |> Choice2Of2
+

--- a/src/app/Fake.Deploy.Lib/Json.fs
+++ b/src/app/Fake.Deploy.Lib/Json.fs
@@ -15,11 +15,16 @@ let deserialize<'a> text : 'a = JsonConvert.DeserializeObject<'a>(text)
 /// Deserializes a file into a object of type 'a
 let deserializeFile<'a> = ReadFileAsString >> deserialize<'a>
 
-exception ParsingException of string * exn
+type ParsingException(input : string, inner : exn) =
+    inherit Exception(sprintf "Faied to parse input: %s" input, inner)
 
 /// Tryes to deserialize a text into a object of type 'a and returns either instance of 'a or parsing error
 let tryDeserialize<'a> (s: string) : Choice<'a, exn> =
     try
         deserialize<'a> s |> Choice1Of2
-    with exn -> ParsingException(s, exn) |> Choice2Of2
+    with exn -> ParsingException(s, exn)
+                :> exn 
+                |> Choice2Of2
+
+
 

--- a/src/app/Fake.Deploy.Lib/paket.references
+++ b/src/app/Fake.Deploy.Lib/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 Newtonsoft.Json
 SSH.NET
+Microsoft.Net.Http


### PR DESCRIPTION
This does two things:
- replaces WebRequest with HttpClient for issuing requests to server
- adds original server response to the error message in case we cannot parse response to JSON (e.g. it was custom server error)

Context:
Spent a lot of time troubleshooting the deployment error that started to occur as my package grew bigger:

```
Unhandled Exception: System.Net.ProtocolViolationException: You must write ContentLength bytes to the request stream before calling [Begin]GetResponse.
   at System.Net.HttpWebRequest.GetResponse()

```
In my case Fake.Deploy was behind nginx proxy. 
So the root cause for me was package size being bigger than nginx's `client_max_body_size`.
Had to replace WebRequest with HttpClient to actually receive nginx's 413 response.
But even after that, the only thing that I saw in output was `Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.` error.
So had to change response parsing logic to include original response into error message.
Now, if server returns something that is not a JSON we expect, the output will look like this:

```
Deployment of ./publish/<my package>.nupkg to http://<address>/deploy/fake failed
Fake.Json+ParsingException: Faied to parse input: <html>
<head><title>413 Request Entity Too Large</title></head>
<body bgcolor="white">
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.10.2</center>
</body>
</html>
 ---> Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.
   at Newtonsoft.Json.JsonTextReader.ParseValue()
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ReadForType(JsonReader reader, JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Fake.Json.tryDeserialize[a](String s) in C:\<path>\FAKE\src\app\Fake.Deploy.Lib\Json.fs:line 24
   --- End of inner exception stack trace ---
```