### PR TITLE
Suggestion: Extend DotNet.BuildConfiguration

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -850,14 +850,24 @@ module DotNet =
         | Debug
         | Release
         | Custom of string
+    with
+        /// Convert the build configuration to a string that can be passed to the .NET CLI
+        override this.ToString() =
+            match this with
+            | Debug -> "Debug"
+            | Release -> "Release"
+            | Custom config -> config
+
+        /// Parse a build configuration string
+        static member Parse (s: string) =
+            match s.ToLowerInvariant() with
+            | "debug" -> Debug
+            | "release" -> Release
+            | _ -> Custom s
 
     /// [omit]
     let private buildConfigurationArg (param: BuildConfiguration) =
-        sprintf "--configuration %s"
-            (match param with
-            | Debug -> "Debug"
-            | Release -> "Release"
-            | Custom config -> config)
+        sprintf "--configuration %O" param
 
     /// dotnet pack command options
     type PackOptions =

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -865,6 +865,13 @@ module DotNet =
             | "release" -> Release
             | _ -> Custom s
 
+        /// Get the build configuration from an environment variable with the given name or returns
+        /// the default if not value was set
+        static member FromEnvironVarOrDefault (name: string) (defaultValue: BuildConfiguration) =
+            match Environment.environVarOrNone name with
+            | Some config -> BuildConfiguration.Parse config
+            | None -> defaultValue           
+
     /// [omit]
     let private buildConfigurationArg (param: BuildConfiguration) =
         sprintf "--configuration %O" param

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -858,8 +858,10 @@ module DotNet =
             | Release -> "Release"
             | Custom config -> config
 
+    [<RequireQualifiedAccess>]
+    module BuildConfiguration =
         /// Parse a build configuration string
-        static member Parse (s: string) =
+        let fromString (s: string) =
             match s.ToLowerInvariant() with
             | "debug" -> Debug
             | "release" -> Release
@@ -867,10 +869,10 @@ module DotNet =
 
         /// Get the build configuration from an environment variable with the given name or returns
         /// the default if not value was set
-        static member FromEnvironVarOrDefault (name: string) (defaultValue: BuildConfiguration) =
+        let fromEnvironVarOrDefault (name: string) (defaultValue: BuildConfiguration) =
             match Environment.environVarOrNone name with
-            | Some config -> BuildConfiguration.Parse config
-            | None -> defaultValue           
+            | Some config -> fromString config
+            | None -> defaultValue      
 
     /// [omit]
     let private buildConfigurationArg (param: BuildConfiguration) =


### PR DESCRIPTION
### Description

Extend `DotNet.BuildConfiguration`:
* Implement `ToString` to be able to get a string representation
* Add a way to parse from a string
* Add an easy way to get a configuration from an environment variable

Combined they allow to use the discriminated union as "one and only" type for .Net build configuration, easily obtaining a value from an environment variable and converting it to string if needed in other tools.

```fsharp

let configuration = DotNet.BuildConfiguration.fromEnvironVarOrDefault "configuration" DotNet.BuildConfiguration.Release

// Later
let cmdLine = sprintf "mytool /configuration %O" configuration
```

## TODO

- [X] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [X] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
