### PR TITLE
 Added Visual Studio 2017 paths for mstest.exe

### DIFF
--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -6,7 +6,10 @@ open System.Text
 
 /// [omit]
 let mstestPaths = 
-    [| @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 
+    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Professional\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Community\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE";
        @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE";
        @"[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]


### PR DESCRIPTION
As seen in the MSBuildHelper.fs file, the locations for MSBuild 15 were already been updated. This PR introduces the paths for mstest.exe.

This does not affect users who have both VS 2015 and 2017 installed. Additionally, you can set the ToolPath as a parameter option or copy/paste the files to the searched location. 