### PR TITLE
expand passed-in path in order to workaround a dotnet cli bug

### DIFF
--- a/src/template/fake-template/Content/fake.tool.sh
+++ b/src/template/fake-template/Content/fake.tool.sh
@@ -3,10 +3,25 @@
 set -eu
 set -o pipefail
 
-TOOL_PATH=(ToolPath)
+# liberated from https://stackoverflow.com/a/18443300/433393
+realpath() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}
 
-if ! [ -e $TOOL_PATH/fake ] 
+TOOL_PATH=$(realpath (ToolPath))
+FAKE="$TOOL_PATH"/fake
+
+if ! [ -e "$FAKE" ]
 then
   dotnet tool install fake-cli --tool-path $TOOL_PATH --version (version)
 fi
-$TOOL_PATH/fake "$@"
+"$FAKE" "$@"


### PR DESCRIPTION
Fixes #2013 by expanding the given`tool-path` using just shell builtins. If you have the fake tool installed already you'll need to clear that directory before using this fix.

@samritchie want to give this a try?