### PR TITLE
add expecto --summary support

### DIFF
--- a/src/app/FakeLib/UnitTest/Expecto/Expecto.fs
+++ b/src/app/FakeLib/UnitTest/Expecto/Expecto.fs
@@ -23,8 +23,6 @@ type ExpectoParams =
       Run : string list
       /// Doesn't run tests, print out list of tests instead.
       ListTests : bool
-      /// Prints out summary after all tests are finished
-      Summary : bool
       /// Custom cli arguments if not yet supported per se.
       CustomArgs : string list
       /// Working directory
@@ -53,7 +51,6 @@ type ExpectoParams =
         |> appendIfNotNullOrWhiteSpace this.FilterTestList "--filter-test-list "
         |> appendList this.Run "--run "
         |> appendIfTrue this.ListTests "--list-tests "
-        |> appendIfTrue this.Summary "--summary "
         |> appendList this.CustomArgs ""
         |> toText
 
@@ -66,7 +63,6 @@ type ExpectoParams =
             FilterTestList = ""
             Run = []
             ListTests = false
-            Summary = false
             CustomArgs = []
             WorkingDirectory = ""
         }

--- a/src/app/FakeLib/UnitTest/Expecto/Expecto.fs
+++ b/src/app/FakeLib/UnitTest/Expecto/Expecto.fs
@@ -23,9 +23,14 @@ type ExpectoParams =
       Run : string list
       /// Doesn't run tests, print out list of tests instead.
       ListTests : bool
+      /// Prints out summary after all tests are finished
+      Summary : bool
+      /// Custom cli arguments if not yet supported per se.
+      CustomArgs : string list
       /// Working directory
       WorkingDirectory : string
     }
+
     override this.ToString() =
         let append (s: string) (sb: StringBuilder) = sb.Append s
         let appendIfTrue p s sb =
@@ -47,6 +52,9 @@ type ExpectoParams =
         |> appendIfNotNullOrWhiteSpace this.FilterTestCase "--filter-test-case "
         |> appendIfNotNullOrWhiteSpace this.FilterTestList "--filter-test-list "
         |> appendList this.Run "--run "
+        |> appendIfTrue this.ListTests "--list-tests "
+        |> appendIfTrue this.Summary "--summary "
+        |> appendList this.CustomArgs ""
         |> toText
 
     static member DefaultParams =
@@ -58,6 +66,8 @@ type ExpectoParams =
             FilterTestList = ""
             Run = []
             ListTests = false
+            Summary = false
+            CustomArgs = []
             WorkingDirectory = ""
         }
 


### PR DESCRIPTION
- add "--summary" argument introduced in https://github.com/haf/expecto/pull/19
- also added a CustomArgs property to instantly add not yet supported expecto args. Though not sure whether thats a good idea to do so