### PR TITLE
Fix NuGet key leak if publish fails

### DIFF
--- a/src/app/FakeLib/NuGet/NugetHelper.fs
+++ b/src/app/FakeLib/NuGet/NugetHelper.fs
@@ -378,7 +378,13 @@ let NuGetPack setParams nuspecOrProjectFile =
 let NuGetPublish setParams = 
     let parameters = NuGetDefaults() |> setParams
     use __ = traceStartTaskUsing "NuGet-Push" (packageFileName parameters)
-    publish parameters
+    try
+        publish parameters
+    with exn ->
+        (if exn.InnerException <> null then exn.Message + "\r\n" + exn.InnerException.Message
+         else exn.Message)
+        |> replaceAccessKey parameters.AccessKey
+        |> failwith
 
 /// Creates a new NuGet package, and optionally publishes it.
 /// Template parameter substitution is performed when passing a .nuspec


### PR DESCRIPTION
I've accidentally found that NuGet key might leak to the build logs if NuGet push fails. 

It might happen that NuGet fails to publish package due to different reason (e.g. such version already exists). In this case the NuGet API key will leak to the build log:

```
....
Pushing AlexPovar.TestPackage.1.0.1.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Conflict https://www.nuget.org/api/v2/package/ 1020ms
Response status code does not indicate success: 409 (A package with ID 'AlexPovar.TestPackage' and version '1.0.1' already exists and cannot be modified.).
Running build failed.
Error:
System.Exception: Error during NuGet push. C:\Test\NuGet.exe push "C:\Test\AlexPovar.TestPackage.1.0.1.nupkg" fd3b8f9b-8fc6-4c73-abb7-e2fd27420b2e -source https://www.nuget.org/api/v2/package
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 313
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 312
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 312
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 312
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 312
   at Fake.NuGetHelper.publish(NuGetParams parameters) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 312
   at Fake.NuGetHelper.NuGetPublish(FSharpFunc`2 setParams) in C:\code\fake\src\app\FakeLib\NuGet\NugetHelper.fs:line 381
   at FSI_0005.Build.clo@243-29.Invoke(Tuple`2 tupledArg)
   at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source)
   at FSI_0005.Build.clo@235-28.Invoke(Unit _arg15)
   at Fake.TargetHelper.runSingleTarget(TargetTemplate`1 target) in C:\code\fake\src\app\FakeLib\TargetHelper.fs:line 594
```

You can easily see that NuGet key is `fd3b8f9b-8fc6-4c73-abb7-e2fd27420b2e`.

It's very critical issue, as FAKE is used for a lot of OSS projects together with CI (e.g. AppVeyor). Build logs are always publicly available, so if NuGet push fails at least once, NuGet key will become publicly available.

I fix the issue by replacing the key with a `PRIVATEKEY` text in an exception message.