### PR TITLE
change the upload uri to the original one.

### DIFF
--- a/src/app/Fake.Azure.WebJobs/WebJobs.fs
+++ b/src/app/Fake.Azure.WebJobs/WebJobs.fs
@@ -78,7 +78,7 @@ let PackageWebJobs webSites =
     webSites |> List.iter (fun webSite -> webSite.WebJobs |> List.iter (zipWebJob webSite))
 
 let private deployWebJobToWebSite webSite webJob =
-    let uploadUri = Uri(webSite.Url, sprintf "api/%swebjobs/%s" (jobTypePath webJob.JobType) webJob.Name)
+    let uploadUri = Uri(webSite.Url, sprintf "api/zip/site/wwwroot/App_Data/jobs/%s/%s" (jobTypePath webJob.JobType) webJob.Name)
     let filePath = webJob.PackageLocation
     tracefn "Deploying %s webjob to %O" filePath uploadUri
 #if NETSTANDARD

--- a/src/app/Fake.Azure.WebJobs/WebJobs.fs
+++ b/src/app/Fake.Azure.WebJobs/WebJobs.fs
@@ -88,7 +88,6 @@ let private deployWebJobToWebSite webSite webJob =
 
     use fileStream = new FileStream(filePath, FileMode.Open)
     use content = new StreamContent(fileStream)
-    content.Headers.ContentDisposition <- Headers.ContentDispositionHeaderValue("attachment; filename=" + (Path.GetFileName webJob.PackageLocation))
     content.Headers.ContentType <- Headers.MediaTypeHeaderValue("application/zip")
 
     let response = client.PutAsync(uploadUri, content).Result


### PR DESCRIPTION
It looks like this got changed when moving to FAKE5

Here is the original uri: https://github.com/fsharp/FAKE/blob/921b7ce5df10ff627046ed123185774660c0d48f/src/app/FakeLib/AzureWebJobs.fs#L64