### PR TITLE
Fix Xml.poke by adding the missing load

### DIFF
--- a/src/app/Fake.Core.Xml/Xml.fs
+++ b/src/app/Fake.Core.Xml/Xml.fs
@@ -159,6 +159,7 @@ let private save (fileName:string) (doc:XmlDocument) =
 /// Replaces text in a XML file at the location specified by a XPath expression.
 let poke (fileName : string) xpath value =
     let doc = new XmlDocument()
+    load fileName doc
     replaceXPath xpath value doc |> save fileName
 
 /// Replaces the inner text of an xml node in a XML file at the location specified by a XPath expression.

--- a/src/test/Fake.Core.UnitTests/Fake.Core.Xml.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.Xml.fs
@@ -34,5 +34,21 @@ let tests =
         let actual = File.ReadAllText tmpFile |> normalize
         Expect.equal expected actual "expected same xml"
       finally
-        File.Delete(tmpFile)      
+        File.Delete(tmpFile)
+
+    testCase "Test that poke pokes" <| fun _ ->
+      let original = normalize """<?xml version="1.0" encoding="UTF-8"?>
+<root attr="original">
+</root>"""
+      let expected = normalize """<?xml version="1.0" encoding="UTF-8"?>
+<root attr="expected">
+</root>"""
+      let tmpFile = Path.GetTempFileName()
+      try
+        File.WriteAllText(tmpFile, original)
+        Xml.poke tmpFile "/root/@attr" "expected"
+        let actual = File.ReadAllText tmpFile |> normalize
+        Expect.equal expected actual "expected same xml"
+      finally
+        File.Delete(tmpFile)
   ]


### PR DESCRIPTION
Xml.poke didn't work, since it never loaded the original xml from disk, unlike other poke* functions