### PR TITLE
Add function to add additional command-line arguments in Fake.DotNet.DotNet.Options as a sequence of strings.

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -498,6 +498,10 @@ module DotNet =
             lift (fun o -> { o with Verbosity = verb}) x
         let inline withCustomParams args x =
             lift (fun o -> { o with CustomParams = args}) x
+        /// Sets custom command-line arguments expressed as a sequence of strings.
+        /// This function overwrites and gets overwritten by `withCustomParams`.
+        let inline withAdditionalArgs args x =
+            withCustomParams (args |> Args.toWindowsCommandLine |> (function | "" -> None | x -> Some x)) x
         let inline withDotNetCliPath path x =
             lift (fun o -> { o with DotNetCliPath = path}) x
 


### PR DESCRIPTION
This funcion internally converts them to a single string.
It does not break anything.
The downside is that the arguments cannot be _read_ as a sequence of strings.

This PR was made to address the hastily closed #2042.