### PR TITLE
Fake template cmd changes

### DIFF
--- a/help/markdown/fake-template.md
+++ b/help/markdown/fake-template.md
@@ -15,11 +15,11 @@ After you installed the template you can setup FAKE by running:
 <pre><code class="lang-bash">
 dotnet new fake
 </code></pre>
-This will create a default `build.fsx` file, a `paket.dependencies` file used to mangage your build dependencies and two shell scripts `fake.sh` and `fake.cmd`. The shell scripts are used to bootstrap and run FAKE. All of the arguments are passed direcly to FAKE so you can run:
+This will create a default `build.fsx` file, a `paket.dependencies` file used to mangage your build dependencies and two shell scripts `build.sh` and `build.cmd`. The shell scripts are used to bootstrap and run FAKE. All of the arguments are passed directly to FAKE so you can run:
 <pre><code class="lang-bash">
-.\fake.cmd build
+.\build.cmd
 </code></pre>
-to run your build. Have a look [this](fake-commandline.html) for the available command-line options. [This page](fake-gettingstarted.html#Example-Compiling-and-building-your-NET-application) additional information on how to use a build script.
+to run your build. Have a look [this](fake-commandline.html) for the available command-line options.
 
 ## Options
 

--- a/src/template/fake-template/Content/.template.config/template.json
+++ b/src/template/fake-template/Content/.template.config/template.json
@@ -71,8 +71,8 @@
             },
             {
                 "rename": {
-                    "fake.tool.sh": "fake.sh",
-                    "fake.tool.cmd": "fake.cmd"
+                    "fake.tool.sh": "build.sh",
+                    "fake.tool.cmd": "build.cmd"
                 }
             },
             {
@@ -81,8 +81,8 @@
             },
             {
                 "rename": {
-                    "fake.proj.sh": "fake.sh",
-                    "fake.proj.cmd": "fake.cmd"
+                    "fake.proj.sh": "build.sh",
+                    "fake.proj.cmd": "build.cmd"
                 }
             },
             {

--- a/src/template/fake-template/Content/build.fsx
+++ b/src/template/fake-template/Content/build.fsx
@@ -5,6 +5,7 @@ nuget Fake.IO.FileSystem
 nuget Fake.Core.Target //"
 //#endif
 #load ".fake/(build.fsx)/intellisense.fsx"
+
 open Fake.Core
 open Fake.DotNet
 open Fake.IO

--- a/src/template/fake-template/Content/fake.proj.cmd
+++ b/src/template/fake-template/Content/fake.proj.cmd
@@ -1,2 +1,2 @@
 dotnet restore build.proj
-dotnet fake %*
+dotnet fake build %*

--- a/src/template/fake-template/Content/fake.proj.sh
+++ b/src/template/fake-template/Content/fake.proj.sh
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 dotnet restore build.proj
-dotnet fake "$@"
+dotnet fake build "$@"

--- a/src/template/fake-template/Content/fake.tool.cmd
+++ b/src/template/fake-template/Content/fake.tool.cmd
@@ -8,4 +8,4 @@ IF NOT EXIST "%TOOL_PATH%\fake.exe" (
   rem #endif
 )
 
-"%TOOL_PATH%/fake.exe" %*
+"%TOOL_PATH%/fake.exe" build %*

--- a/src/template/fake-template/Content/fake.tool.sh
+++ b/src/template/fake-template/Content/fake.tool.sh
@@ -28,4 +28,4 @@ then
   dotnet tool install fake-cli --tool-path "$TOOL_PATH" --version (version)
 #endif
 fi
-"$FAKE" "$@"
+"$FAKE" build "$@"


### PR DESCRIPTION
### Description

Changes the bootstrapping of the fake template to provide a build.cmd/build.sh which directly calls _fake build_. For a beginner this is much easier and most projects which use FAKE later have a build batch script instead of a fake batch script anyway.