### PR TITLE
Enhanced TeamCity Logging

### DIFF
--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -402,6 +402,9 @@ module TeamCity =
                     match description with
                     | Some d -> TeamCityWriter.sendOpenBlock tag.Name (sprintf "%s: %s" tag.Type d)
                     | _ -> TeamCityWriter.sendOpenBlock tag.Name tag.Type
+                | TraceData.CloseTag (tag, _, status) when status = TagStatus.Failed ->
+                    TeamCityWriter.sendCloseBlock tag.Name
+                    reportBuildStatus "FAILURE" (sprintf "Failure in %s" tag.Name)
                 | TraceData.CloseTag (tag, _, _) ->
                     TeamCityWriter.sendCloseBlock tag.Name
                 | TraceData.ImportantMessage text ->

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -222,7 +222,7 @@ module TeamCity =
     let internal warning message =
         TeamCityWriter.sendToTeamCity "##teamcity[message text='%s' status='WARNING']" message
 
-    /// Sends a warning message.
+    /// Sends an error message.
     let internal error message =
         TeamCityWriter.sendToTeamCity "##teamcity[message text='%s' status='ERROR']" message
 
@@ -371,9 +371,6 @@ module TeamCity =
     /// Implements a TraceListener for TeamCity build servers.
     /// 
     /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity) for more information
-    /// ## Parameters
-    ///  - `importantMessagesToStdErr` - Defines whether to trace important messages to StdErr.
-    ///  - `colorMap` - A function which maps TracePriorities to ConsoleColors.
     type internal TeamCityTraceListener() =
 
         interface ITraceListener with

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -392,7 +392,7 @@ module TeamCity =
                 | TraceData.BuildState state when state = TagStatus.Success ->
                     reportBuildStatus "SUCCESS" "{build.status.text}"
                 | TraceData.BuildState state ->
-                    reportBuildStatus "FAILURE" (sprintf "%s - {build.status.text}" state)
+                    reportBuildStatus "FAILURE" (sprintf "%o - {build.status.text}" state)
                 | TraceData.CloseTag (KnownTags.Test name, time, _) ->
                     finishTestCase name time
                 | TraceData.OpenTag (KnownTags.TestSuite name, _) ->

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -389,10 +389,10 @@ module TeamCity =
                     testFailed testName message detail
                 | TraceData.TestStatus (testName,TestStatus.Failed(message, detail, Some (expected, actual))) ->
                     comparisonFailure testName message detail expected actual
-                | TraceData.BuildState state when state = TagStatus.Success ->
+                | TraceData.BuildState TagStatus.Success ->
                     reportBuildStatus "SUCCESS" "{build.status.text}"
                 | TraceData.BuildState state ->
-                    reportBuildStatus "FAILURE" (sprintf "%o - {build.status.text}" state)
+                    reportBuildStatus "FAILURE" (sprintf "%s - {build.status.text}" (state.ToString()))
                 | TraceData.CloseTag (KnownTags.Test name, time, _) ->
                     finishTestCase name time
                 | TraceData.OpenTag (KnownTags.TestSuite name, _) ->
@@ -403,7 +403,7 @@ module TeamCity =
                     match description with
                     | Some d -> TeamCityWriter.sendOpenBlock tag.Name (sprintf "%s: %s" tag.Type d)
                     | _ -> TeamCityWriter.sendOpenBlock tag.Name tag.Type
-                | TraceData.CloseTag (tag, _, status) when status = TagStatus.Failed ->
+                | TraceData.CloseTag (tag, _, TagStatus.Failed) ->
                     TeamCityWriter.sendCloseBlock tag.Name
                     reportBuildStatus "FAILURE" (sprintf "Failure in %s" tag.Name)
                 | TraceData.CloseTag (tag, _, _) ->

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -222,6 +222,10 @@ module TeamCity =
     let internal warning message =
         TeamCityWriter.sendToTeamCity "##teamcity[message text='%s' status='WARNING']" message
 
+    /// Sends a warning message.
+    let internal error message =
+        TeamCityWriter.sendToTeamCity "##teamcity[message text='%s' status='ERROR']" message
+
     /// TeamCity build parameters
     ///
     /// See [Predefined Build Parameters documentation](https://confluence.jetbrains.com/display/TCD18/Predefined+Build+Parameters) for more information
