### PR TITLE
Restore console encoding on .NET Framework

### DIFF
--- a/src/app/FAKE/Program.fs
+++ b/src/app/FAKE/Program.fs
@@ -37,8 +37,8 @@ let paramIsHelp param = containsParam param ["help"; "?"; "/?"; "-h"; "--help"; 
 
 let buildScripts = !! "*.fsx" |> Seq.toList
 
+let encodingToRestore = Console.OutputEncoding
 try
-    let encoding = Console.OutputEncoding
     try
         AutoCloseXmlWriter <- true
 
@@ -167,6 +167,6 @@ try
 
 finally
     traceEndBuild()
-    Console.OutputEncoding <- encoding
+    Console.OutputEncoding <- encodingToRestore
     if !TargetHelper.ExitCode.exitCode <> 0 then exit !TargetHelper.ExitCode.exitCode
     if Environment.ExitCode <> 0 then exit Environment.ExitCode


### PR DESCRIPTION
PR #1580 didn't restore the previous encoding but the value from `Fake.EnvironmentHelper.encoding`. Sorry about that. FAKE on .NET Core should be OK.