### PR TITLE
Look for dotnet on path if it is not in the default install directory

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -59,7 +59,7 @@ module DotNet =
             Process.tryFindFileOnPath "dotnet"
                 |> function
                     | Some dotnet when File.Exists dotnet -> dotnet
-    | _ -> failwithf "Can't find dotnet CLI. Looked in %s and on PATH" defaultCliPath
+                    | _ -> failwithf "Can't find dotnet CLI. Looked in %s and on PATH" defaultCliPath
 
     /// Get .NET Core SDK download uri
     let private getGenericDotNetCliInstallerUrl branch installerName =

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -48,7 +48,16 @@ let mutable DefaultDotNetCliDir =
 /// ## Parameters
 ///
 /// - 'dotnetCliDir' - dotnet cli install directory
-let private dotnetCliPath dotnetCliDir = dotnetCliDir @@ (if Environment.isUnix then "dotnet" else "dotnet.exe")
+let private dotnetCliPath dotnetCliDir = 
+    let defaultCliPath = dotnetCliDir @@ (if Environment.isUnix then "dotnet" else "dotnet.exe")
+    match File.Exists defaultCliPath with
+    | true -> defaultCliPath
+    | _ -> 
+        Process.tryFindFileOnPath "dotnet"
+            |> function
+                | Some dotnet when File.Exists dotnet -> dotnet
+                | _ -> failwithf "Can't find dotnet CLI. Looked in %s and on PATH" defaultCliPath
+
 
 /// Get .NET Core SDK download uri
 let private getGenericDotNetCliInstallerUrl branch installerName =


### PR DESCRIPTION
With this fix, DotNet.Cli looks for `dotnet` on path if it is not found in the default directory.

Fixes #1810 and #1599