### PR TITLE
Add MSBuild location for VS2017 Build Tools

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -29,6 +29,7 @@ let knownMsBuildEntries =
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"; 
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin";
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin";
+                                     @"\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin";
                                      @"\MSBuild\15.0\Bin"] }
     ]
 


### PR DESCRIPTION
The proposed change adds the location for the Build Tools for Visual Studio 2017, for use on a CI server or build agent.