### PR TITLE
List targets quietly

### DIFF
--- a/src/app/Fake.BuildServer.Travis/Travis.fs
+++ b/src/app/Fake.BuildServer.Travis/Travis.fs
@@ -37,9 +37,11 @@ module Travis =
                     write false color true (sprintf "Build Number: %s" number)
                 | TraceData.TestStatus (test, status) ->
                     write false color true (sprintf "Test '%s' status: %A" test status)
+                | TraceData.BuildState state ->
+                    write false color true (sprintf "Build State: %A" state)
 
     let defaultTraceListener =
-      TravisTraceListener() :> ITraceListener
+        TravisTraceListener() :> ITraceListener
     let detect () =
         BuildServer.buildServer = BuildServer.Travis
     let install(force:bool) =

--- a/src/app/Fake.Core.Environment/Environment.fs
+++ b/src/app/Fake.Core.Environment/Environment.fs
@@ -191,7 +191,7 @@ module Environment =
         | _ -> false
     #endif
 
-    /// Determines if the current system is a mono system
+    /// Determines if the current FAKE runner is being run via mono.  With the FAKE 5 runner, this will always be false
     /// Todo: Detect mono on windows
     let isMono = 
     #if NETSTANDARD1_6

--- a/src/app/Fake.Core.SemVer/SemVer.fs
+++ b/src/app/Fake.Core.SemVer/SemVer.fs
@@ -86,7 +86,7 @@ type PreRelease =
                 | _::AlphaNumeric(a)::_ -> a // fallback to 2nd
                 | _ -> ""
                 
-            let parse segment =
+            let parse (segment: string) =
                 match bigint.TryParse segment with
                 | true, number when number >= 0I -> Numeric number
                 | _ -> AlphaNumeric segment
@@ -245,7 +245,7 @@ module SemVer =
         | _ -> None
         
     /// Matches if str is convertible to big int and not less than zero, and returns the bigint value.
-    let inline private (|Big|_|) str =
+    let inline private (|Big|_|) (str: string) =
         match BigInteger.TryParse (str, NumberStyles.Integer, null) with
         | true, big when big > -1I -> Some big
         | _ -> None

--- a/src/app/Fake.Core.Target/Target.fs
+++ b/src/app/Fake.Core.Target/Target.fs
@@ -317,7 +317,7 @@ module Target =
     /// List all targets available.
     let listAvailable() =
         Trace.log "The following targets are available:"
-        for t in getTargetDict().Values do
+        for t in getTargetDict().Values |> Seq.sortBy (fun t -> t.Name) do
             Trace.logfn "   %s%s" t.Name (match t.Description with Some s -> sprintf " - %s" s | _ -> "")
 
 

--- a/src/app/Fake.Runtime/FakeRuntime.fs
+++ b/src/app/Fake.Runtime/FakeRuntime.fs
@@ -611,7 +611,8 @@ let prepareAndRunScript (config:FakeConfig) : RunResult =
 let retrieveHints (config:FakeConfig) (runResult:Runners.RunResult) =
     match runResult with
     | Runners.RunResult.SuccessRun _ -> []
-    | Runners.RunResult.CompilationError err -> [
+    | Runners.RunResult.CompilationError err ->
+      [
         // Add some hints about the error, for example
         // detect https://github.com/fsharp/FAKE/issues/1783
         let containsNotDefined = err.Errors |> Seq.exists (fun er -> er.ErrorNumber = 39)
@@ -621,7 +622,8 @@ let retrieveHints (config:FakeConfig) (runResult:Runners.RunResult) =
         if containsNotSupportOperator then
           yield "Operators now need to be opened manually, try to add 'open Fake.IO.FileSystemOperators' and 'open Fake.IO.Globbing.Operators' to your script to import the most common operators"
       ]
-    | Runners.RunResult.RuntimeError _ -> [
+    | Runners.RunResult.RuntimeError _ ->
+      [
         if config.VerboseLevel.PrintVerbose && Environment.GetEnvironmentVariable "FAKE_DETAILED_ERRORS" <> "true" then
           yield "To further diagnose the problem you can set the 'FAKE_DETAILED_ERRORS' environment variable to 'true'"
         if not config.VerboseLevel.PrintVerbose && Environment.GetEnvironmentVariable "FAKE_DETAILED_ERRORS" <> "true" then

--- a/src/app/Fake.Tracing.NAntXml/NAntXmlTraceListener.fs
+++ b/src/app/Fake.Tracing.NAntXml/NAntXmlTraceListener.fs
@@ -54,7 +54,8 @@ type NAntXmlTraceListener(encoding : Encoding, xmlOutputFile) =
         | TraceData.TestOutput _
         | TraceData.TestStatus _
         | TraceData.ImportData _
-        | TraceData.BuildNumber _ -> ""       
+        | TraceData.BuildNumber _
+        | TraceData.BuildState _ -> ""
 
     interface System.IDisposable with
         member __.Dispose () =

--- a/src/app/Fake.netcore/Program.fs
+++ b/src/app/Fake.netcore/Program.fs
@@ -156,7 +156,7 @@ let runOrBuild (args : RunArguments) =
       let result =
         match runResult with
         | Runners.RunResult.SuccessRun warnings ->
-          if warnings <> "" then
+          if warnings <> "" && args.VerboseLevel.PrintNormal then
             traceFAKE "%O" warnings
           if args.VerboseLevel.PrintVerbose then log "Ready."
           true
@@ -167,9 +167,9 @@ let runOrBuild (args : RunArguments) =
             indentString + String.Join(sprintf "%s%s" Environment.NewLine indentString, splitMsg)
           if args.VerboseLevel.PrintVerbose then
             // in case stderr is not redirected
-            TraceMessage("Script is not a valid, see standard error for details.", true) |> forceWrite
+            TraceMessage("Script is not valid, see standard error for details.", true) |> forceWrite
 
-          ErrorMessage "Script is not a valid:" |> forceWrite
+          ErrorMessage "Script is not valid:" |> forceWrite
           ErrorMessage (indentString 1 err.FormattedErrors) |> forceWrite
           false
         | Runners.RunResult.RuntimeError err ->

--- a/src/app/Fake.netcore/Program.fs
+++ b/src/app/Fake.netcore/Program.fs
@@ -156,7 +156,7 @@ let runOrBuild (args : RunArguments) =
       let result =
         match runResult with
         | Runners.RunResult.SuccessRun warnings ->
-          if warnings <> "" && args.VerboseLevel.PrintNormal then
+          if warnings <> "" then
             traceFAKE "%O" warnings
           if args.VerboseLevel.PrintVerbose then log "Ready."
           true


### PR DESCRIPTION
This PR fixes a build break I got while building the repo, and silences the output of the warnings if the `RunContext` verbosity is set to Silent.