### PR TITLE
Fsi defines

### DIFF
--- a/src/app/Fake.DotNet.Fsi/Fsi.fs
+++ b/src/app/Fake.DotNet.Fsi/Fsi.fs
@@ -75,8 +75,10 @@ type FsiParams = {
 (* - LANGUAGE - *)
     /// Generate overflow checks
     Checked: bool option
-    /// Define a conditional compilation symbols
+    /// Define a conditional compilation symbol
     Define: string
+    /// Define a list of conditional compilation symbols
+    Definitions: string list
     /// Ignore ML compatibility warnings
     MLCompatibility: bool 
 
@@ -147,6 +149,8 @@ with
         /// format a compiler arg that ends with "+" or "-" with string parameters  "--%s%s:\"%s\""
         let inline toglls s b (ls:'a list) = 
             stringEmptyMap (sprintf "--%s%s:%s" s  (chk b)) (String.concat ";" (List.map string ls))
+        /// format a list of short form complier args using the same symbol 
+        let sargmap sym ls = ls |> List.map (sargp sym)
 
         [
             argp "use" p.Use
@@ -193,7 +197,8 @@ with
             togl "readline" p.ReadLine
             togl "quotations-debug" p.QuotationsDebug       
             togl "shadowcopyreferences" p.ShadowCopyReferences
-        ]
+        ] @ (sargmap "d" p.Definitions)
+
         |> List.filter String.isNotNullOrEmpty
 
     static member Create() =
@@ -218,6 +223,7 @@ with
             ConsoleColors = None
             Checked = None
             Define = null
+            Definitions = []
             MLCompatibility = false 
             NoLogo = false
             Help = false

--- a/src/app/Fake.DotNet.Fsi/Fsi.fs
+++ b/src/app/Fake.DotNet.Fsi/Fsi.fs
@@ -75,7 +75,7 @@ type FsiParams = {
 (* - LANGUAGE - *)
     /// Generate overflow checks
     Checked: bool option
-    /// Define a conditional compilation symbol
+    /// (Obsolete) Define a conditional compilation symbol (use FsiParams.Definitions instead)
     Define: string
     /// Define a list of conditional compilation symbols
     Definitions: string list

--- a/src/app/Fake.DotNet.Fsi/Fsi.fs
+++ b/src/app/Fake.DotNet.Fsi/Fsi.fs
@@ -285,7 +285,7 @@ module internal ExternalFsi =
                 { info.WithEnvironmentVariables defaultEnvironmentVars with
                     FileName = fsiExe
                     Arguments = args
-                    WorkingDirectory = ""
+                    WorkingDirectory = parameters.WorkingDirectory
                 }.WithEnvironmentVariables (parameters.Environment |> Map.toSeq)) TimeSpan.MaxValue        
 
         if r.ExitCode <> 0 then

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\app\Fake.DotNet.AssemblyInfoFile\Fake.DotNet.AssemblyInfoFile.fsproj" />
     <ProjectReference Include="..\..\app\Fake.DotNet.Cli\Fake.DotNet.Cli.fsproj" />
+    <ProjectReference Include="..\..\app\Fake.DotNet.Fsi\Fake.DotNet.Fsi.fsproj" />
     <ProjectReference Include="..\..\app\Fake.DotNet.ILMerge\Fake.DotNet.ILMerge.fsproj" />
     <ProjectReference Include="..\..\app\Fake.DotNet.FxCop\Fake.DotNet.FxCop.fsproj" />
     <ProjectReference Include="..\..\app\Fake.IO.Zip\Fake.IO.Zip.fsproj" />
@@ -39,6 +40,7 @@
     <Compile Include="Fake.DotNet.MSBuild.fs" />
     <Compile Include="Fake.DotNet.Testing.NUnit.fs" />
     <Compile Include="Fake.DotNet.Testing.SpecFlow.fs" />
+    <Compile Include="Fake.DotNet.Fsi.fs" />
     <Compile Include="Fake.DotNet.Xdt.fs" />
     <Compile Include="Fake.Testing.ReportGenerator.fs" />
     <Compile Include="Fake.Tools.Git.fs" />

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsi.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsi.fs
@@ -1,0 +1,32 @@
+﻿module Fake.DotNet.FsiTests
+
+open Fake.DotNet
+open Expecto
+
+[<Tests>]
+let tests =
+  let isDefine (s : string) = s.StartsWith "-d:"    
+
+  testList "Fake.DotNet.Fsi.Tests" [
+    testCase "Test that default params have no defines" <| fun _ ->
+      let cmdList = Fsi.FsiParams.Create() |> Fsi.FsiParams.ToArgsList
+      Expect.isFalse (cmdList |> List.exists isDefine) "FsiParams.Create() |> FsiParams.ToArgsList should not specify -d"
+
+    testCase "Test that Define alone adds one -d flag" <| fun _ ->
+      let cmdList = { Fsi.FsiParams.Create() with Define = "DEBUG" } |> Fsi.FsiParams.ToArgsList
+      Expect.contains cmdList "-d:DEBUG" "Define=\"DEBUG\" should create the -d:DEBUG parameter"
+      Expect.hasCountOf cmdList 1u isDefine "Define should create only one -d parameter"
+
+    testCase "Test that Definitions alone adds the -d flags" <| fun _ ->
+      let cmdList = { Fsi.FsiParams.Create() with Definitions = ["DEBUG"; "GUBED"] } |> Fsi.FsiParams.ToArgsList
+      Expect.contains cmdList "-d:DEBUG" "Definitions = [\"DEBUG\"; \"GUBED\"] should create the -d:DEBUG parameter"
+      Expect.contains cmdList "-d:GUBED" "Definitions = [\"DEBUG\"; \"GUBED\"] should create the -d:GUBED parameter"
+      Expect.hasCountOf cmdList 2u isDefine "Definitions should create both -d parameters"
+
+    testCase "Test that Definitions can be used together with Define" <| fun _ ->
+      let cmdList = { Fsi.FsiParams.Create() with Definitions = ["DEBUG"; "GUBED"]; Define="BEDUG" } |> Fsi.FsiParams.ToArgsList
+      Expect.contains cmdList "-d:DEBUG" "Definitions = [\"DEBUG\"; \"GUBED\"] should create the -d:DEBUG parameter"
+      Expect.contains cmdList "-d:GUBED" "Definitions = [\"DEBUG\"; \"GUBED\"] should create the -d:GUBED parameter"
+      Expect.contains cmdList "-d:BEDUG" "Define=\"BEDUG\" should create the -d:BEDUG parameter"
+      Expect.hasCountOf cmdList 3u isDefine "Define and Definitions should all create -d parameters"
+    ]


### PR DESCRIPTION
### Description

Fixes #2259 by adding `FsiParams.Definitions` to specify multiply symbols to be defined in Fsi.
The `Define` parameter is left alone to avoid breaking the existing API.
Also passes the `WorkingDirectory` value to the process.


## TODO

- [x] Documentation (in the form of the doc-comment for the parameter, and correcting the 
- [x] unit or integration test exists
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
