### PR TITLE
Correctly determine the 64-bit "Program Files" folder - fixes #1286

### DIFF
--- a/src/app/FakeLib/EnvironmentHelper.fs
+++ b/src/app/FakeLib/EnvironmentHelper.fs
@@ -104,20 +104,25 @@ let inline getBuildParamOrDefault name defaultParam =
 let inline getBuildParam name = getBuildParamOrDefault name String.Empty
 
 /// The path of the "Program Files" folder - might be x64 on x64 machine
-let ProgramFiles = Environment.GetFolderPath Environment.SpecialFolder.ProgramFiles
-
-/// The path of Program Files (x86)
 /// It seems this covers all cases where PROCESSOR\_ARCHITECTURE may misreport and the case where the other variable
 /// PROCESSOR\_ARCHITEW6432 can be null
-let ProgramFilesX86 =
+let ProgramFiles =
     let wow64 = environVar "PROCESSOR_ARCHITEW6432"
     let globalArch = environVar "PROCESSOR_ARCHITECTURE"
     match wow64, globalArch with
     | "AMD64", "AMD64"
     | null, "AMD64"
-    | "x86", "AMD64" -> environVar "ProgramFiles(x86)"
+    | "x86", "AMD64"
+    | "AMD64", "x86" ->
+        RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64)
+            .OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion")
+            .GetValue("ProgramFilesDir")
+            .ToString()
     | _ -> environVar "ProgramFiles"
-    |> fun detected -> if detected = null then @"C:\Program Files (x86)\" else detected
+    |> fun detected -> if detected = null then @"C:\Program Files\" else detected
+
+/// The path of Program Files (x86)
+let ProgramFilesX86 = Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86
 
 /// The system root environment variable. Typically "C:\Windows"
 let SystemRoot = environVar "SystemRoot"


### PR DESCRIPTION
The preferred way here would be just using `Environment.SpecialFolder.ProgramFiles` and `Environment.SpecialFolder.ProgramFilesX86` for the two values, but that would require compiling `Fake.exe` as `AnyCPU` (with "Prefer 32-bit" off).

In a 32-bit process, both `Environment.SpecialFolder.ProgramFiles` and the environment variable `ProgramFiles` return the x86 folder. That means there is no official API to get the 64-bit `Program Files` folder from a 32-bit process, other than going to the registry, as mentioned in #1286.