### PR TITLE
Throw more helpful exception when directory not a git repository

### DIFF
--- a/src/app/Fake.Tools.Git/CommandHelper.fs
+++ b/src/app/Fake.Tools.Git/CommandHelper.fs
@@ -93,13 +93,17 @@ let fixPath (path:string) =
     let path = path.Trim()
     if "\\\\" <* path then path.Trim() else path.Replace('\\', '/').Trim()
 
-/// Searches the .git directory recursivly up to the root.
+/// Searches for a .git directory in the specified directory or any parent directory.
+/// <exception href="System.InvalidOperationException">Thrown when no .git directory is found.</exception>
 let findGitDir repositoryDir =
     let rec findGitDir (dirInfo:DirectoryInfo) =
         let gitDir = dirInfo.FullName + Path.directorySeparator + ".git" |> DirectoryInfo.ofPath
-        if gitDir.Exists then gitDir else findGitDir dirInfo.Parent
-
+        if gitDir.Exists then gitDir
+        elif isNull dirInfo.Parent then
+            invalidOp "Not a git repository: no .git directory found in the specified directory or any parent directory."
+        else
+            findGitDir dirInfo.Parent
 
     if String.isNullOrEmpty repositoryDir then "." else repositoryDir
-      |> DirectoryInfo.ofPath
-      |> findGitDir
+    |> DirectoryInfo.ofPath
+    |> findGitDir

--- a/src/test/Fake.Core.UnitTests/Fake.Tools.Git.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Tools.Git.fs
@@ -1,24 +1,51 @@
 module Fake.Tools.Git.Tests
 
+open System
+open System.IO
 open Fake.Core
+open Fake.IO.FileSystemOperators
 open Expecto
 
 [<Tests>]
 let tests =
-  let versionTestCases = 
-    [ "git version 2.3.2 (Apple Git-55)", "2.3.2"
-      "git version 2.4.9", "2.4.9"
-      "git version 400.44312.9 (Apple Git-60)", "400.44312.9" ]
-    |> List.map (fun (v, expected) ->
-      testCase (sprintf "Can parse git version output '%s' - #911" v) <| fun _ ->
-        let version = Fake.Tools.Git.Information.extractGitVersion v
-        Expect.equal version (SemVer.parse expected) "Version should match")
+    let versionTestCases =
+        [ "git version 2.3.2 (Apple Git-55)", "2.3.2"
+          "git version 2.4.9", "2.4.9"
+          "git version 400.44312.9 (Apple Git-60)", "400.44312.9" ]
+        |> List.map (fun (v, expected) ->
+          testCase (sprintf "Can parse git version output '%s' - #911" v) <| fun _ ->
+            let version = Information.extractGitVersion v
+            Expect.equal version (SemVer.parse expected) "Version should match")
 
-  let otherTestCases =
-    [
-      //testCase "I fail" <| fun _ ->
-      //  Expect.equal false true "example failure"
-    ]
+    testList "Fake.Tools.Git.Tests" [
+        yield! versionTestCases
 
-  versionTestCases @ otherTestCases
-  |> testList "Fake.Tools.Git.Tests" 
+        yield testCase "findGitDir finds .git directory if one exists" <| fun _ ->
+            let testDir = Path.GetTempFileName()
+            File.Delete testDir
+            Directory.CreateDirectory testDir |> ignore
+            try
+                let gitDir = testDir </> ".git"
+                let childDir = testDir </> "child"
+                Directory.CreateDirectory gitDir |> ignore
+                Directory.CreateDirectory childDir |> ignore
+
+                let result = CommandHelper.findGitDir childDir
+
+                Expect.equal result.FullName gitDir "Found .git directory does not match"
+            finally
+                Directory.Delete(testDir, true)
+
+        yield testCase "findGitDir throws invalidOp if no .git directory exists" <| fun _ ->
+            let testDir = Path.GetTempFileName()
+            File.Delete testDir
+            Directory.CreateDirectory testDir |> ignore
+            try
+                let childDir = testDir </> "child"
+                Directory.CreateDirectory childDir |> ignore
+
+                Expect.throwsT<InvalidOperationException> (fun () ->
+                    CommandHelper.findGitDir childDir |> ignore) ""
+            finally
+                Directory.Delete(testDir, true)
+   ]


### PR DESCRIPTION
When `findGitDir` reaches the root folder having not found a `.git` directory, we throw an `InvalidOperationException` with the message:

 _"Not a git repository: no .git directory found in the specified directory or any parent directory."_ 

This should be a little more helpful than the previous `NullReferenceException`, but doesn't change the API.

Fixes #2249