### PR TITLE
Don't replace AssemblyInfo values in comment lines

### DIFF
--- a/src/app/FakeLib/AssemblyInfoHelper.fs
+++ b/src/app/FakeLib/AssemblyInfoHelper.fs
@@ -244,15 +244,17 @@ let ReplaceAssemblyInfoVersions param =
             |> replaceMetadataAttributes rest
         | _ -> line
 
-    let replaceLine line = 
-        line
-        |> replaceAttribute "AssemblyVersion" parameters.AssemblyVersion
-        |> replaceAttribute "AssemblyConfiguration" parameters.AssemblyConfiguration
-        |> replaceAttribute "AssemblyFileVersion" parameters.AssemblyFileVersion
-        |> replaceAttribute "AssemblyInformationalVersion" parameters.AssemblyInformationalVersion
-        |> replaceAttribute "AssemblyCompany" parameters.AssemblyCompany
-        |> replaceAttribute "AssemblyCopyright" parameters.AssemblyCopyright
-        |> replaceMetadataAttributes parameters.AssemblyMetadata
+    let replaceLine (line : string) =
+        if line.TrimStart().StartsWith("//") then line
+        else
+            line
+            |> replaceAttribute "AssemblyVersion" parameters.AssemblyVersion
+            |> replaceAttribute "AssemblyConfiguration" parameters.AssemblyConfiguration
+            |> replaceAttribute "AssemblyFileVersion" parameters.AssemblyFileVersion
+            |> replaceAttribute "AssemblyInformationalVersion" parameters.AssemblyInformationalVersion
+            |> replaceAttribute "AssemblyCompany" parameters.AssemblyCompany
+            |> replaceAttribute "AssemblyCopyright" parameters.AssemblyCopyright
+            |> replaceMetadataAttributes parameters.AssemblyMetadata
     
     let encoding = Text.Encoding.GetEncoding "UTF-8"
 


### PR DESCRIPTION
AssemblyInfoHelper replaces values in all lines matching the respective pattern, which causes things like examples in commented lines to also be replaced. This change excludes lines that start with `//` (after any whitespace) from that replacement.

(This is still not exact with regard to block comments or lines that don't *start* with the comment, but will at least handle many cases occurring in practice.)