### PR TITLE
Get directory of ToolPath for the XML XSL path.

### DIFF
--- a/src/app/FakeLib/FXCopHelper.fs
+++ b/src/app/FakeLib/FXCopHelper.fs
@@ -91,7 +91,7 @@ let FxCop setParams (assemblies : string seq) =
     use __ = traceStartTaskUsing "FxCop" ""
     let param = 
         if param.ApplyOutXsl && param.OutputXslFileName = String.Empty then 
-            { param with OutputXslFileName = param.ToolPath @@ "Xml" @@ "FxCopReport.xsl" }
+            { param with OutputXslFileName = (directory param.ToolPath) @@ "Xml" @@ "FxCopReport.xsl" }
         else param
     
     let commandLineCommands = 


### PR DESCRIPTION
Get directory of ToolPath for appending the "Xml" to get XSL path.
In response to this old issue: https://github.com/fsharp/FAKE/issues/1394

Old error :
`Error writing output file to 'FXCopResults.xml': Could not find a part of the path 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\FxCop\FxCopCmd.exe\Xml\FxCopReport.xsl'.. If there is an XML report output file, make sure that the location of the report style sheet is correct.`

**Reason:** It sees "FxCop\FxCopCmd.exe\Xml\FxCopReport.xsl" that should be "FxCop\Xml\FxCopReport.xsl"