### PR TITLE
Make the obvious Windows-only tools fail explicitly off the supported platform

### DIFF
--- a/src/app/Fake.DotNet.FxCop/FxCop.fs
+++ b/src/app/Fake.DotNet.FxCop/FxCop.fs
@@ -227,3 +227,5 @@ let run param (assemblies : string seq) =
         |> Proc.run
         |> failAsrequired param
         __.MarkSuccess()
+    else
+        raise <| NotSupportedException("FxCop is currently not supported on mono")

--- a/src/app/Fake.DotNet.ILMerge/ILMerge.fs
+++ b/src/app/Fake.DotNet.ILMerge/ILMerge.fs
@@ -180,3 +180,5 @@ let run parameters outputFile primaryAssembly =
             let args = getArguments outputFile primaryAssembly parameters
             failwithf "'ILMerge %s' failed." (String.separated " " args)
         __.MarkSuccess()
+    else
+        raise <| NotSupportedException("ILMerge is currently not supported on mono")

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.FxCop.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.FxCop.fs
@@ -313,7 +313,15 @@ let testCases =
                              printfn "Unexpected failure %A level=%d index=%d" x level
                                  mapIndex
                              reraise()) ]
-    else []
+    else
+        [ testCase "Test failure on non-Windows platforms" <| fun _ ->
+              let p = FxCop.Params.Create()
+              Expect.throwsC (fun () -> FxCop.run p [])
+                  (fun ex ->
+                  Expect.equal (ex.GetType()) typeof<NotSupportedException>
+                      "Exception type should be as expected"
+                  Expect.equal ex.Message "FxCop is currently not supported on mono"
+                      "Exception message should be as expected") ]
 
 [<Tests>]
 let tests = testList "Fake.DotNet.FxCop.Tests" testCases

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.ILMerge.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.ILMerge.fs
@@ -207,7 +207,17 @@ let testCases =
                                   libs |> Seq.head
                                   libs |> Seq.last ]
                   "Strings should be assigned as expected" ]
-    else []
+    else
+        [ testCase "Test failure on non-Windows platforms" <| fun _ ->
+              let p = ILMerge.Params.Create()
+              let dummy = Guid.NewGuid().ToString()
+              let dummy2 = Guid.NewGuid().ToString()
+              Expect.throwsC (fun () -> ILMerge.run p dummy dummy2)
+                  (fun ex ->
+                  Expect.equal (ex.GetType()) typeof<NotSupportedException>
+                      "Exception type should be as expected"
+                  Expect.equal ex.Message "ILMerge is currently not supported on mono"
+                      "Exception message should be as expected") ]
 
 [<Tests>]
 let tests = testList "Fake.DotNet.ILMerge.Tests" testCases


### PR DESCRIPTION
### Description

Fixes #2199, as per discussion on previous PR, to make behaviour consistent with the expressed intention across both the obviously Windows-only tools I recently PR'd

## TODO

I believe the checklist to be complete
