### PR TITLE
URGENT: Bug Fix For Parallel From #1396

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -501,10 +501,20 @@ let determineBuildOrder (target : string) =
     let rec SetTargetLevel newLevel target  = 
         match targetLevels.TryGetValue target with
         | true, exDependencyLevel -> 
-            if exDependencyLevel.level < newLevel then
-                exDependencyLevel.dependants |> List.iter (fun x -> SetTargetLevel (newLevel - 1) x)
+            let minLevel = targetLevels
+                           |> Seq.filter(fun x -> x.Value.dependants.Contains target)
+                           |> Seq.map(fun x -> x.Value.level)
+                           |> fun x -> match x.Any() with
+                                       | true -> x |> Seq.min
+                                       | _ -> -1
+            
             if exDependencyLevel.dependants.Length > 0 then
-                targetLevels.[target] <- {level = newLevel; dependants = exDependencyLevel.dependants}
+                if (exDependencyLevel.level < newLevel && newLevel < minLevel) || (exDependencyLevel.level > newLevel) then
+                    targetLevels.[target] <- {level = newLevel; dependants = exDependencyLevel.dependants}
+
+                if exDependencyLevel.level < newLevel then
+                    exDependencyLevel.dependants |> List.iter (fun x -> SetTargetLevel (newLevel - 1) x)
+
         | _ -> ()     
 
     let addTargetLevel ((dependantTarget:option<TargetTemplate<unit>>), (target: TargetTemplate<unit>), _, level, _ ) =
@@ -530,11 +540,12 @@ let determineBuildOrder (target : string) =
 
         match targetLevels.TryGetValue target.Name, dependantTarget with
         | LevelIncreaseWithDependantTarget (exDependencyLevel, dt) ->
-            SetTargetLevel (exDependencyLevel.level - 1) dt.Name
             targetLevels.[target.Name] <- {level = exDependencyLevel.level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}
+            SetTargetLevel (exDependencyLevel.level - 1) dt.Name
         |  LevelIncreaseWithNoDependantTarget (exDependencyLevel) -> 
             targetLevels.[target.Name] <- {level = exDependencyLevel.level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}
         |  LevelDecrease (exDependencyLevel) -> 
+            targetLevels.[target.Name] <- {level = level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}
             exDependencyLevel.dependants |> List.iter (fun x -> SetTargetLevel (level - 1) x)
         |  LevelRemain (exDependencyLevel) -> 
             targetLevels.[target.Name] <- {level = level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -520,6 +520,10 @@ let determineBuildOrder (target : string) =
         | (true, exDependencyLevel), _ when exDependencyLevel.level < level -> Some (exDependencyLevel)
         | _ -> None
 
+        let (|LevelRemain|_|) = function
+        | (true, exDependencyLevel), _ -> Some (exDependencyLevel)
+        | _ -> None
+
         let (|NewTarget|_|) = function
         | (false, _), _ -> Some ()
         | _ -> None
@@ -532,6 +536,7 @@ let determineBuildOrder (target : string) =
             targetLevels.[target.Name] <- {level = exDependencyLevel.level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}
         |  LevelDecrease (exDependencyLevel) -> 
             exDependencyLevel.dependants |> List.iter (fun x -> SetTargetLevel (level - 1) x)
+        |  LevelRemain (exDependencyLevel) -> 
             targetLevels.[target.Name] <- {level = level; dependants = (appendDepentantOption exDependencyLevel.dependants dependantTarget)}
         | NewTarget -> 
             targetLevels.[target.Name] <- {level = level; dependants=(appendDepentantOption [] dependantTarget)}


### PR DESCRIPTION
Upon testing #1396 with a complex target order from my company, i discovered issues with ordering of targets so a target could run at the same time or before it's dependency.

This change includes my complex target order as a test case also shown as flow below:
![image](https://cloud.githubusercontent.com/assets/1046836/24401410/32ad37d6-13ac-11e7-8974-20fa54a69196.png)
