### PR TITLE
#1016-MSTest detail switch

### DIFF
--- a/src/app/Fake.Core.String/String.fs
+++ b/src/app/Fake.Core.String/String.fs
@@ -115,7 +115,7 @@ let inline appendIfNotNullOrEmpty value s = appendIfTrue (isNotNullOrEmpty value
 let inline appendFileNamesIfNotNull fileNames (builder : StringBuilder) = 
     fileNames |> Seq.fold (fun builder file -> appendIfTrue (isNullOrEmpty file |> not) file builder) builder
 
-/// Applies action on builder for each element if list.
+/// Applies action on builder for each element of list.
 let inline forEach items action text (builder: StringBuilder) =
     items
     |> List.iter (fun t -> builder |> (action t text) |> ignore)

--- a/src/app/Fake.Core.String/String.fs
+++ b/src/app/Fake.Core.String/String.fs
@@ -115,6 +115,13 @@ let inline appendIfNotNullOrEmpty value s = appendIfTrue (isNotNullOrEmpty value
 let inline appendFileNamesIfNotNull fileNames (builder : StringBuilder) = 
     fileNames |> Seq.fold (fun builder file -> appendIfTrue (isNullOrEmpty file |> not) file builder) builder
 
+/// Applies action on builder for each element if list.
+let inline forEach items action text (builder: StringBuilder) =
+    items
+    |> List.iter (fun t -> builder |> (action t text) |> ignore)
+
+    builder
+
 /// Returns the text from the StringBuilder
 let inline toText (builder : StringBuilder) = builder.ToString()
 

--- a/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
+++ b/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
@@ -43,6 +43,8 @@ type MSTestParams =
       TimeOut : TimeSpan
       /// Path to MSTest.exe 
       ToolPath : string
+      /// List of additional test case properties to display, if they exist (optional)
+      Details : string list
       /// Option which allow to specify if a MSTest error should break the build.
       ErrorLevel : ErrorLevel
       /// Run tests in isolation (optional).
@@ -61,6 +63,7 @@ let MSTestDefaults =
           match tryFindFile mstestPaths mstestexe with
           | Some path -> path
           | None -> ""
+      Details = []
       ErrorLevel = ErrorLevel.Error
       NoIsolation = true }
 
@@ -72,19 +75,16 @@ let buildMSTestArgs parameters assembly =
             sprintf @"%s\%s.trx" parameters.ResultsDir (DateTime.Now.ToString("yyyyMMdd-HHmmss.ff"))
         else null
 
-    let builder =
-        new StringBuilder()
-        |> appendIfNotNull assembly "/testcontainer:"
-        |> appendIfNotNull parameters.Category "/category:"
-        |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
-        |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
-        |> appendIfNotNull testResultsFile "/resultsfile:"
-        |> appendIfTrue parameters.NoIsolation "/noisolation"
-
-    parameters.Tests
-    |> List.iter (fun t -> builder |> appendIfNotNullOrEmpty t "/test:" |> ignore)
-
-    builder |> toText
+    new StringBuilder()
+    |> appendIfNotNull assembly "/testcontainer:"
+    |> appendIfNotNull parameters.Category "/category:"
+    |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
+    |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
+    |> appendIfNotNull testResultsFile "/resultsfile:"
+    |> appendIfTrue parameters.NoIsolation "/noisolation"
+    |> forEach parameters.Tests appendIfNotNullOrEmpty "/test:"
+    |> forEach parameters.Details appendIfNotNullOrEmpty "/detail:"
+    |> toText
 
 /// Runs MSTest command line tool on a group of assemblies.
 /// ## Parameters

--- a/src/app/Fake.DotNet.Testing.MSpec/MSpec.fs
+++ b/src/app/Fake.DotNet.Testing.MSpec/MSpec.fs
@@ -14,7 +14,7 @@ open System.Text
 /// Parameter type to configure the MSpec runner.
 //[<CLIMutable>]
 type MSpecParams =
-    { /// FileName of the mspec runner exe. Use mspec-clr4.exe if you are on .NET 4.0 or above.
+    { /// The path to the mspec console runner. Use `mspec-clr4.exe` if you are on .NET 4.0 or above.
       ToolPath : string
       /// Output directory for html reports (optional).
       HtmlOutputDir : string

--- a/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
+++ b/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
@@ -5,17 +5,11 @@ open Fake.Testing.Common
 open Fake.IO.FileSystem
 open Fake.IO.FileSystem.Operators
 open Fake.Core.String
-open Fake.Core.BuildServer
 open Fake.Core.Process
 open Fake.Core
 open System
 open System.IO
 open System.Text
-open System
-open System.IO
-open System.Linq
-open System.Text
-open Fake
 open Fake.DotNet.Testing.NUnit.Common
 
 /// Process model for NUnit 3 to use.
@@ -219,7 +213,7 @@ type NUnit3Params =
 
 /// The [NUnit3Params](fake-testing-nunit3-nunit3params.html) default parameters.
 ///
-/// - `ToolPath` - The `nunit-console.exe` path if it exists in a subdirectory of the current directory.
+/// - `ToolPath` - The `nunit-console.exe` path if it exists in `tools/Nunit/`.
 /// - `Testlist` - `""`
 /// - `Where` - `""`
 /// - `Config` - `""`

--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -117,7 +117,7 @@ let inline appendIfNotNullOrEmpty value s = appendIfTrue (isNotNullOrEmpty value
 let inline appendFileNamesIfNotNull fileNames (builder : StringBuilder) = 
     fileNames |> Seq.fold (fun builder file -> appendIfTrue (isNullOrEmpty file |> not) file builder) builder
 
-/// Applies action on builder for each element if list.
+/// Applies action on builder for each element of list.
 let inline forEach items action text (builder: StringBuilder) =
     items
     |> List.iter (fun t -> builder |> (action t text) |> ignore)

--- a/src/app/FakeLib/StringHelper.fs
+++ b/src/app/FakeLib/StringHelper.fs
@@ -117,6 +117,13 @@ let inline appendIfNotNullOrEmpty value s = appendIfTrue (isNotNullOrEmpty value
 let inline appendFileNamesIfNotNull fileNames (builder : StringBuilder) = 
     fileNames |> Seq.fold (fun builder file -> appendIfTrue (isNullOrEmpty file |> not) file builder) builder
 
+/// Applies action on builder for each element if list.
+let inline forEach items action text (builder: StringBuilder) =
+    items
+    |> List.iter (fun t -> builder |> (action t text) |> ignore)
+
+    builder
+
 /// Returns the text from the StringBuilder
 let inline toText (builder : StringBuilder) = builder.ToString()
 

--- a/src/app/FakeLib/UnitTest/MSTest.fs
+++ b/src/app/FakeLib/UnitTest/MSTest.fs
@@ -43,6 +43,8 @@ type MSTestParams =
       TimeOut : TimeSpan
       /// Path to MSTest.exe 
       ToolPath : string
+      /// List of additional test case properties to display, if they exist (optional)
+      Details : string list
       /// Option which allow to specify if a MSTest error should break the build.
       ErrorLevel : ErrorLevel
       /// Run tests in isolation (optional).
@@ -62,6 +64,7 @@ let MSTestDefaults =
           match tryFindFile mstestPaths mstestexe with
           | Some path -> path
           | None -> ""
+      Details = []
       ErrorLevel = ErrorLevel.Error
       NoIsolation = true }
 
@@ -73,21 +76,18 @@ let buildMSTestArgs parameters assembly =
         if parameters.ResultsDir <> null then 
             sprintf @"%s\%s.trx" parameters.ResultsDir (DateTime.Now.ToString("yyyyMMdd-HHmmss.ff"))
         else null
-
-    let builder =
-        new StringBuilder()
-        |> appendIfNotNull assembly "/testcontainer:"
-        |> appendIfNotNull parameters.Category "/category:"
-        |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
-        |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
-        |> appendIfNotNull testResultsFile "/resultsfile:"
-        |> appendIfTrue parameters.NoIsolation "/noisolation"
-
-    parameters.Tests
-    |> List.iter (fun t -> builder |> appendIfNotNullOrEmpty t "/test:" |> ignore)
-
-    builder |> toText
-
+    
+    new StringBuilder()
+    |> appendIfNotNull assembly "/testcontainer:"
+    |> appendIfNotNull parameters.Category "/category:"
+    |> appendIfNotNull parameters.TestMetadataPath "/testmetadata:"
+    |> appendIfNotNull parameters.TestSettingsPath "/testsettings:"
+    |> appendIfNotNull testResultsFile "/resultsfile:"
+    |> appendIfTrue parameters.NoIsolation "/noisolation"
+    |> forEach parameters.Tests appendIfNotNullOrEmpty "/test:"
+    |> forEach parameters.Details appendIfNotNullOrEmpty "/detail:"
+    |> toText
+    
 /// Runs MSTest command line tool on a group of assemblies.
 /// ## Parameters
 /// 

--- a/src/app/FakeLib/UnitTest/MSpecHelper.fs
+++ b/src/app/FakeLib/UnitTest/MSpecHelper.fs
@@ -12,7 +12,7 @@ open System.Text
 [<System.Obsolete("use Fake.DotNet.Testing.MSpec instead")>]
 [<CLIMutable>]
 type MSpecParams = 
-    { /// FileName of the mspec runner exe. Use mspec-clr4.exe if you are on .NET 4.0 or above.
+    { /// The path to the mspec console runner. Use `mspec-clr4.exe` if you are on .NET 4.0 or above.
       ToolPath : string
       /// Output directory for html reports (optional).
       HtmlOutputDir : string

--- a/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
+++ b/src/app/FakeLib/UnitTest/NUnit/NUnit3.fs
@@ -215,7 +215,7 @@ type NUnit3Params =
 
 /// The [NUnit3Params](fake-testing-nunit3-nunit3params.html) default parameters.
 ///
-/// - `ToolPath` - The `nunit-console.exe` path if it exists in a subdirectory of the current directory.
+/// - `ToolPath` - The `nunit-console.exe` path if it exists in `tools/Nunit/`.
 /// - `Testlist` - `""`
 /// - `Where` - `""`
 /// - `Config` - `""`

--- a/src/test/Test.FAKECore/MSTestSpecs.cs
+++ b/src/test/Test.FAKECore/MSTestSpecs.cs
@@ -49,6 +49,9 @@ namespace Test.FAKECore.Testing.MSTestSpecs
 
         It should_not_contain_test_argument =
             () => Arguments.ShouldNotContain("/test:");
+
+        It should_not_contain_detail_argument =
+            () => Arguments.ShouldNotContain("/detail:");
     }
 
     [Tags("WindowsOnly")]
@@ -71,5 +74,16 @@ namespace Test.FAKECore.Testing.MSTestSpecs
 
         It should_include_the_expected_test_arguments =
             () => Arguments.ShouldContain("\"/test:test1\" \"/test:testproject32\\generic\"");
+    }
+
+    [Tags("WindowsOnly")]
+    internal class When_using_Details_parameter
+        : BuildArgumentsSpecsBase
+    {
+        Establish context =
+            () => Parameters = Parameters.With(p => p.Details, (new[] { "adapter", "computername", "id" }).ToFSharpList());
+
+        It should_include_the_expected_detail_arguments =
+            () => Arguments.ShouldContain("\"/detail:adapter\" \"/detail:computername\" \"/detail:id\"");
     }
 }


### PR DESCRIPTION
Hello. Please review this PR. 
It adds ```Details``` parameter to MSTest - issue #1016. 
It also should address #1348 (docs for NUnit3 ToolPath).

Sample usage:
```fsharp
Target "Tests" (fun _ ->
    !! (@"UnitTestProject1.dll") 
      |> MSTest (fun p -> { p with Details = ["computername"; "id"; "duration"]})
)
```