@@ -403,7 +407,7 @@ module TeamCity =
                 | TraceData.ImportantMessage text ->
                     warning text
                 | TraceData.ErrorMessage text ->
-                    ConsoleWriter.write false color true text
+                    error text
                 | TraceData.LogMessage(text, newLine) | TraceData.TraceMessage(text, newLine) ->
                     ConsoleWriter.write false color newLine text
                 | TraceData.ImportData (ImportData.BuildArtifactWithName _, path)

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -369,6 +369,8 @@ module TeamCity =
             with get() = RecentlyFailedTests.cache.Value
 
     /// Implements a TraceListener for TeamCity build servers.
+    /// 
+    /// See [the documentation](https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity) for more information
     /// ## Parameters
     ///  - `importantMessagesToStdErr` - Defines whether to trace important messages to StdErr.
     ///  - `colorMap` - A function which maps TracePriorities to ConsoleColors.

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -390,8 +390,10 @@ module TeamCity =
                     testFailed testName message detail
                 | TraceData.TestStatus (testName,TestStatus.Failed(message, detail, Some (expected, actual))) ->
                     comparisonFailure testName message detail expected actual
+                | TraceData.BuildState state when state = TagStatus.Success ->
+                    reportBuildStatus "SUCCESS" "{build.status.text}"
                 | TraceData.BuildState state ->
-                    ConsoleWriter.write false color true (sprintf "Changing BuildState to: %A" state)
+                    reportBuildStatus "FAILURE" (sprintf "%s - {build.status.text}" state)
                 | TraceData.CloseTag (KnownTags.Test name, time, _) ->
                     finishTestCase name time
                 | TraceData.OpenTag (KnownTags.TestSuite name, _) ->

--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -39,11 +39,13 @@ module TeamCityImportExtensions =
 /// The general documentation on how to use CI server integration can be found [here](/buildserver.html).
 /// This module does not provide any special APIs please use FAKE APIs and they should integrate into this CI server.
 /// If some integration is not working as expected or you have features you would like to use directly please open an issue. 
+/// 
+/// For more information on TeamCity interaction from builc scripts [see here](https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity)
 [<RequireQualifiedAccess>]
 module TeamCity =
     open Fake.IO
 
-    // See https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity
+    
 
     /// Open Named Block that will be closed when the block is disposed
     /// Usage: `use __ = TeamCity.block "My Block"`

--- a/src/app/Fake.Core.Target/Target.fs
+++ b/src/app/Fake.Core.Target/Target.fs
@@ -444,11 +444,15 @@ module Target =
                     | Some e -> alignedError name time e.Message)
 
             aligned "Total:" total null
-            if not context.HasError then aligned "Status:" "Ok" null
+            if not context.HasError then 
+                aligned "Status:" "Ok" null
+                Trace.setBuildState TagStatus.Success
             else
                 alignedError "Status:" "Failure" null
+                Trace.setBuildState TagStatus.Failure
         else
             Trace.traceError "No target was successfully completed"
+            Trace.setBuildState TagStatus.Warning
 
         Trace.traceLine()
 

--- a/src/app/Fake.Core.Target/Target.fs
+++ b/src/app/Fake.Core.Target/Target.fs
@@ -449,7 +449,7 @@ module Target =
                 Trace.setBuildState TagStatus.Success
             else
                 alignedError "Status:" "Failure" null
-                Trace.setBuildState TagStatus.Failure
+                Trace.setBuildState TagStatus.Failed
         else
             Trace.traceError "No target was successfully completed"
             Trace.setBuildState TagStatus.Warning

--- a/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
+++ b/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
@@ -74,7 +74,7 @@ let tests =
             let c = DotNet.Options.Create() |> dotnetSdk.Value
             let d = Path.GetDirectoryName c.DotNetCliPath
             if not (p.StartsWith d) then
-                Environment.SetEnvironmentVariable("PATH", sprintf "%s%c%s" d Path.DirectorySeparatorChar p)
+                Environment.SetEnvironmentVariable("PATH", sprintf "%s%c%s" d Path.PathSeparator p)
             
             printfn "PATH: %s" <| Environment.GetEnvironmentVariable "PATH"
 


### PR DESCRIPTION
### Description

Superseeds: #2109
Fixes #2108

Update TeamCity listener to match the documentation for service messages
Add functionality in the targets to report build state through trace