### PR TITLE
add extended commit message

### DIFF
--- a/src/app/Fake.Tools.Git/Commit.fs
+++ b/src/app/Fake.Tools.Git/Commit.fs
@@ -10,3 +10,8 @@ let exec repositoryDir message =
     |> runSimpleGitCommand repositoryDir
     |> Trace.trace
 
+/// Commits all files in the given repository with the given short message along with an extended message
+let execExtended repositoryDir shortMessage extendedMessage = 
+    sprintf "commit -m \"%s\" -m \"%s\"" shortMessage extendedMessage
+    |> runSimpleGitCommand repositoryDir
+    |> Trace.trace


### PR DESCRIPTION
### Description

Git allows the user to specify two `-m` flags, where the first is sort of an issue summary, and the second has the longer, detailed message.  I added support for this because I'd like to use it in our pipelines at work 😄 

My only outstanding question is that the api guidelines suggest that modules have `RequireQualifiedAccess` and we don't have that on the `Fake.Tools.Git.Commit` module. Would you like me to add it?

## TODO

- [X] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [X] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
