### PR TITLE
Refactor GitHub API

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -915,6 +915,17 @@ Target.Create "FastRelease" (fun _ ->
         | s when not (System.String.IsNullOrWhiteSpace s) -> s
         | _ -> failwith "please set the github_token environment variable to a github personal access token with repro access."
 
+#if BOOTSTRAP
+    let files = 
+        runtimes @ [ "portable"; "packages" ]
+        |> List.map (fun n -> sprintf "nuget/dotnetcore/Fake.netcore/fake-dotnetcore-%s.zip" n)
+    
+    GitHub.CreateClientWithToken token
+    |> GitHub.CreateDraftWithNotes gitOwner gitName release.NugetVersion (release.SemVer.PreRelease <> None) release.Notes
+    |> GitHub.UploadFiles files    
+    |> GitHub.ReleaseDraft
+    |> Async.RunSynchronously
+#else
     let draft =
         GitHub.createClientWithToken token
         |> GitHub.createDraft gitOwner gitName release.NugetVersion (release.SemVer.PreRelease <> None) release.Notes
@@ -927,6 +938,7 @@ Target.Create "FastRelease" (fun _ ->
     draftWithFiles
     |> GitHub.releaseDraft
     |> Async.RunSynchronously
+#endif
 )
 
 open System

--- a/build.fsx
+++ b/build.fsx
@@ -401,7 +401,7 @@ Target.Create "BootstrapTest" (fun _ ->
             { info with
                 FileName = "build/FAKE.exe"
                 WorkingDirectory = "."
-                Arguments = sprintf "%s %s --fsiargs \"--define:BOOTSTRAP\" -pd" script target }
+                Arguments = sprintf "%s %s --fsiargs \"--define:BOOTSTRAP\"" script target }
             |> Process.setEnvironmentVariable "FAKE_DETAILED_ERRORS" "true"
                 ) span
 

--- a/build.fsx
+++ b/build.fsx
@@ -921,9 +921,9 @@ Target.Create "FastRelease" (fun _ ->
         |> List.map (fun n -> sprintf "nuget/dotnetcore/Fake.netcore/fake-dotnetcore-%s.zip" n)
     
     GitHub.CreateClientWithToken token
-    |> GitHub.CreateDraftWithNotes gitOwner gitName release.NugetVersion (release.SemVer.PreRelease <> None) release.Notes
+    |> GitHub.DraftNewRelease gitOwner gitName release.NugetVersion (release.SemVer.PreRelease <> None) release.Notes
     |> GitHub.UploadFiles files    
-    |> GitHub.ReleaseDraft
+    |> GitHub.PublishDraft
     |> Async.RunSynchronously
 #else
     let draft =

--- a/src/app/Fake.Api.GitHub/GitHub.fs
+++ b/src/app/Fake.Api.GitHub/GitHub.fs
@@ -158,9 +158,9 @@ module GitHub =
     /// - `repoName` - the repository's name
     /// - `tagName` - the name of the tag to use for this release
     /// - `prerelease` - indicates whether the release will be created as a prerelease
-    /// - `notes` - collection of release notes that will be inserted into the Body of the release
+    /// - `notes` - collection of release notes that will be inserted into the body of the release
     /// - `client` - GitHub API v3 client
-    let CreateDraftWithNotes owner repoName tagName prerelease (notes : seq<string>) client =
+    let DraftNewRelease owner repoName tagName prerelease (notes : seq<string>) client =
         let setParams p = 
             { p with 
                 Body = String.Join(Environment.NewLine, notes) 
@@ -186,13 +186,13 @@ module GitHub =
         return release'
     }
 
-    /// Publishes the specified release by removing its Draft status
-    let ReleaseDraft (release : Async<Release>) =
+    /// Publishes the specified release by removing its draft status
+    let PublishDraft (release : Async<Release>) =
         retryWithArg 5 release <| fun release' -> async {
             let update = release'.Release.ToUpdate()
             update.Draft <- Nullable<bool>(false)
             let! released = Async.AwaitTask <| release'.Client.Repository.Release.Edit(release'.Owner, release'.RepoName, release'.Release.Id, update)
-            printfn "Released %d on GitHub" released.Id
+            printfn "Published release %d on GitHub" released.Id
         }
 
     /// Gets the latest release for the specified repository


### PR DESCRIPTION
The primary change here is to allow the user to specify the release property values explicitly when creating a GitHub release. The previous `createDraft` / `createRelease` API enforced that the release name matched the tag name and that the body was set to a newline delimited set of release notes.

`CreateRelease` uses a similar pattern to a lot of Fake modules in that you can override the default params where required.

~`CreateDraftWithNotes`~ `DraftNewRelease` keeps the previous opinionated behaviour of `createDraft` for users who are happy with that.

As this is a breaking change and Fake 5 is as-yet unreleased, I also pascal cased the functions to be more consistent with the rest of the Fake modules. Happy to revert this if the prevailing opinion is to the contrary.

Closes #1723 