### PR TITLE
Append the content headers so the header `Content-Type` is included in the headers list

### DIFF
--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -612,6 +612,7 @@ type HttpClient with
         return
             result,
             response.Headers :> seq<KeyValuePair<string, seq<string>>>
+            |> Seq.append (response.Content.Headers :> seq<KeyValuePair<string, seq<string>>>)
             |> Seq.map (fun kv -> kv.Key, kv.Value |> Seq.toList)
             |> Map.ofSeq
       } |> Async.RunSynchronously


### PR DESCRIPTION
Fixes #2124

I'm not an expert with f# but it seems a simple fix and I have tested this in isolation and it fixes the bug mentioned in the other issue.

Hopefully this is ok.