### PR TITLE
Update FakeRuntime to use NetStandard 2.0.3

### DIFF
--- a/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
+++ b/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
@@ -74,7 +74,7 @@ let tests =
             let c = DotNet.Options.Create() |> dotnetSdk.Value
             let d = Path.GetDirectoryName c.DotNetCliPath
             if not (p.StartsWith d) then
-                Environment.SetEnvironmentVariable("PATH", sprintf "%s%c%s" d Path.DirectorySeparatorChar p)
+                Environment.SetEnvironmentVariable("PATH", sprintf "%s%c%s" d Path.PathSeparator p)
             
             printfn "PATH: %s" <| Environment.GetEnvironmentVariable "PATH"
 


### PR DESCRIPTION
### Description

I keep running into https://github.com/dotnet/standard/issues/708 and this is apparently fixed in 2.0.3

I'm not sure if this has any other effects...
