### PR TITLE
Added WarnAsError to MSBuild options

### DIFF
--- a/src/app/Fake.DotNet.MsBuild/MsBuild.fs
+++ b/src/app/Fake.DotNet.MsBuild/MsBuild.fs
@@ -242,7 +242,7 @@ type MSBuildParams =
       ToolsVersion : string option
       Verbosity : MSBuildVerbosity option
       NoConsoleLogger : bool
-      WarnAsErrors: string list option
+      WarnAsError: string list option
       FileLoggers : MSBuildFileLoggerConfig list option
       BinaryLoggers : string list option
       DistributedLoggers : (MSBuildDistributedLoggerConfig * MSBuildDistributedLoggerConfig option) list option }
@@ -257,16 +257,16 @@ let mutable MSBuildDefaults =
       ToolsVersion = None
       Verbosity = None
       NoConsoleLogger = false
-      WarnAsErrors = None
+      WarnAsError = None
       RestorePackagesFlag = false
       FileLoggers = None
       BinaryLoggers = None
       DistributedLoggers = None }
 
 /// [omit]
-let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties =
-    if Environment.isUnix then [ targets; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
-    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsError fileLoggers binaryLoggers distributedFileLoggers properties =
+    if Environment.isUnix then [ targets; tools; verbosity; noconsolelogger; warnAsError ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger; warnAsError ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
 
 let private serializeArgs args =
     args
@@ -327,8 +327,8 @@ let serializeMSBuildParams (p : MSBuildParams) =
         if p.NoConsoleLogger then Some("noconlog", "")
         else None
 
-    let warnAsErrors =
-        match p.WarnAsErrors with
+    let warnAsError =
+        match p.WarnAsError with
         | None -> None
         | Some w -> Some("warnaserror", w |> String.concat ";")
 
@@ -401,7 +401,7 @@ let serializeMSBuildParams (p : MSBuildParams) =
             dfls
             |> List.map(fun (cl, fl) -> Some("dl", createLoggerString cl fl))
 
-    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties
+    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsError fileLoggers binaryLoggers distributedFileLoggers properties
     |> serializeArgs
 
 #if !NO_MSBUILD_AVAILABLE

--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -226,7 +226,7 @@ type MSBuildParams =
       ToolsVersion : string option
       Verbosity : MSBuildVerbosity option
       NoConsoleLogger : bool
-      WarnAsErrors: string list option
+      WarnAsError: string list option
       FileLoggers : MSBuildFileLoggerConfig list option
       BinaryLoggers : string list option
       DistributedLoggers : (MSBuildDistributedLoggerConfig * MSBuildDistributedLoggerConfig option) list option }
@@ -241,16 +241,16 @@ let mutable MSBuildDefaults =
       ToolsVersion = None
       Verbosity = None
       NoConsoleLogger = false
-      WarnAsErrors = None
+      WarnAsError = None
       RestorePackagesFlag = false
       FileLoggers = None
       BinaryLoggers = None
       DistributedLoggers = None }
 
 /// [omit]
-let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties =
-    if isUnix then [ targets; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
-    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsError fileLoggers binaryLoggers distributedFileLoggers properties =
+    if isUnix then [ targets; tools; verbosity; noconsolelogger; warnAsError ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger; warnAsError ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
 
 let private serializeArgs args =
     args
@@ -309,8 +309,8 @@ let serializeMSBuildParams (p : MSBuildParams) =
         if p.NoConsoleLogger then Some("noconlog", "")
         else None
 
-    let warnAsErrors =
-        match p.WarnAsErrors with
+    let warnAsError =
+        match p.WarnAsError with
         | None -> None
         | Some w -> Some("warnaserror", w |> String.concat ";")
 
@@ -383,7 +383,7 @@ let serializeMSBuildParams (p : MSBuildParams) =
             dfls
             |> List.map(fun (cl, fl) -> Some("dl", createLoggerString cl fl))
 
-    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties
+    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsError fileLoggers binaryLoggers distributedFileLoggers properties
     |> serializeArgs
 
 /// [omit]

--- a/src/app/FakeLib/MSBuildHelper.fs
+++ b/src/app/FakeLib/MSBuildHelper.fs
@@ -226,6 +226,7 @@ type MSBuildParams =
       ToolsVersion : string option
       Verbosity : MSBuildVerbosity option
       NoConsoleLogger : bool
+      WarnAsErrors: string list option
       FileLoggers : MSBuildFileLoggerConfig list option
       BinaryLoggers : string list option
       DistributedLoggers : (MSBuildDistributedLoggerConfig * MSBuildDistributedLoggerConfig option) list option }
@@ -240,15 +241,16 @@ let mutable MSBuildDefaults =
       ToolsVersion = None
       Verbosity = None
       NoConsoleLogger = false
+      WarnAsErrors = None
       RestorePackagesFlag = false
       FileLoggers = None
       BinaryLoggers = None
       DistributedLoggers = None }
 
 /// [omit]
-let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers binaryLoggers distributedFileLoggers properties =
-    if isUnix then [ targets; tools; verbosity; noconsolelogger ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
-    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+let getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties =
+    if isUnix then [ targets; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
+    else [ targets; maxcpu; noLogo; nodeReuse; tools; verbosity; noconsolelogger; warnAsErrors ] @ fileLoggers @ binaryLoggers @ distributedFileLoggers @ properties
 
 let private serializeArgs args =
     args
@@ -306,6 +308,11 @@ let serializeMSBuildParams (p : MSBuildParams) =
     let noconsolelogger =
         if p.NoConsoleLogger then Some("noconlog", "")
         else None
+
+    let warnAsErrors =
+        match p.WarnAsErrors with
+        | None -> None
+        | Some w -> Some("warnaserror", w |> String.concat ";")
 
     let fileLoggers =
         let serializeLogger fl =
@@ -376,7 +383,7 @@ let serializeMSBuildParams (p : MSBuildParams) =
             dfls
             |> List.map(fun (cl, fl) -> Some("dl", createLoggerString cl fl))
 
-    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger fileLoggers binaryLoggers distributedFileLoggers properties
+    getAllParameters targets maxcpu noLogo nodeReuse tools verbosity noconsolelogger warnAsErrors fileLoggers binaryLoggers distributedFileLoggers properties
     |> serializeArgs
 
 /// [omit]


### PR DESCRIPTION
Resolves https://github.com/fsharp/FAKE/issues/1662

Allows you to specify MSBuild error codes to fail the build with:

```fsharp
    { MSBuildDefaults with
        WarnAsError = Some [] }

     = msbuild /warnaserror

    { MSBuildDefaults with
        WarnAsError = Some ["MSB4237"; "MSB4011"] }

    = msbuild /warnaserror:MSB4237;MSB4011
```