### PR TITLE
Add support for MSBuild 16 / VS 2019

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -92,7 +92,7 @@ module private MSBuildExeFromVsWhere =
     open System.Diagnostics
 
     let private getAllVsPath () =
-        VsInstances.getWithPackage "Microsoft.Component.MSBuild" true
+        VsInstances.getWithPackage "Microsoft.Component.MSBuild" false
         |> List.map (fun vs -> vs.InstallationPath)
 
     let private getAllMsBuildPaths vsPath =
@@ -245,6 +245,8 @@ module private MSBuildExe =
         Trace.traceFAKE "If you encounter msbuild errors make sure you have copied the required SDKs, see https://github.com/Microsoft/msbuild/issues/1697"
     elif foundExe.Contains @"\2017\" then
         Trace.logVerbosefn "Using msbuild of VS2017 (%s), if you encounter build errors make sure you have installed the necessary workflows!" foundExe
+    elif foundExe.Contains @"\2019\" then
+        Trace.logVerbosefn "Using msbuild of VS2019 (%s), if you encounter build errors make sure you have installed the necessary workflows!" foundExe
     foundExe
 
 /// A type for MSBuild task parameters


### PR DESCRIPTION
VS2019 changes the location of MSBuild from e.g. `MSBuild\15.0\Bin` to `MSBuild\Current\Bin`. This is noted in the [VSWhere Wiki](https://github.com/Microsoft/vswhere/wiki/Find-MSBuild):

> Starting in Visual Studio 2019 Preview, MSBuild will use "Current" instead of the major version number to make it easier to invoke for different versions.

This changes the approach to search all folders within MSBuild for `Bin\MSBuild.exe` and reads the major version from the executable itself. 

The fix is as suggested by @vbfox in [a comment](https://github.com/fsharp/FAKE/issues/2271#issuecomment-470965570) to the issue. I've tested on my machine with only VS 2019 RC installed, MSBuild 16 is now picked instead of MSBuild 14.

Fixes #2271