### PR TITLE
Fix for  #1463: Use correct CLI parameter for silent xUnit output

### DIFF
--- a/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
+++ b/src/app/FakeLib/UnitTest/XUnit/XUnit2.fs
@@ -202,7 +202,7 @@ let buildXUnit2Args assemblies parameters =
     |> appendIfTrueWithoutQuotes parameters.ForceTeamCity "-teamcity"
     |> appendIfTrueWithoutQuotes parameters.ForceAppVeyor "-appveyor"
     |> appendIfTrueWithoutQuotes parameters.Wait "-wait"
-    |> appendIfTrueWithoutQuotes parameters.Silent "-silent"
+    |> appendIfTrueWithoutQuotes parameters.Silent "-quiet"
     |> appendIfSome parameters.XmlOutputPath (sprintf @"-xml ""%s""")
     |> appendIfSome parameters.XmlV1OutputPath (sprintf @"-xmlv1 ""%s""")
     |> appendIfSome parameters.NUnitXmlOutputPath (sprintf @"-nunit ""%s""")

--- a/src/test/Test.FAKECore/XUnit2Specs.cs
+++ b/src/test/Test.FAKECore/XUnit2Specs.cs
@@ -60,7 +60,7 @@ namespace Test.FAKECore.XUnit2Specs
             Arguments.ShouldNotContain(" -noshadow");
 
         It should_not_request_silence = () =>
-            Arguments.ShouldNotContain(" -silent");
+            Arguments.ShouldNotContain(" -quiet");
 
         It should_not_request_wait = () =>
             Arguments.ShouldNotContain(" -wait");
@@ -298,7 +298,7 @@ namespace Test.FAKECore.XUnit2Specs
             Arguments.ShouldContain(" -noshadow");
 
         It should_request_silence = () =>
-            Arguments.ShouldContain(" -silent");
+            Arguments.ShouldContain(" -quiet");
 
         It should_request_wait = () =>
             Arguments.ShouldContain(" -wait");


### PR DESCRIPTION
Minimum fix for the -quiet parameter issue: https://github.com/fsharp/FAKE/issues/1463

Updated specs and Fake.Testing.XUnit2, no changes in XUnit2Helper, no changes in public API.