### PR TITLE
bash-completion: Don't alter global shell var $cur

### DIFF
--- a/bash-completion/fake
+++ b/bash-completion/fake
@@ -1,7 +1,7 @@
 _fake_completion()
 {
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
+    local cur="${COMP_WORDS[COMP_CWORD]}"
 
     if [ -f build.fsx ] ; then
         # egrep doesn't have the -P switch to match group on OSX


### PR DESCRIPTION
```
juergen@samson:~/fsharp/FSharp Org/FnuPlot → source ~/fsharp/FAKE/bash-completion/fake 
juergen@samson:~/fsharp/FSharp Org/FnuPlot → cur="FOO"
juergen@samson:~/fsharp/FSharp Org/FnuPlot → ./build.sh 
AddLangDocs            CleanDocs              NuGet
All                    GenerateDocs           Release
AssemblyInfo           GenerateHelp           ReleaseDocs
Build                  GenerateHelpDebug      RunTests
BuildPackage           GenerateReferenceDocs  SourceLink
Clean                  KeepRunning            
juergen@samson:~/fsharp/FSharp Org/FnuPlot → echo $cur

juergen@samson:~/fsharp/FSharp Org/FnuPlot → 
```