### PR TITLE
TeamCitySummary, added in ReportGenerator 4.1.3 Fixes #2300

### DIFF
--- a/src/app/Fake.Testing.ReportGenerator/ReportGenerator.fs
+++ b/src/app/Fake.Testing.ReportGenerator/ReportGenerator.fs
@@ -38,6 +38,7 @@ type ReportType =
     | Badges
     | CsvSummary
     | Cobertura
+    | TeamCitySummary
 
 type LogVerbosity =
     | Verbose = 0


### PR DESCRIPTION
### Description

ReportGenerator 4.1.3 has a TeamCitySummary flag, this PR adds the ability to specify it in Fake.

- fixes #2300 

