### PR TITLE
Improve log integration with AppVeyor

### DIFF
--- a/src/app/FakeLib/AppVeyor.fs
+++ b/src/app/FakeLib/AppVeyor.fs
@@ -5,68 +5,68 @@ open System
 open System.IO
 
 /// AppVeyor environment variables as [described](http://www.appveyor.com/docs/environment-variables)
-type AppVeyorEnvironment = 
-    
+type AppVeyorEnvironment =
+
     /// AppVeyor Build Agent API URL
     static member ApiUrl = environVar "APPVEYOR_API_URL"
 
     /// AppVeyor Account Name
     static member AccountName = environVar "APPVEYOR_ACCOUNT_NAME"
-    
+
     /// AppVeyor unique project ID
     static member ProjectId = environVar "APPVEYOR_PROJECT_ID"
-    
+
     /// Project name
     static member ProjectName = environVar "APPVEYOR_PROJECT_NAME"
-    
+
     /// Project slug (as seen in project details URL)
     static member ProjectSlug = environVar "APPVEYOR_PROJECT_SLUG"
-    
+
     /// Path to clone directory
     static member BuildFolder = environVar "APPVEYOR_BUILD_FOLDER"
-    
+
     /// AppVeyor unique build ID
     static member BuildId = environVar "APPVEYOR_BUILD_ID"
-    
+
     /// Build number
     static member BuildNumber = environVar "APPVEYOR_BUILD_NUMBER"
-    
+
     /// Build version
     static member BuildVersion = environVar "APPVEYOR_BUILD_VERSION"
-    
+
     /// GitHub Pull Request number
     static member PullRequestNumber = environVar "APPVEYOR_PULL_REQUEST_NUMBER"
-    
+
     /// GitHub Pull Request title
     static member PullRequestTitle = environVar "APPVEYOR_PULL_REQUEST_TITLE"
-    
+
     /// AppVeyor unique job ID
     static member JobId = environVar "APPVEYOR_JOB_ID"
-    
+
     /// GitHub, BitBucket or Kiln
     static member RepoProvider = environVar "APPVEYOR_REPO_PROVIDER"
-    
+
     /// git or mercurial
     static member RepoScm = environVar "APPVEYOR_REPO_SCM"
-    
+
     /// Repository name in format owner-name/repo-name
     static member RepoName = environVar "APPVEYOR_REPO_NAME"
-    
+
     /// Build branch
     static member RepoBranch = environVar "APPVEYOR_REPO_BRANCH"
-    
+
     /// Commit ID (SHA)
     static member RepoCommit = environVar "APPVEYOR_REPO_COMMIT"
-    
+
     /// Commit author's name
     static member RepoCommitAuthor = environVar "APPVEYOR_REPO_COMMIT_AUTHOR"
-    
+
     /// Commit author's email address
     static member RepoCommitAuthorEmail = environVar "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL"
-    
+
     /// Commit date/time
     static member RepoCommitTimestamp = environVar "APPVEYOR_REPO_COMMIT_TIMESTAMP"
-    
+
     /// Commit message
     static member RepoCommitMessage = environVar "APPVEYOR_REPO_COMMIT_MESSAGE"
 
@@ -81,7 +81,7 @@ type AppVeyorEnvironment =
 
     /// If the build has been started by the "Re-Build commit/PR" button or from the same API
     static member IsReBuild = environVar "APPVEYOR_RE_BUILD"
-    
+
     /// true if build has started by pushed tag; otherwise false
     static member RepoTag =
         let rt = environVar "APPVEYOR_REPO_TAG"
@@ -93,31 +93,35 @@ type AppVeyorEnvironment =
     /// Platform name set on Build tab of project settings (or through platform parameter in appveyor.yml).
     static member Platform = environVar "PLATFORM"
 
-    /// Configuration name set on Build tab of project settings (or through configuration parameter in appveyor.yml).  
+    /// Configuration name set on Build tab of project settings (or through configuration parameter in appveyor.yml).
     static member Configuration  = environVar "CONFIGURATION"
 
     /// The job name
     static member JobName = environVar "APPVEYOR_JOB_NAME"
