### PR TITLE
Add MSBuild binary logger support

### DIFF
--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -227,6 +227,7 @@ type MSBuildParams =
       Verbosity : MSBuildVerbosity option
       NoConsoleLogger : bool
       FileLoggers : MSBuildFileLoggerConfig list option
+      BinaryLoggers : string list option
       DistributedLoggers : (MSBuildDistributedLoggerConfig * MSBuildDistributedLoggerConfig option) list option }
 
 /// Defines a default for MSBuild task parameters
@@ -241,12 +242,13 @@ let mutable MSBuildDefaults =
       NoConsoleLogger = false
       RestorePackagesFlag = false
       FileLoggers = None
+      BinaryLoggers = None
       DistributedLoggers = None }
 
 /// [omit]
-let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers distributedFileLoggers properties =
-    if isUnix then [ targets; tools; verbosity; noconsolelogger ] @ fileLoggers @ distributedFileLoggers @ properties
-    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger ] @ fileLoggers @ distributedFileLoggers @ properties
+let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers binaryLoggers distributedFileLoggers properties =
+    if isUnix then [ targets; tools; verbosity; noconsolelogger ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
 
 let private serializeArgs args =
     args
@@ -344,6 +346,13 @@ let serializeMSBuildParams (p : MSBuildParams) =
             fls
             |> List.map (fun fl -> Some ("flp" + (string fl.Number), serializeLogger fl) )
 
+    let binaryLoggers =
+        match p.BinaryLoggers with
+        | None -> []
+        | Some bls ->
+            bls
+            |> List.map (fun bl -> Some ("bl", bl) )
+
     let distributedFileLoggers =
         let serializeDLogger (dlogger : MSBuildDistributedLoggerConfig) =
             sprintf "%s%s%s"
@@ -367,7 +376,7 @@ let serializeMSBuildParams (p : MSBuildParams) =
             dfls
             |> List.map(fun (cl, fl) -> Some("dl", createLoggerString cl fl))
 
-    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers distributedFileLoggers properties
+    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers binaryLoggers distributedFileLoggers properties
     |> serializeArgs
 
 /// [omit]


### PR DESCRIPTION
Fixes #1631 by adding support for binary loggers to MSBuild (both the .NET Core and regular flavours).

Note that the `iOSBuild` function does not currently support loggers in its params. However, it is merely a facade onto the `build` function, so I don't really understand why it exists. Instead of attempting to add support for loggers and other missing bits into `iOSBuildParams`, I just changed my build script from using `iOSBuild` to `build`. For anyone wondering, the basic invocation looks like this:

```F#
    build (fun defaults ->
        {
            defaults with
                Verbosity = Some(Detailed)
                Targets = ["Rebuild"]
                Properties =
                    [
                        "Optimize", "True"
                        "Configuration", iosConfiguration
                        "Platform", iosPlatform
                        "BuildIpa", "true"
                    ]
                BinaryLoggers = Some
                    [
                        logFile
                    ]
                NoConsoleLogger = true
        })
        iosSolution
```

_Please excuse whitespace changes - I have an addin that strips superfluous whitespace. If this is a problem, I can add the whitespace back in with a separate commit - let me know._