### PR TITLE
Fix Azure Storage Emulator path and arguments

### DIFF
--- a/src/app/FakeLib/AzureHelper.fs
+++ b/src/app/FakeLib/AzureHelper.fs
@@ -6,82 +6,64 @@ open System
 
 /// A type for the controlling parameter
 [<CLIMutable>]
-type AzureEmulatorParams = {
+type private AzureEmulatorParams = {
+    StorageEmulatorToolPath:Lazy<string>
     CSRunToolPath:string
-    DSInitToolPath:string
-    StartStorage:string
-    StopStorage:string
-    StartFabric:string
-    StopFabric:string
-    ClearFabric:string
-    ForceCreate:string
     TimeOut:TimeSpan
     }
 
-/// The default parameter of emulator
-let AzureEmulatorDefaults = {
+/// The default parameters for Azure emulators
+let private AzureEmulatorDefaults = {
+    StorageEmulatorToolPath =
+        lazy
+            let path = msSdkBasePath @@ "\Azure\Storage Emulator\AzureStorageEmulator.exe"
+            if fileExists path then path
+            else failwith (sprintf "Unable to locate Azure Storage Emulator at %s" path)
     CSRunToolPath = "\"C:\Program Files\Microsoft SDKs\Windows Azure\Emulator\csrun.exe\""
-    DSInitToolPath = "\"C:\Program Files\Microsoft SDKs\Windows Azure\Emulator\devstore\dsinit.exe\""
-    StartStorage = "/devstore:start"
-    StopStorage = "/devstore:shutdown"
-    StartFabric = "/devfabric:start"
-    StopFabric = "/devfabric:shutdown"
-    ClearFabric = "/devfabric:clear"
-    ForceCreate = "/forceCreate"
     TimeOut = TimeSpan.FromMinutes 5.
     }
 
 /// Stops the storage emulator
 let StopStorageEmulator = (fun _ ->
-    let emulatorParameter = AzureEmulatorDefaults
-
     if 0 <> ExecProcess (fun info ->  
-        info.FileName <- emulatorParameter.CSRunToolPath
-        info.Arguments <- emulatorParameter.StopStorage) emulatorParameter.TimeOut
+        info.FileName <- AzureEmulatorDefaults.StorageEmulatorToolPath.Value
+        info.Arguments <- "stop") AzureEmulatorDefaults.TimeOut
     then
         failwithf "Azure Emulator Failure on stop Storage Emulator"
 )
 
 /// Starts the storage emulator
 let StartStorageEmulator = (fun _ ->
-    let emulatorParameter = AzureEmulatorDefaults
-
     if 0 <> ExecProcess (fun info ->  
-        info.FileName <- emulatorParameter.CSRunToolPath
-        info.Arguments <- emulatorParameter.StartStorage) emulatorParameter.TimeOut
+        info.FileName <- AzureEmulatorDefaults.StorageEmulatorToolPath.Value
+        info.Arguments <- "start") AzureEmulatorDefaults.TimeOut
     then
         failwithf "Azure Emulator Failure on start Storage Emulator"
 )
 
 /// Stops the compute emulator
 let StopComputeEmulator = (fun _ ->
-    let emulatorParameter = AzureEmulatorDefaults
-
     if 0 <> ExecProcess (fun info ->  
-        info.FileName <- emulatorParameter.CSRunToolPath
-        info.Arguments <- emulatorParameter.StopFabric) emulatorParameter.TimeOut
+        info.FileName <- AzureEmulatorDefaults.CSRunToolPath
+        info.Arguments <- "/devfabric:shutdown") AzureEmulatorDefaults.TimeOut
     then
         failwithf "Azure Emulator Failure on stop Fabric Emulator"
 )
 
 /// Starts the compute emulator
 let StartComputeEmulator = (fun _ ->
-    let emulatorParameter = AzureEmulatorDefaults
-
     if 0 <> ExecProcess (fun info ->  
-        info.FileName <- emulatorParameter.CSRunToolPath
-        info.Arguments <- emulatorParameter.StartFabric) emulatorParameter.TimeOut
+        info.FileName <- AzureEmulatorDefaults.CSRunToolPath
+        info.Arguments <- "/devfabric:start") AzureEmulatorDefaults.TimeOut
     then
         failwithf "Azure Emulator Failure on start Fabric Emulator"
 )
 
 /// Resets the devstore (BLOB, Queues and Tables)
 let ResetDevStorage = (fun _ ->
-    let emulatorParameter = AzureEmulatorDefaults
-
     if 0 <> ExecProcess (fun info ->  
-        info.FileName <- emulatorParameter.DSInitToolPath
-        info.Arguments <- emulatorParameter.ForceCreate) emulatorParameter.TimeOut
+        info.FileName <- AzureEmulatorDefaults.StorageEmulatorToolPath.Value
+        info.Arguments <- "clear all") AzureEmulatorDefaults.TimeOut
     then
         failwithf "Azure Emulator Failure on reset Dev Storage"
 )

--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -173,8 +173,11 @@ let mutable TargetPlatformPrefix =
         else Some @"C:\Windows\Microsoft.NET\Framework"
     |> Option.get
 
-/// Base path for getting tools from windows SDKs
-let sdkBasePath = ProgramFilesX86 @@ "Microsoft SDKs\Windows"
+/// Base path for getting tools from Microsoft SDKs
+let msSdkBasePath = ProgramFilesX86 @@ "Microsoft SDKs"
+
+/// Base path for getting tools from Windows SDKs
+let sdkBasePath = msSdkBasePath @@ "Windows"
 
 /// Helper function to help find framework or sdk tools from the 
 /// newest toolkit available


### PR DESCRIPTION
This is a fix for #765. cc @isaacabraham

I have removed fields from the `AzureEmulatorParams` record because they did not make sense as parameters so this is technically a breaking change. However, none of the functions here actually take an instance of this record (or a function transforming it) so it was effectively useless being exposed as a public type. Given this fact, and since I was already changing the record, I made it private.