### PR TITLE
Using IGlobbingPattern instead of FileSystem.FileIncludes

### DIFF
--- a/src/app/FakeLib/ChangeWatcher.fs
+++ b/src/app/FakeLib/ChangeWatcher.fs
@@ -3,6 +3,7 @@
 module Fake.ChangeWatcher
 
 open System.IO
+open Fake.Core
 
 type FileStatus =
     | Deleted
@@ -22,7 +23,7 @@ let private handleWatcherEvents (status : FileStatus) (onChange : FileChange -> 
                 Name = e.Name
                 Status = status })
 
-let private calcDirsToWatch fileIncludes =
+let private calcDirsToWatch (fileIncludes:IGlobbingPattern) =
     let dirsToWatch = fileIncludes.Includes |> Seq.map (fun file -> Globbing.getRoot fileIncludes.BaseDirectory file)
 
     // remove subdirectories from watch list so that we don't get duplicate file watchers running
@@ -52,7 +53,7 @@ let private calcDirsToWatch fileIncludes =
 ///         watcher.Dispose() // if you need to cleanup the watches.
 ///     )
 ///
-let WatchChangesWithOptions options (onChange : FileChange seq -> unit) (fileIncludes : FileIncludes) =
+let WatchChangesWithOptions options (onChange : FileChange seq -> unit) (fileIncludes : IGlobbingPattern) =
     let dirsToWatch = fileIncludes |> calcDirsToWatch
 
     tracefn "dirs to watch: %A" dirsToWatch
@@ -118,4 +119,4 @@ let WatchChangesWithOptions options (onChange : FileChange seq -> unit) (fileInc
               timer.Dispose() }
 
 
-let WatchChanges = WatchChangesWithOptions { IncludeSubdirectories = true }
+let WatchChanges (onChange : FileChange seq -> unit) (fileIncludes : IGlobbingPattern) = WatchChangesWithOptions { IncludeSubdirectories = true } onChange fileIncludes

--- a/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
+++ b/src/test/Test.FAKECore/ChangeWatcherSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Fake;
+using Fake.Core.Globbing;
 using Machine.Specifications;
 using Microsoft.FSharp.Collections;
 
@@ -11,7 +12,7 @@ namespace Test.FAKECore
             () =>
             {
                 var includes = ListModule.OfArray(new[] { @"test1\bin\*.dll", @"test2\bin\*.dll", });
-                var fileIncludes = new FileSystem.FileIncludes(@"C:\Project", includes, ListModule.Empty<string>());
+                var fileIncludes = new LazyGlobbingPattern(@"C:\Project", includes, ListModule.Empty<string>());
 
                 var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
 
@@ -24,7 +25,7 @@ namespace Test.FAKECore
             () =>
             {
                 var includes = ListModule.OfArray(new[] { @"tests\**\test1\bin\*.dll", @"tests\test2\bin\*.dll", });
-                var fileIncludes = new FileSystem.FileIncludes(@"C:\Project", includes, ListModule.Empty<string>());
+                var fileIncludes = new LazyGlobbingPattern(@"C:\Project", includes, ListModule.Empty<string>());
 
                 var dirsToWatch = ChangeWatcher.calcDirsToWatch(fileIncludes);
 


### PR DESCRIPTION
This is so that the [documentation](https://fake.build/apidocs/fake-changewatcher.html) makes sense. 

I noticed that the API didn't match the docs while working on an other pull request: https://github.com/fsprojects/SyntacticVersioning/pull/24