### PR TITLE
Fix version normalization

### DIFF
--- a/src/app/Fake.DotNet.AssemblyInfoFile/AssemblyInfoFile.fs
+++ b/src/app/Fake.DotNet.AssemblyInfoFile/AssemblyInfoFile.fs
@@ -8,7 +8,7 @@ open System.Text.RegularExpressions
 
 module internal Helper =
     open Fake.Core
-    let internal assemblyVersionRegex = String.getRegEx @"([0-9]+.)+[0-9]+"
+    let internal assemblyVersionRegex = String.getRegEx @"([0-9]+\.)+[0-9]+"
 
     // matches [assembly: name(value)] and captures "name" and "value" as named captures. Variations for C#, F#, C++ and VB
     let regexAttrNameValueCs = @"^\s*\[\s*assembly:\s*(?<name>\w+?)\s*\((?<value>.*)\)\s*\]\s*$"

--- a/src/app/FakeLib/AssemblyInfoFile.fs
+++ b/src/app/FakeLib/AssemblyInfoFile.fs
@@ -17,7 +17,7 @@ let (|Fsproj|Csproj|Vbproj|Shproj|) (projFileName:string) =
     | f when f.EndsWith("shproj") -> Shproj
     | _                           -> failwith (sprintf "Project file %s not supported. Unknown project type." projFileName)
 
-let internal assemblyVersionRegex = getRegEx @"([0-9]+.)+[0-9]+"
+let internal assemblyVersionRegex = getRegEx @"([0-9]+\.)+[0-9]+"
 
 // matches [assembly: name(value)] and captures "name" and "value" as named captures. Variations for C#, F#, C++ and VB
 let private regexAttrNameValueCs = @"^\s*\[\s*assembly:\s*(?<name>\w+?)\s*\((?<value>.*)\)\s*\]\s*$"

--- a/src/test/Test.FAKECore/AssemblyInfoSpecs.cs
+++ b/src/test/Test.FAKECore/AssemblyInfoSpecs.cs
@@ -13,6 +13,29 @@ namespace Test.FAKECore
             () => AssemblyInfoFile.getDependencies(new List<AssemblyInfoFile.Attribute>());
     }
 
+    public class when_using_version_attributes
+    {
+        private static string Input = "1.0.0+0e5da7a";
+
+        It normalizes_the_string_for_Version = () =>
+        {
+            var attribute = AssemblyInfoFile.Attribute.Version(Input);
+            attribute.Value.ShouldEqual("\"1.0.0\"");
+        };
+
+        It normalizes_the_string_for_FileVersion = () =>
+        {
+            var attribute = AssemblyInfoFile.Attribute.FileVersion(Input);
+            attribute.Value.ShouldEqual("\"1.0.0\"");
+        };
+
+        It leaves_string_as_is_for_InformationalVersion = () =>
+        {
+            var attribute = AssemblyInfoFile.Attribute.InformationalVersion(Input);
+            attribute.Value.ShouldEqual("\"1.0.0+0e5da7a\"");
+        };
+    }
+
     public class when_using_fsharp_task_with_default_config
     {
         It should_use_system_namespace_and_emit_a_version_module = () =>


### PR DESCRIPTION
I noticed this when I wanted to attach the commit hash to the assembly version in one of my projects. I ended up with `AssemblyVersionAttribute("1.0.0-0e5")` for `"1.1.0+0e5da7a"`.