### PR TITLE
Add .NET SDK 2.1.400, 2.1.401, 2.1.402

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -337,6 +337,36 @@ module DotNet =
                 Version = Version "2.1.302"
             }
 
+        let Release_2_1_400 option =
+            { option with
+                InstallerOptions = (fun io ->
+                    { io with
+                        Branch = "release/2.1"
+                    })
+                Channel = None
+                Version = Version "2.1.400"
+            }
+
+        let Release_2_1_401 option =
+            { option with
+                InstallerOptions = (fun io ->
+                    { io with
+                        Branch = "release/2.1"
+                    })
+                Channel = None
+                Version = Version "2.1.401"
+            }
+
+        let Release_2_1_402 option =
+            { option with
+                InstallerOptions = (fun io ->
+                    { io with
+                        Branch = "release/2.1"
+                    })
+                Channel = None
+                Version = Version "2.1.402"
+            }
+
         let FromGlobalJson option =
             { option with
                 InstallerOptions = id


### PR DESCRIPTION
### Description

3 new .NET SDKs are out, but currently the only way to use them with FAKE is with global.json.  This adds supports directly in `DotNet.Versions`.

## TODO

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
    - Current fields have no additional documentation
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
    - Could not find tests for previous SDK versions, not sure it needs testing.
- [] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
    - N/A
- [] (if new module) the module is in the correct namespace
    - N/A
- [] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
    - N/A
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
    - follows current .NET SDK pattern.