### PR TITLE
Teamcity build parameters

### DIFF
--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -307,11 +307,11 @@ module TeamCity =
 
     /// Describe a change between builds
     type FileChange = {
-        /// Path of the file that changed, relative to the current checkout directory ('system.teamcity.build.checkoutDir')
+        /// Path of the file that changed, relative to the current checkout directory (TemaCity.Environment.CheckoutDirectory)
         FilePath: string
         /// Type of modification for the file
         ModificationType: FileChangeType
-        ///
+        /// File revision in the repository. If the file is a part of change list started via the remote run, then the value will be None
         Revision: string option }
 
     module private ChangedFiles =
@@ -375,6 +375,9 @@ module TeamCity =
 
         /// Get the branch of the main VCS root
         static member Branch with get() = BuildParameters.tryGetConfiguration "vcsroot.branch"
+
+        /// Get the path to the build checkout directory
+        static member CheckoutDirectory with get() = BuildParameters.tryGetSystem "teamcity.build.checkoutDir"
 
         /// Get the display name of the branch of the main VCS root as shown in TeamCity
         /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Working+with+Feature+Branches#WorkingwithFeatureBranches-branchSpec) for more information

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -376,9 +376,6 @@ module TeamCity =
         /// Get the branch of the main VCS root
         static member Branch with get() = BuildParameters.tryGetConfiguration "vcsroot.branch"
 
-        /// Get the path to the build checkout directory
-        static member CheckoutDirectory with get() = BuildParameters.tryGetSystem "teamcity.build.checkoutDir"
-
         /// Get the display name of the branch of the main VCS root as shown in TeamCity
         /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Working+with+Feature+Branches#WorkingwithFeatureBranches-branchSpec) for more information
         static member BranchDisplayName
@@ -399,6 +396,9 @@ module TeamCity =
                         Environment.Branch.IsSome
                 else
                     false
+
+        /// Get the path to the build checkout directory
+        static member CheckoutDirectory with get() = BuildParameters.tryGetSystem "teamcity.build.checkoutDir"
 
         /// Changed files (since previous build) that are included in this build
         /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Risk+Tests+Reordering+in+Custom+Test+Runner) for more information

--- a/src/app/Fake.BuildServer.TeamCity/TeamCityInternal.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCityInternal.fs
@@ -336,4 +336,58 @@ module internal TeamCityRest =
         getFirstNode serverURL username password "/httpAuth/app/rest/projects"
         |> Xml.parse "projects" Xml.getChilds
         |> Seq.map (Xml.getAttribute "id")
-        
+    
+module internal TeamCityBuildParameters =
+    let private get (fileName: string option) =
+        match fileName with
+        | Some fileName when not (isNull fileName) && (File.Exists fileName) ->
+            use stream = File.OpenRead(fileName)
+            use reader = new StreamReader(stream)
+
+            reader
+            |> JavaPropertiesFile.parseTextReader
+            |> Seq.choose(function
+                | JavaPropertiesFile.Comment _ -> None
+                | JavaPropertiesFile.KeyValue(k, v) -> Some (k,v))
+            |> Map.ofSeq
+        | _ ->
+            Map.empty
+
+    let private systemFile = Environment.environVarOrNone "TEAMCITY_BUILD_PROPERTIES_FILE"
+    let private system = lazy(get (systemFile))
+
+    let getAllSystem () = system.Value
+
+    let private configurationFile = lazy (getAllSystem() |> Map.tryFind "teamcity.configuration.properties.file")
+    let private configuration = lazy (get configurationFile.Value)
+
+    let getAllConfiguration () = configuration.Value
+
+    let private runnerFile = lazy (getAllSystem() |> Map.tryFind "teamcity.runner.properties.file")
+    let private runner = lazy (get runnerFile.Value)
+    
+    let getAllRunner () = runner.Value
+
+    let private all = lazy (
+        if BuildServer.buildServer = BuildServer.TeamCity then
+            seq {
+                // Environment variables are available using 'env.foo' syntax in TeamCity configuration
+                for pair in System.Environment.GetEnvironmentVariables() do
+                    let pair = pair :?> System.Collections.DictionaryEntry
+                    let key = pair.Key :?> string
+                    let value = pair.Value :?> string
+                    yield sprintf "env.%s" key, value
+
+                // Runner variables aren't available in TeamCity configuration so we choose an arbitrary syntax of 'runner.foo'
+                for pair in runner.Value do yield sprintf "runner.%s" pair.Key, pair.Value
+
+                // System variables are prefixed with 'system.' as in TeamCity configuration
+                for pair in system.Value do yield sprintf "system.%s" pair.Key, pair.Value
+
+                for pair in configuration.Value do yield pair.Key, pair.Value
+            }
+            |> Map.ofSeq
+        else
+            Map.empty)
+
+    let getAll () = all.Value

--- a/src/legacy/FakeLib/TeamCityHelper.fs
+++ b/src/legacy/FakeLib/TeamCityHelper.fs
@@ -246,26 +246,26 @@ let ComparisonFailure name message details expected actual =
         (EncapsulateSpecialChars expected) (EncapsulateSpecialChars actual) |> sendStrToTeamCity
 
 /// The Version of the TeamCity server. This property can be used to determine the build is run within TeamCity.
