### PR TITLE
MSBuild 15.0/VS 2017RC support (#1442)

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -23,6 +23,9 @@ let msBuildExe =
     if isUnix then "xbuild"
     else
         let MSBuildPath = 
+            (ProgramFilesX86 @@ @"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin") + ";" +
+            (ProgramFilesX86 @@ @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin") + ";" +
+            (ProgramFilesX86 @@ @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin") + ";" +
             (ProgramFilesX86 @@ @"\MSBuild\14.0\Bin") + ";" +
             (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin") + ";" +
             (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin\amd64") + ";" + 


### PR DESCRIPTION
Added MSBuild 15.0 locations to search paths as per @opcon's diagnosis.
@opcon's VS community installation was at [1]. I installed VS pro and it
ended up at [2]. Am guessing the "Enterprise" path.

[1] (ProgramFilesX86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin
[2] (ProgramFilesX86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin

Note: I had trouble building locally so haven't managed to test this yet. Will update if I manage to get it sorted.