### PR TITLE
Consolidate logic for build ordering into a single determineBuildOrder function

### DIFF
--- a/src/test/FsCheck.Fake/FsCheck.Fake.fsproj
+++ b/src/test/FsCheck.Fake/FsCheck.Fake.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -81,7 +81,7 @@
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="TestStringHelper.fs" />
-    <Compile Include="TestParallelBuildOrder.fs" />
+    <Compile Include="TestBuildOrder.fs" />
     <Compile Include="TestNuget.fs" />
     <None Include="app.config" />
     <None Include="paket.references" />


### PR DESCRIPTION
This enables tests to be written for parallel and non parallel build orders.
Also added bug scenario from https://github.com/fsharp/FSharp.Data to ensure fixes are correct