### PR TITLE
2186: Look for Paket executable without ".exe" extension on non-Windows platforms.

### DIFF
--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -33,20 +33,12 @@ type PaketPackParams =
       PinProjectReferences : bool }
 
 let private findPaketExecutable () =
-    let windowsName = "paket.exe"
-    let unixName = "paket"
+    match Tools.tryFindToolFolderInSubPath "paket" with
+    | Some folder ->
+        folder @@ "paket"
+    | None ->
+        (Tools.findToolFolderInSubPath "paket.exe" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket.exe"
 
-    let exeName =
-        if Environment.isWindows then
-            windowsName
-        else
-            if !! ("./**/" @@ unixName) |> Seq.isEmpty |> not then
-                unixName
-            else
-                windowsName
-
-    (Tools.findToolFolderInSubPath exeName (Directory.GetCurrentDirectory() @@ ".paket")) @@ exeName
-    
 /// Paket pack default parameters
 let PaketPackDefaults() : PaketPackParams =
     { ToolPath = findPaketExecutable ()

--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -32,9 +32,24 @@ type PaketPackParams =
       MinimumFromLockFile : bool
       PinProjectReferences : bool }
 
+let private findPaketExecutable () =
+    let windowsName = "paket.exe"
+    let unixName = "paket"
+
+    let exeName =
+        if Environment.isWindows then
+            windowsName
+        else
+            if !! ("./**/" @@ unixName) |> Seq.isEmpty |> not then
+                unixName
+            else
+                windowsName
+
+    (Tools.findToolFolderInSubPath exeName (Directory.GetCurrentDirectory() @@ ".paket")) @@ exeName
+    
 /// Paket pack default parameters
 let PaketPackDefaults() : PaketPackParams =
-    { ToolPath = (Tools.findToolFolderInSubPath "paket.exe" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket.exe"
+    { ToolPath = findPaketExecutable ()
       TimeOut = TimeSpan.FromMinutes 5.
       Version = null
       SpecificVersions = []
@@ -64,7 +79,7 @@ type PaketPushParams =
 
 /// Paket push default parameters
 let PaketPushDefaults() : PaketPushParams =
-    { ToolPath = (Tools.findToolFolderInSubPath "paket.exe" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket.exe"
+    { ToolPath = findPaketExecutable ()
       TimeOut = System.TimeSpan.MaxValue
       PublishUrl = null
       EndPoint =  null
@@ -84,7 +99,7 @@ type PaketRestoreParams =
 
 /// Paket restore default parameters
 let PaketRestoreDefaults() : PaketRestoreParams =
-    { ToolPath = (Tools.findToolFolderInSubPath "paket.exe" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket.exe"
+    { ToolPath = findPaketExecutable ()
       TimeOut = System.TimeSpan.MaxValue
       WorkingDir = "."
       ForceDownloadOfPackages = false

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -238,13 +238,20 @@ module Tools =
         with
         | _ -> defaultPath @@ toolname
 
+    /// Looks for a tool in all subfolders - returns the folder where the tool was found
+    /// or None if not found.
+    let tryFindToolFolderInSubPath toolname =
+        try
+            !! ("./**/" @@ toolname)
+            |> Seq.tryHead
+            |> Option.map (fun path -> 
+                let fi = FileInfo path
+                fi.Directory.FullName)            
+        with
+        | _ -> None
+
     /// Looks for a tool in all subfolders - returns the folder where the tool was found.
     let findToolFolderInSubPath toolname defaultPath =
-        try
-            let tools = !! ("./**/" @@ toolname)
-            if Seq.isEmpty tools then defaultPath
-            else 
-                let fi = FileInfo (Seq.head tools)
-                fi.Directory.FullName
-        with
-        | _ -> defaultPath
+        toolname
+        |> tryFindToolFolderInSubPath 
+        |> Option.defaultValue defaultPath

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -244,9 +244,7 @@ module Tools =
         try
             !! ("./**/" @@ toolname)
             |> Seq.tryHead
-            |> Option.map (fun path -> 
-                let fi = FileInfo path
-                fi.Directory.FullName)            
+            |> Option.map Path.GetDirectoryName
         with
         | _ -> None
 

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -241,12 +241,9 @@ module Tools =
     /// Looks for a tool in all subfolders - returns the folder where the tool was found
     /// or None if not found.
     let tryFindToolFolderInSubPath toolname =
-        try
-            !! ("./**/" @@ toolname)
-            |> Seq.tryHead
-            |> Option.map Path.GetDirectoryName
-        with
-        | _ -> None
+        !! ("./**/" @@ toolname)
+        |> Seq.tryHead
+        |> Option.map Path.GetDirectoryName
 
     /// Looks for a tool in all subfolders - returns the folder where the tool was found.
     let findToolFolderInSubPath toolname defaultPath =

--- a/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
@@ -63,7 +63,7 @@ let tests =
           Directory.Delete(testDir, true)
   ]
 
-[<FTests>]
+[<Tests>]
 let toolsTests = 
   let currentDir =
     Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)

--- a/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
@@ -72,6 +72,7 @@ let toolsTests =
       Directory.CreateDirectory folder |> ignore
       folder
   
+  // Sequenced because otherwise folders conflict with the globbing pattern '!! "./**"' in the impl.
   testSequencedGroup "Find tool paths" <|
     testList "Fake.Core.Globbing.Tools.Tests" [
       testCase "Test try find tool folder in sub path" <| fun _ ->

--- a/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.IO.Globbing.fs
@@ -1,6 +1,8 @@
 module Fake.Core.GlobbingTests
 
+open System
 open System.IO
+open System.Reflection
 open Fake.IO
 open Fake.IO.Globbing
 open Fake.IO.FileSystemOperators
@@ -60,3 +62,47 @@ let tests =
         finally
           Directory.Delete(testDir, true)
   ]
+
+[<FTests>]
+let toolsTests = 
+  let currentDir =
+    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+  let createUniqueDirectory () =
+      let folder = currentDir </> ((Guid.NewGuid ()).ToString())
+      Directory.CreateDirectory folder |> ignore
+      folder
+  
+  testSequencedGroup "Find tool paths" <|
+    testList "Fake.Core.Globbing.Tools.Tests" [
+      testCase "Test try find tool folder in sub path" <| fun _ ->
+        let folder = createUniqueDirectory ()
+
+        try
+          let filepath = folder </> "sometool"
+          File.create filepath |> ignore
+
+          Tools.tryFindToolFolderInSubPath "sometool"
+          |> Flip.Expect.equal "Expected tools folder to be found" (Some folder)
+        finally
+          Directory.Delete(folder, true)
+
+      testCase "Test cannot find tool folder in sub path" <| fun _ ->
+        Tools.tryFindToolFolderInSubPath "SomeMissingTool"
+        |> Flip.Expect.isNone "Expected tools folder not to be found"
+
+      testCase "Test find tool folder in sub path" <| fun _ ->
+        let folder = createUniqueDirectory ()
+
+        try
+          let filepath = folder </> "sometool"
+          File.create filepath |> ignore
+
+          Tools.findToolFolderInSubPath "sometool" "defaultToolsPath"
+          |> Flip.Expect.equal "Expected tools folder to be found" folder
+        finally
+          Directory.Delete(folder, true)
+
+      testCase "Test cannot find tool folder in sub path returns default" <| fun _ ->
+        Tools.findToolFolderInSubPath "SomeMissingTool" "defaultpath"
+        |> Flip.Expect.equal "Expected default path to be returned" "defaultpath"
+    ]


### PR DESCRIPTION
Looking for a file called `paket` without `.exe` extension on non-windows platforms before falling back to `paket.exe`. This is to support Paket bootstrapped in .NET Core "mode".

Fixes #2186

I could not find any tests for this module. 