### PR TITLE
Adding newline to fix 'fake --help' formatting.

### DIFF
--- a/src/app/Fake.netcore/Program.fs
+++ b/src/app/Fake.netcore/Program.fs
@@ -228,7 +228,7 @@ let handleAction (verboseLevel:VerboseLevel) (action:CliAction) =
     0
   | ShowHelp ->
     printf "%s" Cli.fakeUsage
-    printf "Hint: Run 'fake run <script.fsx> --help' to get help from your script."
+    printfn "Hint: Run 'fake run <script.fsx> --help' to get help from your script."
     0
   | InvalidUsage str ->
     eprintfn "%s" str


### PR DESCRIPTION
### Description

This PR fixes some formatting when running `fake --help`.  Without the PR, the terminal prompt is on the same line as the last message that FAKE prints out.  With the PR, the prompt is on a new line.