### PR TITLE
Make anchors have top-padding

### DIFF
--- a/help/content/assets/css/style.css
+++ b/help/content/assets/css/style.css
@@ -61,7 +61,7 @@ section.is-small {
 
 .content .anchor {
     text-decoration: none;
-    padding-top: 50px;
+    padding-top: 70px;
 }
 
 @media screen and (max-width: 768px) {

--- a/help/content/assets/css/style.css
+++ b/help/content/assets/css/style.css
@@ -61,6 +61,7 @@ section.is-small {
 
 .content .anchor {
     text-decoration: none;
+    padding-top: 50px;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
This padding makes it so that a clicked anchor is visible underneath the top sticky nav. I am not at all sure that this is the correct way to handle this situation.

### Description

- fixes #2201 by adding 50px padding.

## TODO

- [] Is this the appropriate sizing?
- [] Is there a constant that would otherwise be appropriate?
- [] Is this padding appropriate for all `.content .anchor`s?