### PR TITLE
Write the NUnit arguements to a temp file and pass that to NUnit console

### DIFF
--- a/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
+++ b/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
@@ -317,34 +317,37 @@ let run (setParams : NUnit3Params -> NUnit3Params) (assemblies : string seq) =
     if Array.isEmpty assemblies then failwith "NUnit: cannot run tests (the assembly list is empty)."
     let tool = parameters.ToolPath
     let generatedArgs = buildArgs parameters assemblies
-    let path = Path.Combine(Path.GetTempPath(), (sprintf "%s.txt" (Guid.NewGuid().ToString())))
-    File.WriteAllText(path, generatedArgs)
-    Trace.trace(sprintf "Saved args to '%s' with value: %s" path generatedArgs)
-    let args = (sprintf "@%s" path)
-    Trace.trace (tool + " " + args)
     let processTimeout = TimeSpan.MaxValue // Don't set a process timeout. The timeout is per test.
-    let result =
-        Process.execSimple ((fun info ->
-        { info with
-            FileName = tool
-            WorkingDirectory = getWorkingDir parameters
-            Arguments = args }) >> Process.withFramework) processTimeout
+    let path = Path.GetTempFileName()
 
-    File.Delete(path)
+    try        
+        File.WriteAllText(path, generatedArgs)
+        Trace.trace(sprintf "Saved args to '%s' with value: %s" path generatedArgs)
+        let args = (sprintf "@%s" path)
+        Trace.trace (tool + " " + args)
+
+        let result = Process.execSimple ((fun info -> { info with
+                                                            FileName = tool
+                                                            WorkingDirectory = getWorkingDir parameters
+                                                            Arguments = args }) >> Process.withFramework) processTimeout
+
+        let errorDescription error =
+            match error with
+            | OK -> "OK"
+            | TestsFailed -> sprintf "NUnit test failed (%d)." error
+            | FatalError x -> sprintf "NUnit test failed. Process finished with exit code %s (%d)." x error
+
+        match parameters.ErrorLevel with
+        | NUnit3ErrorLevel.DontFailBuild ->
+            match result with
+            | OK | TestsFailed -> ()
+            | _ -> raise (FailedTestsException(errorDescription result))
+        | NUnit3ErrorLevel.Error | FailOnFirstError ->
+            match result with
+            | OK -> ()
+            | _ -> raise (FailedTestsException(errorDescription result))
+
+    finally
+        File.Delete(path)    
     
-    let errorDescription error =
-        match error with
-        | OK -> "OK"
-        | TestsFailed -> sprintf "NUnit test failed (%d)." error
-        | FatalError x -> sprintf "NUnit test failed. Process finished with exit code %s (%d)." x error
-
-    match parameters.ErrorLevel with
-    | NUnit3ErrorLevel.DontFailBuild ->
-        match result with
-        | OK | TestsFailed -> ()
-        | _ -> raise (FailedTestsException(errorDescription result))
-    | NUnit3ErrorLevel.Error | FailOnFirstError ->
-        match result with
-        | OK -> ()
-        | _ -> raise (FailedTestsException(errorDescription result))
     __.MarkSuccess()


### PR DESCRIPTION
### Description

Another option for #2113 to always write NUnit args to a file and call nunit with the path to the args.