-[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.<> instead")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.Version instead")>]
 let TeamCityVersion = environVarOrNone "TEAMCITY_VERSION"
 
 /// The Name of the project the current build belongs to or None if it's not on TeamCity.
-[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.<> instead")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.ProjectName instead")>]
 let TeamCityProjectName = environVarOrNone "TEAMCITY_PROJECT_NAME"
 
 /// The Name of the Build Configuration the current build belongs to or None if it's not on TeamCity.
-[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.<> instead")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.BuildConfigurationName instead")>]
 let TeamCityBuildConfigurationName = environVarOrNone "TEAMCITY_BUILDCONF_NAME"
 
 /// Is set to true if the build is a personal one.
-[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.<> instead")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.BuildIsPersonal instead")>]
 let TeamCityBuildIsPersonal =
     match environVarOrNone "BUILD_IS_PERSONAL" with
     | Some _ -> true
     | None -> false
 
 /// The Build number assigned to the build by TeamCity using the build number format or None if it's not on TeamCity.
-[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.<> instead")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.BuildNumber instead")>]
 let TeamCityBuildNumber = environVarOrNone "BUILD_NUMBER"
 
 module private JavaPropertiesFile =
@@ -426,8 +426,8 @@ module private JavaPropertiesFile =
         Parser.parseWithReader reader
 
 /// TeamCity build parameters
-/// See [Predefined Build Parameters documentation](https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters) for more information
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+/// See [Predefined Build Parameters documentation](https://confluence.jetbrains.com/display/TCD18/Predefined+Build+Parameters) for more information
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.BuildParameters instead")>]
 module TeamCityBuildParameters =
     open System
     open System.IO
@@ -505,7 +505,7 @@ module TeamCityBuildParameters =
     let tryGet name = all.Value |> Map.tryFind name
 
 /// Get files changed between builds in TeamCity
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.ChangedFiles instead")>]
 module TeamCityChangedFiles =
     /// The type of change that occured
     type ModificationType =
@@ -558,7 +558,7 @@ module TeamCityChangedFiles =
     let private fileChanges = lazy (getFileChanges' ())
 
     /// Changed files (since previous build) that are included in this build
-    /// See [the documentation](https://confluence.jetbrains.com/display/TCD10/Risk+Tests+Reordering+in+Custom+Test+Runner) for more information
+    /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Risk+Tests+Reordering+in+Custom+Test+Runner) for more information
     let get () = fileChanges.Value
 
 let private getRecentlyFailedTests' () =
@@ -569,24 +569,24 @@ let private getRecentlyFailedTests' () =
 let private recentlyFailedTests = lazy (getRecentlyFailedTests' ())
 
 /// Name of recently failing tests
-/// See [the documentation](https://confluence.jetbrains.com/display/TCD10/Risk+Tests+Reordering+in+Custom+Test+Runner) for more information
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+/// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Risk+Tests+Reordering+in+Custom+Test+Runner) for more information
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.RecentlyFailedTests instead")>]
 let getTeamCityRecentlyFailedTests () = recentlyFailedTests.Value
 
 /// Get the branch of the main VCS root
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.Branch instead")>]
 let getTeamCityBranch () = TeamCityBuildParameters.tryGetConfiguration "vcsroot.branch"
 
 /// Get the display name of the branch as shown in TeamCity
-/// See [the documentation](https://confluence.jetbrains.com/display/TCD10/Working+with+Feature+Branches#WorkingwithFeatureBranches-branchSpec) for more information
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+/// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Working+with+Feature+Branches#WorkingwithFeatureBranches-branchSpec) for more information
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.BranchDisplayName instead")>]
 let getTeamCityBranchName () =
     match TeamCityBuildParameters.tryGetConfiguration "teamcity.build.branch" with
     | Some _  as branch -> branch
     | None -> TeamCityBuildParameters.tryGetConfiguration "vcsroot.branch"
 
 /// Get if the current branch is the one configured as default
-[<System.Obsolete("please check the Fake.BuildServer.TeamCity module for a replacement and send a PR to include this into FAKE 5 if needed.")>]
+[<System.Obsolete("please use nuget 'Fake.BuildServer.TeamCity', open Fake.BuildServer and use TeamCity.Environment.IsDefaultBranch instead")>]
 let getTeamCityBranchIsDefault () =
     if buildServer = TeamCity then
         match TeamCityBuildParameters.tryGetConfiguration "teamcity.build.branch.is_default" with


### PR DESCRIPTION
### Description

TeamCity exposes a lot of build parameters that FAKE 4 made accessible but the class and some associated methods were made internal (and unused) in FAKE 5

This PR add them back with a slighty modified API.

The public API surface change is :

```fsharp
module Fake.BuildServer.TeamCity =
+	module BuildParameters =
+		System: Map<string, string>
+		Configuration: Map<string, string>
+		Runner: Map<string, string>
+		All: Map<string, string>
+	type FileChangeType = // DU
+	type FileChange = // Record
	type Environment =
+		Branch: string option
+		BranchDisplayName: string option
+		IsDefaultBranch: string option
+		CheckoutDirectory: string option
+		ChangedFiles: FileChange  list option
+		RecentlyFailedTests: string list option

```

It add build parameters for people who need them (We query all VCS properties that way for example) and exposes some common ones in `Environment`.

*PS: Lot of things can be done via build parameters, they contains for example the PATH of all versions of visual studio installed that are detected by TC*