### PR TITLE
[Breaking] Fixes Environment-Map behavior for windows.

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -483,7 +483,7 @@ module DotNet =
             /// Gets the environment variables that apply to this process and its child processes.
             /// NOTE: Recommendation is to not use this Field, but instead use the helper function in the Proc module (for example Process.setEnvironmentVariable)
             /// NOTE: This field is ignored when UseShellExecute is true.
-            Environment : Map<string, string>
+            Environment : IMap<string, string>
         }
         static member Create() = {
             DotNetCliPath =
@@ -499,11 +499,11 @@ module DotNet =
             RedirectOutput = false
             Environment =
                 Process.createEnvironmentMap()
-                |> Map.remove "MSBUILD_EXE_PATH"
-                |> Map.remove "MSBuildExtensionsPath"
-                |> Map.remove "MSBuildLoadMicrosoftTargetsReadOnly"
-                |> Map.remove "MSBuildSDKsPath"
-                |> Map.remove "DOTNET_HOST_PATH"
+                |> IMap.remove "MSBUILD_EXE_PATH"
+                |> IMap.remove "MSBuildExtensionsPath"
+                |> IMap.remove "MSBuildLoadMicrosoftTargetsReadOnly"
+                |> IMap.remove "MSBuildSDKsPath"
+                |> IMap.remove "DOTNET_HOST_PATH"
         }
         [<Obsolete("Use Options.Create instead")>]
         static member Default = Options.Create()
@@ -628,7 +628,7 @@ module DotNet =
             let f (info:ProcStartInfo) =
                 let dir = System.IO.Path.GetDirectoryName options.DotNetCliPath
                 let oldPath =
-                    match options.Environment |> Map.tryFind "PATH" with
+                    match options.Environment |> IMap.tryFind "PATH" with
                     | None -> ""
                     | Some s -> s
                 { info with

--- a/src/app/Fake.DotNet.Fsi/Fsi.fs
+++ b/src/app/Fake.DotNet.Fsi/Fsi.fs
@@ -119,7 +119,7 @@ type FsiParams = {
     /// Sets the path to the fsharpi / fsi.exe to use
     ToolPath : FsiTool
     /// Environment variables
-    Environment : Map<string, string>
+    Environment : IMap<string, string>
     /// When UseShellExecute is true, the fully qualified name of the directory that contains the process to be started. When the UseShellExecute property is false, the working directory for the process to be started. The default is an empty string ("").
     WorkingDirectory : string
 }
@@ -280,7 +280,7 @@ module internal ExternalFsi =
                     FileName = fsiExe
                     Arguments = args
                     WorkingDirectory = ""
-                }.WithEnvironmentVariables (parameters.Environment |> Map.toSeq)) TimeSpan.MaxValue        
+                }.WithEnvironmentVariables (parameters.Environment |> IMap.toSeq)) TimeSpan.MaxValue        
 
         if r.ExitCode <> 0 then
             List.iter Trace.traceError r.Errors

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -281,7 +281,7 @@ type MSBuildParams =
       Loggers : (MSBuildLoggerConfig) list option
       /// corresponds to the msbuild option '/dl'
       DistributedLoggers : (MSBuildLoggerConfig * MSBuildLoggerConfig option) list option
-      Environment : Map<string, string> }
+      Environment : IMap<string, string> }
     /// Defines a default for MSBuild task parameters
     static member Create() =
         { ToolPath = MSBuildExe.msBuildExe
@@ -307,10 +307,10 @@ type MSBuildParams =
           Loggers = None
           Environment =
             Process.createEnvironmentMap()
-            |> Map.remove "MSBUILD_EXE_PATH"
-            |> Map.remove "MSBuildExtensionsPath"
-            |> Map.remove "MSBuildLoadMicrosoftTargetsReadOnly"
-            |> Map.remove "MSBuildSDKsPath" }
+            |> IMap.remove "MSBUILD_EXE_PATH"
+            |> IMap.remove "MSBuildExtensionsPath"
+            |> IMap.remove "MSBuildLoadMicrosoftTargetsReadOnly"
+            |> IMap.remove "MSBuildSDKsPath" }
     [<Obsolete("Please use 'Create()' instead and make sure to properly set Environment via Process-module funtions!")>]
     static member Empty = MSBuildParams.Create()
 


### PR DESCRIPTION
... where environment variables are case insensitive.

Maybe we can get away with this breaking change. I don't see how we can do this reasonably without breaking change as `Map` doesn't support a custom comparison or case insensitivity...