-    
-let private sendToAppVeyor args = 
-    ExecProcess (fun info -> 
+
+let private sendToAppVeyor args =
+    ExecProcess (fun info ->
         info.FileName <- "appveyor"
         info.Arguments <- args) (System.TimeSpan.MaxValue)
     |> ignore
 
-let private add msg category = 
-    sprintf "AddMessage %s -Category %s" (quoteIfNeeded msg) (quoteIfNeeded category) |> sendToAppVeyor
+let private add msg category =
+    if not <| isNullOrEmpty msg then
+        let enableProcessTracingPreviousValue = enableProcessTracing
+        enableProcessTracing <- false
+        sprintf "AddMessage %s -Category %s" (quoteIfNeeded msg) (quoteIfNeeded category) |> sendToAppVeyor
+        enableProcessTracing <- enableProcessTracingPreviousValue
 let private addNoCategory msg = sprintf "AddMessage %s" (quoteIfNeeded msg) |> sendToAppVeyor
 
 // Add trace listener to track messages
-if buildServer = BuildServer.AppVeyor then 
+if buildServer = BuildServer.AppVeyor then
     { new ITraceListener with
-          member this.Write msg = 
+          member this.Write msg =
               match msg with
               | ErrorMessage x -> add x "Error"
               | ImportantMessage x -> add x "Warning"
               | LogMessage(x, _) -> add x "Information"
-              | TraceMessage(x, _) -> 
+              | TraceMessage(x, _) ->
                   if not enableProcessTracing then addNoCategory x
               | StartMessage | FinishedMessage | OpenTag(_, _) | CloseTag _ -> () }
     |> listeners.Add
@@ -129,23 +133,23 @@ let FinishTestSuite testSuiteName = () // Nothing in API yet
 let StartTestSuite testSuiteName = () // Nothing in API yet
 
 /// Starts the test case.
-let StartTestCase testSuiteName testCaseName = 
+let StartTestCase testSuiteName testCaseName =
     sendToAppVeyor <| sprintf "AddTest \"%s\" -Outcome Running" (testSuiteName + " - " + testCaseName)
 
 /// Reports a failed test.
-let TestFailed testSuiteName testCaseName message details = 
+let TestFailed testSuiteName testCaseName message details =
     sendToAppVeyor <| sprintf "UpdateTest \"%s\" -Outcome Failed -ErrorMessage %s -ErrorStackTrace %s" (testSuiteName + " - " + testCaseName)
         (EncapsulateSpecialChars message) (EncapsulateSpecialChars details)
 
-/// Ignores the test case.      
+/// Ignores the test case.
 let IgnoreTestCase testSuiteName testCaseName message = sendToAppVeyor <| sprintf "UpdateTest \"%s\" -Outcome Ignored" (testSuiteName + " - " + testCaseName)
 
 /// Reports a succeeded test.
 let TestSucceeded testSuiteName testCaseName = sendToAppVeyor <| sprintf "UpdateTest \"%s\" -Outcome Passed" (testSuiteName + " - " + testCaseName)
 
 /// Finishes the test case.
-let FinishTestCase testSuiteName testCaseName (duration : System.TimeSpan) = 
-    let duration = 
+let FinishTestCase testSuiteName testCaseName (duration : System.TimeSpan) =
+    let duration =
         duration.TotalMilliseconds
         |> round
         |> string
@@ -238,7 +242,7 @@ let PushArtifacts paths =
 
 /// AppVeyor parameters for update build as [described](https://www.appveyor.com/docs/build-worker-api/#update-build-details)
 [<CLIMutable>]
-type UpdateBuildParams = 
+type UpdateBuildParams =
     { /// Build version; must be unique for the current project
       Version : string
       /// Commit message
@@ -271,7 +275,7 @@ let UpdateBuild (setParams : UpdateBuildParams -> UpdateBuildParams) =
     if buildServer = BuildServer.AppVeyor then
         let parameters = setParams defaultUpdateBuildParams
 
-        let committedStr = 
+        let committedStr =
             match parameters.Committed with
             | Some x -> x.ToString("o")
             | None -> ""
@@ -290,5 +294,5 @@ let UpdateBuild (setParams : UpdateBuildParams -> UpdateBuildParams) =
         |> sendToAppVeyor
 
 /// Update build version. This must be unique for the current project.
-let UpdateBuildVersion version = 
+let UpdateBuildVersion version =
     UpdateBuild (fun p -> { p with Version = version })

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -3,6 +3,7 @@
 module Fake.TargetHelper
 
 open System
+open System.Text
 open System.Collections.Generic
 open System.Linq
 
@@ -333,9 +334,16 @@ let runBuildFailureTargets() =
 
 /// Prints all targets.
 let PrintTargets() =
-    log "The following targets are available:"
+    let sb = StringBuilder()
+    let appendfn fmt = Printf.ksprintf (sb.AppendLine >> ignore) fmt
+
+    appendfn "The following targets are available:"
     for t in TargetDict.Values do
-        logfn "   %s%s" t.Name (if isNullOrEmpty t.Description then "" else sprintf " - %s" t.Description)
+        appendfn "   %s%s" t.Name (if isNullOrEmpty t.Description then "" else sprintf " - %s" t.Description)
+
+    sb.Length <- sb.Length - Environment.NewLine.Length
+
+    log <| sb.ToString()
 
 
 // Maps the specified dependency type into the list of targets
@@ -380,35 +388,47 @@ let PrintDependencyGraph verbose target =
     match TargetDict.TryGetValue (target) with
     | false,_ -> PrintTargets()
     | true,target ->
-        logfn "%sDependencyGraph for Target %s:" (if verbose then String.Empty else "Shortened ") target.Name
+        let sb = StringBuilder()
+        let appendfn fmt = Printf.ksprintf (sb.AppendLine >> ignore) fmt
+
+        appendfn "%sDependencyGraph for Target %s:" (if verbose then String.Empty else "Shortened ") target.Name
 
         let logDependency ((t: TargetTemplate<unit>), depType, level, isVisited) =
             if verbose ||  not isVisited then
                 let indent = (String(' ', level * 3))
                 if depType = DependencyType.Soft then
-                    log <| sprintf "%s<=? %s" indent t.Name
+                    appendfn "%s<=? %s" indent t.Name
                 else
-                    log <| sprintf "%s<== %s" indent t.Name
+                    appendfn "%s<== %s" indent t.Name
 
         let _, ordered = visitDependencies logDependency target.Name
 
-        log ""
-        log "The resulting target order is:"
-        Seq.iter (logfn " - %s") ordered
+        appendfn ""
+        appendfn "The resulting target order is:"
+        Seq.iter (appendfn " - %s") ordered
+
+        sb.Length <- sb.Length - Environment.NewLine.Length
+
+        log <| sb.ToString()
 
 /// <summary>Writes a dependency graph of all targets in the DOT format.</summary>
 let PrintDotDependencyGraph () =
-    logfn "digraph G {"
-    logfn "  rankdir=TB;"
-    logfn "  node [shape=box];"
+    let sb = StringBuilder()
+    let appendfn fmt = Printf.ksprintf (sb.AppendLine >> ignore) fmt
+
+    appendfn "digraph G {"
+    appendfn "  rankdir=TB;"
+    appendfn "  node [shape=box];"
     for target in TargetDict.Values do
-        logfn "  \"%s\";" target.Name
+        appendfn "  \"%s\";" target.Name
         let deps = target.Dependencies
         for d in target.Dependencies do
-            logfn "  \"%s\" -> \"%s\"" target.Name d
+            appendfn "  \"%s\" -> \"%s\"" target.Name d
         for d in target.SoftDependencies do
-            logfn "  \"%s\" -> \"%s\" [style=dotted];" target.Name d
-    logfn "}"
+            appendfn "  \"%s\" -> \"%s\" [style=dotted];" target.Name d
+    sb.Append "}" |> ignore
+
+    log <| sb.ToString()
 
 /// Writes a summary of errors reported during build.
 let WriteErrors () =

--- a/src/app/FakeLib/TraceHelper.fs
+++ b/src/app/FakeLib/TraceHelper.fs
@@ -167,7 +167,7 @@ let traceStartTaskUsing task description =
     traceStartTask task description
     { new IDisposable with member x.Dispose() = traceEndTask task description }
 
-let console = new ConsoleTraceListener(false, colorMap) :> ITraceListener
+let console = new ConsoleTraceListener(false, colorMap, false) :> ITraceListener
 
 open System.Diagnostics
 

--- a/src/app/FakeLib/TraceListener.fs
+++ b/src/app/FakeLib/TraceListener.fs
@@ -5,7 +5,7 @@ module Fake.TraceListener
 open System
 
 /// Defines Tracing information for TraceListeners
-type TraceData = 
+type TraceData =
     | StartMessage
     | ImportantMessage of string
     | ErrorMessage of string
@@ -36,11 +36,11 @@ type TraceData =
         | CloseTag _ -> None
 
 /// Defines a TraceListener interface
-type ITraceListener = 
+type ITraceListener =
     abstract Write : TraceData -> unit
 
 /// A default color map which maps TracePriorities to ConsoleColors
-let colorMap traceData = 
+let colorMap traceData =
     match traceData with
     | ImportantMessage _ -> ConsoleColor.Yellow
     | ErrorMessage _ -> ConsoleColor.Red
@@ -53,48 +53,82 @@ let colorMap traceData =
 /// ## Parameters
 ///  - `importantMessagesToStdErr` - Defines whether to trace important messages to StdErr.
 ///  - `colorMap` - A function which maps TracePriorities to ConsoleColors.
-type ConsoleTraceListener(importantMessagesToStdErr, colorMap) = 
-    
-    let writeText toStdErr color newLine text = 
+type ConsoleTraceListener(importantMessagesToStdErr, colorMap, useAnsiColorCodes) =
+    let writeTextConsoleColor print color text =
         let curColor = Console.ForegroundColor
         try
           try
             if curColor <> color then Console.ForegroundColor <- color
-            let printer =
-              match toStdErr, newLine with
-              | true, true -> eprintfn
-              | true, false -> eprintf
-              | false, true -> printfn
-              | false, false -> printf
-            printer "%s" text
+            print text
           with
-            | :? ArgumentException when EnvironmentHelper.isMono -> 
+            | :? ArgumentException when EnvironmentHelper.isMono ->
               printfn "* Color output has been disabled because of a bug in GNOME Terminal."
               printfn "* Hint: To workaround this bug, please set environment property TERM=xterm-256color"
               reraise()
         finally
           if curColor <> color then Console.ForegroundColor <- curColor
-    
+
+    let writeTextAnsiColor print color text =
+        let colorCode = function
+            | ConsoleColor.Black -> [30]
+            | ConsoleColor.Blue -> [34]
+            | ConsoleColor.Cyan -> [36]
+            | ConsoleColor.Gray -> [37;2]
+            | ConsoleColor.Green -> [32]
+            | ConsoleColor.Magenta -> [35]
+            | ConsoleColor.Red -> [31]
+            | ConsoleColor.White -> [37]
+            | ConsoleColor.Yellow -> [33]
+            | ConsoleColor.DarkBlue -> [34;2]
+            | ConsoleColor.DarkCyan -> [36;2]
+            | ConsoleColor.DarkGray -> [37;2]
+            | ConsoleColor.DarkGreen -> [32;2]
+            | ConsoleColor.DarkMagenta -> [35;2]
+            | ConsoleColor.DarkRed -> [31;2]
+            | ConsoleColor.DarkYellow -> [33;2]
+            | _ -> [39]
+
+        let codeStr =
+            colorCode color
+            |> List.map (sprintf "%i")
+            |> String.concat ";"
+
+        print <| sprintf "\x1b[%sm%s\x1b[0m" codeStr text
+
+    let printer toStdErr newLine =
+        match toStdErr, newLine with
+        | true, true -> eprintfn "%s"
+        | true, false -> eprintf "%s"
+        | false, true -> printfn "%s"
+        | false, false -> printf "%s"
+
     interface ITraceListener with
         /// Writes the given message to the Console.
-        member this.Write msg = 
+        member this.Write msg =
             let color = colorMap msg
+            let writeText text printer =
+                if useAnsiColorCodes
+                then writeTextAnsiColor printer color text
+                else writeTextConsoleColor printer color text
             match msg with
             | StartMessage -> ()
             | OpenTag _ -> ()
             | CloseTag _ -> ()
             | ImportantMessage text | ErrorMessage text ->
-                writeText importantMessagesToStdErr color true text
+                printer importantMessagesToStdErr true |> writeText text
             | LogMessage(text, newLine) | TraceMessage(text, newLine) ->
-                writeText false color newLine text
+                printer false newLine |> writeText text
             | FinishedMessage -> ()
 
 // If we write the stderr on those build servers the build will fail.
 let importantMessagesToStdErr = buildServer <> CCNet && buildServer <> AppVeyor && buildServer <> TeamCity
 
+// stdout is piped to the logger, so colours are lost. AppVeyor supports ANSI color codes.
+let useAnsiColors = buildServer = AppVeyor
+
 /// The default TraceListener for Console.
 let defaultConsoleTraceListener =
-  ConsoleTraceListener(importantMessagesToStdErr, colorMap)
+  ConsoleTraceListener(importantMessagesToStdErr, colorMap, useAnsiColors)
 
 /// Specifies if the XmlWriter should close tags automatically
 let mutable AutoCloseXmlWriter = false
@@ -102,24 +136,24 @@ let mutable AutoCloseXmlWriter = false
 /// Implements a TraceListener which writes NAnt like XML files.
 /// ## Parameters
 ///  - `xmlOutputFile` - Defines the xml output file.
-type NAntXmlTraceListener(xmlOutputFile) = 
+type NAntXmlTraceListener(xmlOutputFile) =
     let xmlOutputPath = FullName xmlOutputFile
     let getXmlWriter() = new IO.StreamWriter(xmlOutputPath, true, encoding)
     let mutable xmlWriter : IO.StreamWriter = null
-    
-    let deleteOldFile() = 
+
+    let deleteOldFile() =
         let fi = fileInfo xmlOutputPath
-        if fi.Exists then 
+        if fi.Exists then
             fi.IsReadOnly <- false
             fi.Delete()
         if not fi.Directory.Exists then fi.Directory.Create()
-    
-    let closeWriter() = 
-        if xmlWriter <> null then 
+
+    let closeWriter() =
+        if xmlWriter <> null then
             xmlWriter.Close()
             xmlWriter <- null
-    
-    let getXml msg = 
+
+    let getXml msg =
         match msg with
         | StartMessage -> "<?xml version=\"1.0\"?>\r\n<buildresults>"
         | ImportantMessage text -> sprintf "<message level=\"Info\"><![CDATA[%s]]></message>" text // TODO: Set Level
@@ -127,12 +161,12 @@ type NAntXmlTraceListener(xmlOutputFile) =
         | FinishedMessage -> "</buildresults>"
         | OpenTag(tag, name) -> sprintf "<%s name=\"%s\">" tag name
         | CloseTag tag -> sprintf "</%s>" tag
-        | ErrorMessage text -> 
+        | ErrorMessage text ->
             sprintf "<failure><builderror><message level=\"Error\"><![CDATA[%s]]></message></builderror></failure>" text
-    
+
     interface ITraceListener with
         /// Writes the given message to the xml file.
-        member this.Write msg = 
+        member this.Write msg =
             if msg = StartMessage then deleteOldFile()
             if xmlWriter = null then xmlWriter <- getXmlWriter()
             msg

--- a/src/test/Test.FAKECore/FSIHelperSpecs.cs
+++ b/src/test/Test.FAKECore/FSIHelperSpecs.cs
@@ -121,6 +121,21 @@ namespace Test.FAKECore
             return new FSIHelper.Script(contents, path.Replace("\\", "/"), null, null);
         }
 
+        private Establish context = () =>
+        {
+            var consoleListener = TraceListener.defaultConsoleTraceListener;
+
+            if (consoleListener.useAnsiColorCodes)
+            {
+                TraceListener.listeners.Remove(consoleListener);
+                TraceListener.listeners.Add(
+                    new TraceListener.ConsoleTraceListener(
+                        consoleListener.importantMessagesToStdErr,
+                        consoleListener.colorMap,
+                        useAnsiColorCodes: false));
+            }
+        };
+
         It fallback_should_not_trigger_when_attribute_constructor_throws =
             () =>
             {


### PR DESCRIPTION
There were a couple of fairly inconsequential and primarily cosmetic issues that  I'd noticed when AppVeyor runs a FAKE build script.

At the start, FAKE calls `PrintDependencyGraph`. This is written as multiple `LogMessages`, which the AppVeyor helper also writes to AppVeyor's message log in the Messages tab.  There are two issues that arise from this:

1. Adding a message to AppVeyor seems to be processed asynchronously. As a result, there is no ordering guaranteed.  Here's a snippet from a log for a failed build:

![image](https://cloud.githubusercontent.com/assets/5575049/23851736/788211cc-07dc-11e7-9aec-7708ad187a40.png)

2. The call to `appveyor AddMessage` is included in a trace. This seems to be a little redundant:

![image](https://cloud.githubusercontent.com/assets/5575049/23851673/4134836c-07dc-11e7-9a59-bc46aaa600fd.png)

3. The call to `appveyor AddMessage` fails when the message is empty:

![image](https://cloud.githubusercontent.com/assets/5575049/23852220/9b1ab0ca-07de-11e7-8d30-c3f01f1ac047.png)

4. The console output from FAKE is redirected by AppVeyor and logged. This loses all the colouring, so the log appears entirely in white.  However, AppVeyor supports ANSI color codes. 

The changes I've made address each of those points:

1. I've changed the dependency message to be written as a single multi-line message so this appears as a single message in the log on AppVeyor. This makes no difference when written to the console.

2. I've changed to disable tracing when sending a message to the AppVeyor message log.

3. I've changed to not send empty messages to the AppVeyor message log, avoiding the error that results.

4. I've added ANSI color code support and use this when we're running on AppVeyor. If other build servers have the same issue & support ANSI colors then perhaps this could be enabled for those too. I ran a quick test for all `ConsoleColor` values to show how these are rendered on AppVeyor:

![image](https://cloud.githubusercontent.com/assets/5575049/23851543/d106459e-07db-11e7-96ff-58f5078ec79a.png)
