### PR TITLE
Chocolatey package structure update

### DIFF
--- a/src/Fake-choco-template.nuspec
+++ b/src/Fake-choco-template.nuspec
@@ -26,5 +26,5 @@ If you need more than the default functionality you can either write F# or simpl
     @dependencies@
   </metadata>
   @files@
-    <!--<file src="..\nuget\dotnetcore\Fake.netcore\win7-x86\**" target="bin" />-->
+    <!--<file src="..\nuget\legacy\tools\**" target="tools" />-->
 </package>


### PR DESCRIPTION
Keep content and structure in sync for Chocolatey and NuGet packages.

Currently the `nuget/dotnetcore/chocolatey/fake.nupkg` is generated based on the `nuget\dotnetcore\Fake.netcore\win7-x86`, which is wrong 

Changing the source to `.build` folder, the same as for NuGet generation.

Chocolatey structure changes:
 - use `tools` folder instead of `bin`

Targets changes:
 - `CreateChocolateyPackage` - new, use instead of `DotnetCoreCreateChocolateyPackage`
 - `PushChocolateyPackage` - new, use instead of `DotnetCorePushChocolateyPackage`
 - `DotnetCoreCreateChocolateyPackage` - removed
 - `DotnetCorePushChocolateyPackage` - removed