### PR TITLE
Thread safe for `Path.toRelativeFrom`

### DIFF
--- a/src/app/Fake.IO.FileSystem/Path.fs
+++ b/src/app/Fake.IO.FileSystem/Path.fs
@@ -105,7 +105,7 @@ let private ProduceRelativePath baseLocation targetLocation =
             (!resultPath).Substring(2, (!resultPath).Length - 3)
         else (!resultPath).Substring(0, (!resultPath).Length - 1)
 
-let toRelativeFrom =
+let toRelativeFrom basePath value =
     /// A cache of relative path names.
     /// [omit]
     let relativePaths = new Dictionary<_, _>()
@@ -120,7 +120,7 @@ let toRelativeFrom =
             relativePaths.Add(key, x)
             x
 
-    toRelativePath
+    toRelativePath basePath value
 
 let toRelativeFromCurrent path =
     let currentDir = normalizeFileName <| Directory.GetCurrentDirectory()

--- a/src/app/Fake.IO.FileSystem/Path.fs
+++ b/src/app/Fake.IO.FileSystem/Path.fs
@@ -7,6 +7,7 @@ open Fake.Core.String.Operators
 open System
 open System.IO
 open System.Collections.Generic
+open System.Collections.Concurrent
 
 /// Combines two path strings using Path.Combine
 let inline combineTrimEnd path1 (path2 : string) = Path.Combine(path1, path2.TrimStart [| '\\'; '/' |])
@@ -105,22 +106,19 @@ let private ProduceRelativePath baseLocation targetLocation =
             (!resultPath).Substring(2, (!resultPath).Length - 3)
         else (!resultPath).Substring(0, (!resultPath).Length - 1)
 
-let toRelativeFrom basePath value =
+let toRelativeFrom =
     /// A cache of relative path names.
     /// [omit]
-    let relativePaths = new Dictionary<_, _>()
+    let relativePaths = new ConcurrentDictionary<string * string, string>()
 
     /// Replaces the absolute path to a relative path.
     let inline toRelativePath basePath value =
         let key = (basePath, value)
-        match relativePaths.TryGetValue key with
-        | true, x -> x
-        | _ -> 
-            let x = ProduceRelativePath basePath value
-            relativePaths.Add(key, x)
-            x
+        relativePaths.GetOrAdd(key, fun _ ->
+            ProduceRelativePath basePath value
+        )
 
-    toRelativePath basePath value
+    toRelativePath
 
 let toRelativeFromCurrent path =
     let currentDir = normalizeFileName <| Directory.GetCurrentDirectory()


### PR DESCRIPTION
### Description
I encounted this in async workflow
Null Reference expection was throw


[before](https://sharplab.io/#v2:DYLgZgzgNAJiDUAfA9gBwKYDsAEBlAnhAC7oC2AdAMLLDDoDGRAlsphOQOJboBOT9AWABQdItiLIASumABDZgDd0AMR7JSIbMT6YA5tgC0APi1Ed+46fPYAvMOwPsAehfYAgtnqz6AC3TZkMGweGXkmJWxUeR9sTFlSdHZ7RxcnbABtdSYiAF1kh1Fg0MV0AAVoiFtY9AB3bAARfmZWWR58AB4AfShsTqMACgBKYXznV2lUOXpE8T9sWQAjCBoAVxJI6PFkeaK5Eo2iH3JRwqZMYDP/CWk98LLNhdkIe8PsBVlgFf87IUc/7AARAAJAByMmAyABI1+jmuxTu5UOQA===)  (dictionary is global)

```fsharp
let toRelativeFrom =
    /// A cache of relative path names.
    /// [omit]
    let relativePaths = new Dictionary<_, _>()

    /// Replaces the absolute path to a relative path.
    let inline toRelativePath basePath value =
        let key = (basePath, value)
        match relativePaths.TryGetValue key with
        | true, x -> x
        | _ -> 
            let x = ProduceRelativePath basePath value
            relativePaths.Add(key, x)
            x

    toRelativePath
```

[now](https://sharplab.io/#v2:DYLgZgzgNAJiDUAfA9gBwKYDsAEBlAnhAC7oC2AdAMLLDDoDGRAlsphOQOJboBOT9AWABQdItiLIASumABDZgDd0AMR7JS2AEayI6AAryAFtgWzgAV3QhsxPpgDm2ALzDsb7AHov2AILZ6svSG6NjIYNg8MvJMStioRtiYsqTo7K7uXh7YANrqTEQAuuluohFRivpGEM6J6ADu2AAi/Myssjz4ADwA+lDY3QB8ABQAlMLFnt7SqHL0qeLB2LKaEDTmJHEJEktlchWbRIbkE6VMmMBnIRLSezGVh1o698amFiEuQu5f2ABEABIAORkwGQP3Gn3c13KdwMD20ulhLzMliAA===) (dictionary is in block)
```fsharp
let toRelativeFrom basePath value =
    /// A cache of relative path names.
    /// [omit]
    let relativePaths = new Dictionary<_, _>()

    /// Replaces the absolute path to a relative path.
    let inline toRelativePath basePath value =
        let key = (basePath, value)
        match relativePaths.TryGetValue key with
        | true, x -> x
        | _ -> 
            let x = ProduceRelativePath basePath value
            relativePaths.Add(key, x)
            x

    toRelativePath basePath value
```