### PR TITLE
Fixes api docs snippets overlapping navigation

### DIFF
--- a/help/content/assets/css/style.css
+++ b/help/content/assets/css/style.css
@@ -87,6 +87,11 @@ div.tip strong {
     color: #d1d1d1;
 }
 
+table.module-list {
+    overflow: auto;
+    display: block;
+}
+
 table.pre pre {
     padding: 0px;
     margin: 0px;


### PR DESCRIPTION
### Description

Workaround for the problem in #2161 [(Comment from @matthid)](https://github.com/fsharp/FAKE/pull/2161#issuecomment-433482679)

It's not pretty but it works for now. Seems like pre-tags inside a table inside a table with flexible width is not very easy to control.