### PR TITLE
TeamCityHelper report build status incorrect string

### DIFF
--- a/src/app/FakeLib/TeamCityHelper.fs
+++ b/src/app/FakeLib/TeamCityHelper.fs
@@ -167,7 +167,7 @@ let ReportProgressFinish message = EncapsulateSpecialChars message |> sendToTeam
 /// Create  the build status.
 /// [omit]
 let buildStatus status message =
-    sprintf "##teamcity[buildStatus '%s' text='%s']" (EncapsulateSpecialChars status) (EncapsulateSpecialChars message)
+    sprintf "##teamcity[buildStatus status='%s' text='%s']" (EncapsulateSpecialChars status) (EncapsulateSpecialChars message)
 
 /// Reports the build status.
 let ReportBuildStatus status message = buildStatus status message |> sendStrToTeamCity

--- a/src/test/Test.FAKECore/TeamCitySpecs.cs
+++ b/src/test/Test.FAKECore/TeamCitySpecs.cs
@@ -16,6 +16,6 @@ namespace Test.FAKECore
     {
         It should_encapsulate_special_chars =
             () => TeamCityHelper.buildStatus("FAILURE", "Total 47, Failures 1, NotRun 0, Inconclusive 0, Skipped 0")
-                      .ShouldEqual("##teamcity[buildStatus 'FAILURE' text='Total 47, Failures 1, NotRun 0, Inconclusive 0, Skipped 0']");
+                      .ShouldEqual("##teamcity[buildStatus status='FAILURE' text='Total 47, Failures 1, NotRun 0, Inconclusive 0, Skipped 0']");
     }
 }


### PR DESCRIPTION
The status needs to be prefixed "status="

Workaround we are currently using is to pass this function "status=myStatus" rather than just "myStatus"