### PR TITLE
Fix the link to FAKE header

### DIFF
--- a/help/templates/template.cshtml
+++ b/help/templates/template.cshtml
@@ -299,7 +299,7 @@
 									<ul class="has-text-grey-light">
 										<li><a href="/fake-gettingstarted.html">Getting started</a></li>
 										<li><a href="/fake-fake5-modules.html">Modules</a></li>
-										<li><a href="/fake-fake5-modules.html#Declaring-FAKE-5-Header">FAKE Header</a></li>
+										<li><a href="/fake-fake5-modules.html#Declaring-FAKE-5-dependencies-within-the-script">FAKE Header</a></li>
 									</ul>
 								</div>
 								<div class="column is-6">


### PR DESCRIPTION
According to commit `eeced8fe3fe5ab2877dbc34c107aadfebbd009fd`, FAKE Header term should be removed. For now just fixing the link.