### PR TITLE
Upgrade assembly binding redirect for FluentMigrator

### DIFF
--- a/src/app/FAKE/app.config
+++ b/src/app/FAKE/app.config
@@ -101,11 +101,11 @@
   </dependentAssembly>
   <dependentAssembly>
     <assemblyIdentity name="FluentMigrator.Runner" publicKeyToken="aacfc7de5acabf05" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.6.1.0" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.6.2.0" />
   </dependentAssembly>
   <dependentAssembly>
     <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.6.1.0" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.6.2.0" />
   </dependentAssembly>
   <dependentAssembly>
     <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />


### PR DESCRIPTION
This PR modifies `app.config` with correct assembly bindings for `FluentMigrator`.

**I recently unpinned `FAKE` and upgraded from `4.52` to `4.61.2` and bled the following error:**

![cmd_195](https://cloud.githubusercontent.com/assets/478118/26227010/899bbc06-3be4-11e7-9129-01f365919774.png)

**Appears the latest version of `FAKE` ships with `FluentMigratior` `v1.6.2`.**

![reflector_196](https://cloud.githubusercontent.com/assets/478118/26227077/f9e2ead4-3be4-11e7-9ab8-c6b27545f50a.png)
![reflector_197](https://cloud.githubusercontent.com/assets/478118/26227078/fd4f9bcc-3be4-11e7-92ea-b76458aa722a.png)

----

Currently blocked on our CI server without some hacking of the `FAKE.config`; I would greatly appreciate it if someone could push a minor update.

Thanks,
Brian


:sunny: :crescent_moon: ***["I've been counting down the days and the nights..."](https://www.youtube.com/watch?v=uMcYRk_o82M)***