### PR TITLE
Fix menu on mobile

### DIFF
--- a/help/content/assets/css/main.css
+++ b/help/content/assets/css/main.css
@@ -2252,6 +2252,9 @@
 					font-weight: 700;
 					font-size: 0.95em;
 					letter-spacing: 0.075em;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
 				}
 
 					#navPanel .link:first-child {

--- a/help/content/assets/sass/main.scss
+++ b/help/content/assets/sass/main.scss
@@ -1186,6 +1186,9 @@
 					font-weight: 700;
 					font-size: 0.95em;
 					letter-spacing: 0.075em;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
 
 					&:first-child {
 						border-top: 0;


### PR DESCRIPTION
I believe the right way to fix this is just to hide text that doesn't fit into the mobile menu item width.

Also the common approach is to add `...` at the end of the string (text-overflow: ellipsis). So it looks like this:
![fake web](https://user-images.githubusercontent.com/8005242/30562649-13f13490-9c74-11e7-83f1-6d82e5aef7e3.jpg)

CSS changes:
```
overflow: hidden;
text-overflow: ellipsis;
white-space: nowrap;
```