### PR TITLE
Added SkipNonTestAssemblies to NUnit3Params

### DIFF
--- a/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
+++ b/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
@@ -210,6 +210,9 @@ type NUnit3Params =
       /// Controls the trace logs NUnit3 will output, defaults to Off
       TraceLevel : NUnit3TraceLevel
 
+      /// Skips assemblies that do not contain tests or assemblies that contain the NUnit.Framework.NonTestAssemblyAttribute without raising an error
+      SkipNonTestAssemblies : bool
+
       /// A test parameter specified in the form name=value. Multiple parameters may be specified, separated by semicolons
       Params : string
     }
@@ -238,6 +241,7 @@ type NUnit3Params =
 /// - `TeamCity` - `false`
 /// - `ErrorLevel` - `Error`
 /// - `TraceLevel` - `Default` (By default NUnit3 sets this to off internally)
+/// - `SkipNonTestAssemblies` - `false`
 /// - `Params` - `""`
 /// ## Defaults
 let NUnit3Defaults =
@@ -265,6 +269,7 @@ let NUnit3Defaults =
       Labels = LabelsLevel.Default
       ErrorLevel = NUnit3ErrorLevel.Error
       TraceLevel= NUnit3TraceLevel.Default
+      SkipNonTestAssemblies = false
       Params = ""
     }
 
@@ -306,6 +311,7 @@ let buildNUnit3Args parameters assemblies =
     |> appendResultString parameters.ResultSpecs
     |> appendIfTrue parameters.ShadowCopy "--shadowcopy"
     |> appendIfTrue parameters.TeamCity "--teamcity"
+    |> appendIfTrue parameters.SkipNonTestAssemblies "--skipnontestassemblies"
     |> appendIfNotNullOrEmpty parameters.Params "--params="
     |> appendFileNamesIfNotNull assemblies
     |> toText

--- a/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
@@ -206,6 +206,9 @@ type NUnit3Params =
       /// Controls the trace logs NUnit3 will output, defaults to Off
       TraceLevel : NUnit3TraceLevel
 
+      /// Skips assemblies that do not contain tests or assemblies that contain the NUnit.Framework.NonTestAssemblyAttribute without raising an error
+      SkipNonTestAssemblies : bool
+
       /// A test parameter specified in the form name=value. Multiple parameters may be specified, separated by semicolons
       Params : string
     }
@@ -234,6 +237,7 @@ type NUnit3Params =
 /// - `TeamCity` - `false`
 /// - `ErrorLevel` - `Error`
 /// - `TraceLevel` - `Default` (By default NUnit3 sets this to off internally)
+/// - `SkipNonTestAssemblies` - `false`
 /// - `Params` - `""`
 /// ## Defaults
 [<System.Obsolete("use Fake.DotNet.Testing.NUnit instead")>]
@@ -262,6 +266,7 @@ let NUnit3Defaults =
       Labels = LabelsLevel.Default
       ErrorLevel = NUnit3ErrorLevel.Error
       TraceLevel= NUnit3TraceLevel.Default
+      SkipNonTestAssemblies = false
       Params = ""
     }
 
@@ -305,6 +310,7 @@ let buildNUnit3Args parameters assemblies =
     |> appendResultString parameters.ResultSpecs
     |> appendIfTrue parameters.ShadowCopy "--shadowcopy"
     |> appendIfTrue parameters.TeamCity "--teamcity"
+    |> appendIfTrue parameters.SkipNonTestAssemblies "--skipnontestassemblies"
     |> appendIfNotNullOrEmpty parameters.Params "--params="
     |> appendFileNamesIfNotNull assemblies
     |> toText

--- a/src/test/Test.FAKECore/NUnit3Specs.cs
+++ b/src/test/Test.FAKECore/NUnit3Specs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Fake.Testing;
+using FSharp.Testing;
 using Machine.Specifications;
 
 namespace Test.FAKECore.Testing.NUnit3Specs
@@ -9,7 +10,7 @@ namespace Test.FAKECore.Testing.NUnit3Specs
     {
         private Establish context = () =>
         {
-            Assemblies = new[] {"test1.dll", "test2.dll"};
+            Assemblies = new[] { "test1.dll", "test2.dll" };
             Parameters = NUnit3.NUnit3Defaults;
         };
 
@@ -27,47 +28,30 @@ namespace Test.FAKECore.Testing.NUnit3Specs
     internal class When_using_the_default_parameters
         : BuildArgumentsSpecsBase
     {
-        It should_not_set_any_trace_value = () =>
-        {
-            Arguments.ShouldNotContain("--trace");
-        };
+        It should_not_set_any_trace_value =
+            () => Arguments.ShouldNotContain("--trace");
+
+        It should_not_skip_non_test_assemblies =
+            () => Arguments.ShouldNotContain("--skipnontestassemblies");
     }
 
     internal class When_using_non_default_trace_parameter
         : BuildArgumentsSpecsBase
     {
-        Establish context = () =>
-        {
-            Parameters = new NUnit3.NUnit3Params(
-                NUnit3.NUnit3Defaults.ToolPath,
-                NUnit3.NUnit3Defaults.Testlist,
-                NUnit3.NUnit3Defaults.Where,
-                NUnit3.NUnit3Defaults.Config,
-                NUnit3.NUnit3Defaults.ProcessModel,
-                NUnit3.NUnit3Defaults.Agents,
-                NUnit3.NUnit3Defaults.Domain,
-                NUnit3.NUnit3Defaults.Framework,
-                NUnit3.NUnit3Defaults.Force32bit,
-                NUnit3.NUnit3Defaults.DisposeRunners,
-                NUnit3.NUnit3Defaults.TimeOut,
-                NUnit3.NUnit3Defaults.Seed,
-                NUnit3.NUnit3Defaults.Workers,
-                NUnit3.NUnit3Defaults.StopOnError,
-                NUnit3.NUnit3Defaults.WorkingDir,
-                NUnit3.NUnit3Defaults.OutputDir,
-                NUnit3.NUnit3Defaults.ErrorDir,
-                NUnit3.NUnit3Defaults.ResultSpecs,
-                NUnit3.NUnit3Defaults.ShadowCopy,
-                NUnit3.NUnit3Defaults.TeamCity,
-                NUnit3.NUnit3Defaults.Labels,
-                NUnit3.NUnit3Defaults.ErrorLevel,
-                NUnit3.NUnit3TraceLevel.Verbose,
-                NUnit3.NUnit3Defaults.Params);
-        };
+        Establish context =
+            () => Parameters = Parameters.With(p => p.TraceLevel, NUnit3.NUnit3TraceLevel.Verbose);
 
-        It should_include_the_expected_trace_argument = () =>
-        {
-            Arguments.ShouldContain(@"--trace=Verbose");
-        };
+        It should_include_the_expected_trace_argument =
+            () => Arguments.ShouldContain(@"--trace=Verbose");
+    }
+
+    internal class When_using_SkipNonTestAssemblies_parameter
+        : BuildArgumentsSpecsBase
+    {
+        Establish context =
+            () => Parameters = Parameters.With(p => p.SkipNonTestAssemblies, true);
+
+        It should_include_the_expected_skipnontestassemblies_argument =
+            () => Arguments.ShouldContain(@"--skipnontestassemblies");
     }
 }


### PR DESCRIPTION
Hello, please review this PR. 

It contains fix for #1498. ```SkipNonTestAssemblies``` parameter is added to obsolete ```NUnit3Params``` too.