### PR TITLE
Fix the template version

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -694,17 +694,6 @@ Target.create "_DotNetPackage" (fun _ ->
     Environment.setEnvironVar "PackageProjectUrl" "https://github.com/fsharp/Fake"
     Environment.setEnvironVar "PackageLicenseUrl" "https://github.com/fsharp/FAKE/blob/d86e9b5b8e7ebbb5a3d81c08d2e59518cf9d6da9/License.txt"
 
-    // Update template
-    let templateFromVersion, templateToVersion = """"defaultValue": "5.*",""", sprintf """"defaultValue": "%s",""" nugetVersion
-    let templateConfigFile = "src/template/fake-template/Content/.template.config/template.json"
-    let replaceInTemplate fromDefault toDefault =
-        [ templateConfigFile ]
-        |> Shell.replaceInFiles [ fromDefault, toDefault ]
-    let configContents = File.ReadAllText(templateConfigFile)
-    if not <| configContents.Contains templateFromVersion then
-        failwithf "Make sure to revert your changes in '%s' or update the build script accordingly" templateConfigFile
-    replaceInTemplate templateFromVersion templateToVersion
-
     // dotnet pack
     DotNet.pack (fun c ->
         { c with
@@ -715,9 +704,6 @@ Target.create "_DotNetPackage" (fun _ ->
                     { c.Common with CustomParams = Some "/m:1" }
                 else c.Common
         } |> dtntSmpl) "Fake.sln"
-
-    // Revert template
-    replaceInTemplate templateToVersion templateFromVersion
 
     // TODO: Check if we run the test in the current build!
     Directory.ensure "temp"

--- a/src/template/fake-template/Content/.template.config/template.json
+++ b/src/template/fake-template/Content/.template.config/template.json
@@ -59,7 +59,7 @@
             "type": "parameter",
             "description": "Version of FAKE to install. This parameter is only applicable when either 'tool' or 'project' is used for bootstrapping",
             "dataType": "string",
-            "defaultValue": "5.*",
+            "defaultValue": "latest",
             "replaces": "(version)"
         }
     },

--- a/src/template/fake-template/Content/build.proj
+++ b/src/template/fake-template/Content/build.proj
@@ -3,6 +3,10 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
+        <!--#if (version == "latest") -->
+        <DotNetCliToolReference Include="dotnet-fake" Version="*" />
+        <!--#else-->
         <DotNetCliToolReference Include="dotnet-fake" Version="(version)" />
+        <!--#endif-->
     </ItemGroup>
 </Project>

--- a/src/template/fake-template/Content/fake.tool.cmd
+++ b/src/template/fake-template/Content/fake.tool.cmd
@@ -1,7 +1,11 @@
 SET TOOL_PATH=(ToolPath)
 
 IF NOT EXIST "%TOOL_PATH%\fake.exe" (
+  rem #if (version == "latest")
+  dotnet tool install fake-cli --tool-path ./%TOOL_PATH%
+  rem #else 
   dotnet tool install fake-cli --tool-path ./%TOOL_PATH% --version (version)
+  rem #endif
 )
 
 "%TOOL_PATH%/fake.exe" %*

--- a/src/template/fake-template/Content/fake.tool.sh
+++ b/src/template/fake-template/Content/fake.tool.sh
@@ -22,6 +22,10 @@ FAKE="$TOOL_PATH"/fake
 
 if ! [ -e "$FAKE" ]
 then
+#if (version == "latest")
+  dotnet tool install fake-cli --tool-path "$TOOL_PATH"
+#else
   dotnet tool install fake-cli --tool-path "$TOOL_PATH" --version (version)
+#endif
 fi
 "$FAKE" "$@"


### PR DESCRIPTION
* only add a version constraint if the user specified one
* use * for DotNetCliToolReference if no version was specified
* do not add --version for the global tool if no version was specified

