### PR TITLE
Fix duplicate build order output

### DIFF
--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -412,8 +412,10 @@ let PrintDependencyGraph verbose target =
                 else
                     appendfn "%s<== %s" indent t.Name
 
-        visitDependencies logDependency target.Name |> ignore
-        log ""
+        let _, ordered = visitDependencies logDependency target.Name
+        appendfn ""
+        sb.Length <- sb.Length - Environment.NewLine.Length
+        log <| sb.ToString()
 
 let PrintRunningOrder() = 
         log "The running order is:"

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -412,7 +412,7 @@ let PrintDependencyGraph verbose target =
                 else
                     appendfn "%s<== %s" indent t.Name
 
-        visitDependencies logDependency target.Name
+        visitDependencies logDependency target.Name |> ignore
         log ""
 
 let PrintRunningOrder() = 

--- a/src/app/FakeLib/TargetHelper.fs
+++ b/src/app/FakeLib/TargetHelper.fs
@@ -412,15 +412,8 @@ let PrintDependencyGraph verbose target =
                 else
                     appendfn "%s<== %s" indent t.Name
 
-        let _, ordered = visitDependencies logDependency target.Name
-
-        appendfn ""
-        appendfn "The resulting target order is:"
-        Seq.iter (appendfn " - %s") ordered
-
-        sb.Length <- sb.Length - Environment.NewLine.Length
-
-        log <| sb.ToString()
+        visitDependencies logDependency target.Name
+        log ""
 
 let PrintRunningOrder() = 
         log "The running order is:"


### PR DESCRIPTION
The build order is currently output twice.
This appears to be a bug added as part of the appveyor logging PR