### PR TITLE
Fake.Testing.ReportGenerator: Add new ReportType "Cobertura"

### DIFF
--- a/src/app/Fake.Testing.ReportGenerator/ReportGenerator.fs
+++ b/src/app/Fake.Testing.ReportGenerator/ReportGenerator.fs
@@ -37,6 +37,7 @@ type ReportType =
     | LatexSummary
     | Badges
     | CsvSummary
+    | Cobertura
 
 type LogVerbosity =
     | Verbose = 0

--- a/src/test/Fake.Core.UnitTests/Fake.Testing.ReportGenerator.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Testing.ReportGenerator.fs
@@ -49,4 +49,13 @@ let tests =
 
       Expect.equal commandLine
         (sprintf "%s -reports:report1.xml;report2.xml -targetdir:targetDir -reporttypes:Html;MHtml -sourcedirs:source1;source2 -historydir:history -assemblyfilters:+a1*;-a2* -classfilters:+c1*;-c2* -filefilters:+f1*;-f2* -tag:mytag -verbosity:Verbose" expectedPath) "expected proper command line"
+
+    testCase "Test that ReportType Cobertura works" <| fun _ ->
+      let expectedPath, commandLine =
+        runCreateProcess (fun p ->
+          { p with 
+              ReportTypes = [ ReportGenerator.ReportType.Cobertura ] })
+
+      Expect.equal commandLine
+        (sprintf "%s -reports:report1.xml;report2.xml -targetdir:targetDir -reporttypes:Cobertura -verbosity:Verbose" expectedPath) "expected proper command line"
   ]


### PR DESCRIPTION
### Description

ReportGenrator supports a new ReportType "Cobertura"
I Added it to the list of available report types

## TODO

- [x] New (API-)documentation not needed
- [x] unit or integration test exists
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
