### PR TITLE
Suggestion: a way to start globbing from a specific basedir

### DIFF
--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -127,6 +127,12 @@ module GlobbingPattern =
           Includes = [ x ]
           Excludes = [] } :> IGlobbingPattern
 
+    // Start an empty globbing pattern from the specified directory
+    let fromBaseDir (dir : string) =
+        { BaseDirectory = dir
+          Includes = []
+          Excludes = [] } :> IGlobbingPattern
+
     /// Sets a directory as baseDirectory for fileIncludes. 
     let setBaseDir (dir : string) (fileIncludes : IGlobbingPattern) = fileIncludes.SetBaseDirectory dir
 

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -128,7 +128,7 @@ module GlobbingPattern =
           Excludes = [] } :> IGlobbingPattern
 
     // Start an empty globbing pattern from the specified directory
-    let fromBaseDir (dir : string) =
+    let createFrom (dir : string) =
         { BaseDirectory = dir
           Includes = []
           Excludes = [] } :> IGlobbingPattern

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -127,7 +127,7 @@ module GlobbingPattern =
           Includes = [ x ]
           Excludes = [] } :> IGlobbingPattern
 
-    // Start an empty globbing pattern from the specified directory
+    /// Start an empty globbing pattern from the specified directory
     let createFrom (dir : string) =
         { BaseDirectory = dir
           Includes = []


### PR DESCRIPTION
### Description

I suggest this simple helper in Globbing that allow to start from a base directory, providing a syntax that I find clearer where the basedir is specified as the starting point :

```fsharp
// Before
let projects =
    !! "**/*.fsproj"
    |> GlobbingPattern.setBaseDir "src"

// After
let projects =
    GlobbingPattern.createFrom "src"
    ++ "**/*.fsproj"
```

## TODO

- [X] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [X] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
