### PR TITLE
Git: recognize renamed (and other status) files

### DIFF
--- a/src/app/FakeLib/Git/FileStatus.fs
+++ b/src/app/FakeLib/Git/FileStatus.fs
@@ -6,16 +6,25 @@ open Fake
 open System
 open System.IO
 
+let private (|Status|_|) expected (actualWithCode:string) =
+    if actualWithCode.StartsWith expected then
+        let success, code = Int32.TryParse(actualWithCode.Substring(expected.Length))
+        if success then Some code else None
+    else None
+
 /// A type which represents a file status in git.
 type FileStatus =
 | Added
 | Modified
 | Deleted
+/// The file has been renamed (with 0 < similarity <= 100)
+| Renamed of similarity:int
     with 
-        static member Parse = function      
+        static member Parse = function
           | "A" -> Added
           | "M" -> Modified
           | "D" -> Deleted
+          | Status "R" similarity -> Renamed similarity
           | s -> failwithf "Unknown file status %s" s
  
 /// Gets the changed files between the given revisions

--- a/src/test/Test.Git/FileStatusSpecs.cs
+++ b/src/test/Test.Git/FileStatusSpecs.cs
@@ -1,0 +1,18 @@
+﻿using Machine.Specifications;
+using static Fake.Git.FileStatus;
+
+namespace Test.Git
+{
+    public class when_getting_file_status
+    {
+        It should_be_able_to_get_renamed_files =
+            () => FileStatus
+                .Parse.Invoke("R100")
+                .ShouldEqual(FileStatus.NewRenamed(100));
+
+        It should_be_able_to_get_probably_renamed_files =
+            () => FileStatus
+                .Parse.Invoke("R75")
+                .ShouldEqual(FileStatus.NewRenamed(75));
+    }
+}

--- a/src/test/Test.Git/FileStatusSpecs.cs
+++ b/src/test/Test.Git/FileStatusSpecs.cs
@@ -5,14 +5,24 @@ namespace Test.Git
 {
     public class when_getting_file_status
     {
+        It should_be_able_to_get_modified_files =
+            () => FileStatus
+                .Parse.Invoke("M")
+                .ShouldEqual(FileStatus.Modified);
+
+        It should_be_able_to_get_rewritten_files =
+            () => FileStatus
+                .Parse.Invoke("M42")
+                .ShouldEqual(FileStatus.Modified);
+
         It should_be_able_to_get_renamed_files =
             () => FileStatus
                 .Parse.Invoke("R100")
-                .ShouldEqual(FileStatus.NewRenamed(100));
+                .ShouldEqual(FileStatus.Renamed);
 
         It should_be_able_to_get_probably_renamed_files =
             () => FileStatus
                 .Parse.Invoke("R75")
-                .ShouldEqual(FileStatus.NewRenamed(75));
+                .ShouldEqual(FileStatus.Renamed);
     }
 }

--- a/src/test/Test.Git/Test.Git.csproj
+++ b/src/test/Test.Git/Test.Git.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileStatusSpecs.cs" />
     <Compile Include="Sha1Specs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GitInformationSpec.cs" />


### PR DESCRIPTION
*This is a **breaking change**!*

Recognize renamed (and other less wellknown) files instead of bailing out with "Unknown file status"
fixes #1458 
According to [git docs](https://git-scm.com/docs/git-diff#git-diff---diff-filterACDMRTUXB82308203).