### PR TITLE
implement Target.initEnvironment()

### DIFF
--- a/help/markdown/core-targets.md
+++ b/help/markdown/core-targets.md
@@ -61,6 +61,7 @@ FAKE has a special param "target" which can be used to run specific targets in a
 nuget Fake.Core.Target //"
 
 open Fake.Core
+Target.initEnvironment()
 
 // *** Define Targets ***
 Target.create "Clean" (fun p ->
@@ -137,6 +138,7 @@ Example:
 nuget Fake.Core.Target //"
 
 open Fake.Core
+Target.initEnvironment()
 
 // *** Define Targets ***
 Target.create "Clean" (fun p ->


### PR DESCRIPTION
fixes https://github.com/fsharp/FAKE/issues/2283 by introducing a new API to parse the command line and set the environment.
Now you should use near the start of your script
```
Target.initEnvironment()
```
to initialize the target module.

The only other "way" that comes to mind is module initialization, but that depends on static class initialization of .NET and therefore can be a bit tricky or unexpected. Also, this way has the advantage that is not "breaking" or changing the semantics of existing scripts.