### PR TITLE
Allow FSI evaluation option for FSharp.Formatting.

### DIFF
--- a/src/app/Fake.DotNet.FSFormatting/FSFormatting.fs
+++ b/src/app/Fake.DotNet.FSFormatting/FSFormatting.fs
@@ -27,7 +27,8 @@ type LiterateArguments =
       OutputDirectory : string 
       Template : string
       ProjectParameters : (string * string) list
-      LayoutRoots : string list }
+      LayoutRoots : string list 
+      FsiEval : bool }
 
 let defaultLiterateArguments =
     { ToolPath = toolPath
@@ -35,7 +36,8 @@ let defaultLiterateArguments =
       OutputDirectory = ""
       Template = ""
       ProjectParameters = []
-      LayoutRoots = [] }
+      LayoutRoots = [] 
+      FsiEval = false }
 
 let createDocs p =
     let arguments = (p:LiterateArguments->LiterateArguments) defaultLiterateArguments
@@ -45,6 +47,7 @@ let createDocs p =
     let source = arguments.Source
     let template = arguments.Template
     let outputDir = arguments.OutputDirectory
+    let fsiEval = if arguments.FsiEval then [ "--fsieval" ] else []
 
     let command = 
         arguments.ProjectParameters
@@ -52,7 +55,7 @@ let createDocs p =
         |> Seq.concat
         |> Seq.append 
                (["literate"; "--processdirectory" ] @ layoutroots @ [ "--inputdirectory"; source; "--templatefile"; template; 
-                  "--outputDirectory"; outputDir; "--replacements" ])
+                  "--outputDirectory"; outputDir] @ fsiEval @ [ "--replacements" ])
         |> Seq.map (fun s -> 
                if s.StartsWith "\"" then s
                else sprintf "\"%s\"" s)


### PR DESCRIPTION
### Description

Add an option to do FSI evaluation to FAKE wrapper for FSharp.Formatting command-line tool.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [] (if new module) the module is in the correct namespace
- [] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
