### PR TITLE
Correct quoting used by sendPublishNamedArtifact

### DIFF
--- a/src/app/Fake.BuildServer.TeamCity/TeamCityInternal.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCityInternal.fs
@@ -99,7 +99,7 @@ module internal TeamCityWriter =
     let internal sendPublishArtifact path = sendToTeamCity(TeamCityMessage.OneParamSingleLine("##teamcity[publishArtifacts '%s']", path))
 
     /// Publish Named Artifact
-    let internal sendPublishNamedArtifact name path = sendToTeamCity(TeamCityMessage.TwoParamSingleLineBoth("##teamcity[publishArtifacts '%s' => '%s']", path, name))
+    let internal sendPublishNamedArtifact name path = sendToTeamCity(TeamCityMessage.TwoParamSingleLineBoth("##teamcity[publishArtifacts '%s => %s']", path, name))
 
     /// Build Number
     let internal sendBuildNumber buildNumber = sendToTeamCity(TeamCityMessage.OneParamSingleLine("##teamcity[buildNumber '%s']", buildNumber))


### PR DESCRIPTION
Description

This corrects the quoting used by `sendPublishNamedArtifact`

*  fixes #2236

[This replaces the PR #2237, which was based on the wrong branch].