### PR TITLE
Make ExitCode variable

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -450,7 +450,8 @@ let WriteTaskTimeSummary total =
 
 module ExitCode =
     let exitCode = ref 0
-let private changeExitCodeIfErrorOccured() = if errors <> [] then Environment.ExitCode <- 42; ExitCode.exitCode := 42
+    let mutable exitCodeValue = 42
+let private changeExitCodeIfErrorOccured() = if errors <> [] then Environment.ExitCode <- ExitCode.exitCodeValue; ExitCode.exitCode := ExitCode.exitCodeValue
 
 /// [omit]
 let isListMode = hasBuildParam "list"

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -450,8 +450,8 @@ let WriteTaskTimeSummary total =
 
 module ExitCode =
     let exitCode = ref 0
-    let mutable exitCodeValue = 42
-let private changeExitCodeIfErrorOccured() = if errors <> [] then Environment.ExitCode <- ExitCode.exitCodeValue; ExitCode.exitCode := ExitCode.exitCodeValue
+    let mutable Value = 42
+let private changeExitCodeIfErrorOccured() = if errors <> [] then Environment.ExitCode <- ExitCode.Value; ExitCode.exitCode := ExitCode.Value
 
 /// [omit]
 let isListMode = hasBuildParam "list"


### PR DESCRIPTION
There is an exitCode variable in TargetHelper bug since it is set as a last function in the finally block you are not able to ever use the value to return anything else than the default value of 42. The newly introduced ExitCode.Value will be set as a value for in case of an error if there were errors found running a target now.