### PR TITLE
Change how npm.cmd is located in NpmHelper [hotfix_fake4]

### DIFF
--- a/src/app/FakeLib/NpmHelper.fs
+++ b/src/app/FakeLib/NpmHelper.fs
@@ -15,7 +15,7 @@ let private npmFileName =
         |> Seq.tryFind (sprintf @"%s\npm.cmd" >> File.Exists)
         |> function
             | Some npm -> (sprintf @"%s\npm.cmd" npm)
-            | None -> "Unable to find npm.cmd. Make sure you have the folder that holds npm.cmd in your PATH environment variable. Optionally you can set the NpmFilePath input parameter."
+            | None -> failwith "Unable to find npm.cmd. Make sure you have the folder that holds npm.cmd in your PATH environment variable. Optionally you can set the NpmFilePath input parameter."
     | _ -> 
         let info = new ProcessStartInfo("which","npm")
         info.StandardOutputEncoding <- System.Text.Encoding.UTF8

--- a/src/app/FakeLib/NpmHelper.fs
+++ b/src/app/FakeLib/NpmHelper.fs
@@ -11,11 +11,11 @@ let private npmFileName =
     | true -> 
         System.Environment.GetEnvironmentVariable("PATH")
         |> fun path -> path.Split ';'
-        |> Seq.tryFind (fun p -> p.Contains "nodejs")
-        |> fun res ->
-            match res with
-            | Some npm when File.Exists (sprintf @"%s\npm.cmd" npm) -> (sprintf @"%s\npm.cmd" npm)
-            | _ -> "./packages/Npm.js/tools/npm.cmd"
+        |> Seq.filter (fun p -> p.Contains "nodejs")
+        |> Seq.tryFind (sprintf @"%s\npm.cmd" >> File.Exists)
+        |> function
+            | Some npm -> (sprintf @"%s\npm.cmd" npm)
+            | None -> "Unable to find npm.cmd. Make sure you have the folder that holds npm.cmd in your PATH environment variable. Optionally you can set the NpmFilePath input parameter."
     | _ -> 
         let info = new ProcessStartInfo("which","npm")
         info.StandardOutputEncoding <- System.Text.Encoding.UTF8


### PR DESCRIPTION
I've noticed that Yarn adds nodejs\bin to the path variable, which in the old code could return a folder that did not contain the npm.cmd file. I fixed this and also removed the fallback to the npm.js package, as it is silly to assume where the package directory is. If people are using that package they should overwrite the NpmFilePath variable.

This is the same as #1629 just against the `hotfix_fake4` branch