### PR TITLE
Add support for custom NuGet symbol feed during push

### DIFF
--- a/src/test/Test.FAKECore/PackageMgt/NugetSpecs.cs
+++ b/src/test/Test.FAKECore/PackageMgt/NugetSpecs.cs
@@ -34,6 +34,7 @@ namespace Test.FAKECore.PackageMgt
                     files: ListModule.OfSeq(new [] { new Tuple<string, FSharpOption<string>, FSharpOption<string>>("*.*", FSharpOption<string>.None, FSharpOption<string>.None) }),
 
                     accessKey: p.AccessKey,
+                    symbolAccessKey: p.SymbolAccessKey,
                     copyright: p.Copyright,
                     dependencies: p.Dependencies,
                     dependenciesByFramework: p.DependenciesByFramework,
@@ -45,6 +46,7 @@ namespace Test.FAKECore.PackageMgt
                     publish: p.Publish,
                     publishTrials: p.PublishTrials,
                     publishUrl: p.PublishUrl,
+                    symbolPublishUrl: p.SymbolPublishUrl,
                     references: p.References,
                     referencesByFramework: p.ReferencesByFramework,
                     frameworkAssemblies: p.FrameworkAssemblies,
@@ -90,6 +92,7 @@ namespace Test.FAKECore.PackageMgt
                     files: ListModule.OfSeq(new[] { new Tuple<string, FSharpOption<string>, FSharpOption<string>>("*.*", FSharpOption<string>.None, FSharpOption<string>.None) }),
 
                     accessKey: p.AccessKey,
+                    symbolAccessKey: p.SymbolAccessKey,
                     copyright: p.Copyright,
                     dependencies: p.Dependencies,
                     dependenciesByFramework: p.DependenciesByFramework,
@@ -101,6 +104,7 @@ namespace Test.FAKECore.PackageMgt
                     publish: p.Publish,
                     publishTrials: p.PublishTrials,
                     publishUrl: p.PublishUrl,
+                    symbolPublishUrl: p.SymbolPublishUrl,
                     references: p.References,
                     referencesByFramework: p.ReferencesByFramework,
                     frameworkAssemblies: p.FrameworkAssemblies,
@@ -158,6 +162,7 @@ namespace Test.FAKECore.PackageMgt
                     files: ListModule.OfSeq(new [] { new Tuple<string, FSharpOption<string>, FSharpOption<string>>("*.*", FSharpOption<string>.None, FSharpOption<string>.None) }),
 
                     accessKey: p.AccessKey,
+                    symbolAccessKey: p.SymbolAccessKey,
                     copyright: p.Copyright,
                     dependencies: p.Dependencies,
                     dependenciesByFramework: p.DependenciesByFramework,
@@ -169,6 +174,7 @@ namespace Test.FAKECore.PackageMgt
                     publish: p.Publish,
                     publishTrials: p.PublishTrials,
                     publishUrl: p.PublishUrl,
+                    symbolPublishUrl: p.SymbolPublishUrl,
                     references: p.References,
                     referencesByFramework: p.ReferencesByFramework,
                     frameworkAssemblies: p.FrameworkAssemblies,


### PR DESCRIPTION
Starting from NuGet 3.5 it's [now possible](https://github.com/NuGet/Home/issues/2348) to publish package together with its symbols for the custom feeds as well (previously it was possible for the official feed only).

I've extended the `NuGetParams` with the `SymbolPublishUrl` and `SymbolAccessKey` properties, so that `NuGetPublish` and `NuGet` functions will publish package with its symbols if the `SymbolPublishUrl` is specified.