### PR TITLE
Add SelfContained, Force and Manifest to dotnet publish,

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -1206,8 +1206,10 @@ module DotNet =
             OutputPath: string option
             /// Defines what `*` should be replaced with in version field in project.json (--version-suffix)
             VersionSuffix: string option
-            /// The path to a target manifest file that contains the list of packages to be excluded from the publish step. (--manifest)
-            Manifest: string option
+            /// Specifies one or several target manifests to use to trim the set of packages published with the app.
+            /// The manifest file is part of the output of the dotnet store command.
+            /// This option is available starting with .NET Core 2.0 SDK. (--manifest)
+            Manifest: string list option
             /// Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
             /// The default is 'true' if a runtime identifier is specified. (--self-contained)
             SelfContained: bool option
@@ -1262,11 +1264,11 @@ module DotNet =
             param.BuildBasePath |> Option.toList |> argList2 "build-base-path"
             param.OutputPath |> Option.toList |> argList2 "output"
             param.VersionSuffix |> Option.toList |> argList2 "version-suffix"
-            param.Manifest |> Option.toList |> argList2 "manifest"
+            param.Manifest |> Option.toList |> List.collect id |> argList2 "manifest"
             param.NoBuild |> argOption "no-build"
             param.NoRestore |> argOption "no-restore"
             param.SelfContained |> Option.map (argOptionExplicit "self-contained") |> Option.defaultValue []
-            param.Force |> Option.map (argOptionExplicit "force") |> Option.defaultValue []
+            param.Force |> Option.map (argOption "force") |> Option.defaultValue []
         ]
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Cli.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Cli.fs
@@ -43,4 +43,17 @@ let tests =
             let expected = "--disable-buffering --api-key abc123 --no-symbols --no-service-endpoint --source MyNuGetSource --symbol-api-key MySymbolApiKey --symbol-source MySymbolSource --timeout 300"
                 
             Expect.equal cli expected "Push args generated correctly."
+
+        testCase "Test that the dotnet publish self-contained works as expected" <| fun _ ->
+            let param =
+                { DotNet.PublishOptions.Create() with
+                    SelfContained = Some false }
+            let cli =
+                param
+                |> DotNet.buildPublishArgs
+                |> Args.toWindowsCommandLine
+    
+            let expected = "--configuration Release --self-contained=false"
+                
+            Expect.equal cli expected "Push args generated correctly."
     ]

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Cli.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Cli.fs
@@ -56,4 +56,30 @@ let tests =
             let expected = "--configuration Release --self-contained=false"
                 
             Expect.equal cli expected "Push args generated correctly."
+        
+        testCase "Test that the dotnet publish force works as expected" <| fun _ ->
+            let param =
+                { DotNet.PublishOptions.Create() with
+                    Force = Some true }
+            let cli =
+                param
+                |> DotNet.buildPublishArgs
+                |> Args.toWindowsCommandLine
+    
+            let expected = "--configuration Release --force"
+                
+            Expect.equal cli expected "Push args generated correctly."
+
+        testCase "Test that the dotnet publish manifest works as expected" <| fun _ ->
+            let param =
+                { DotNet.PublishOptions.Create() with
+                    Manifest = Some ["Path1"; "Path2"] }
+            let cli =
+                param
+                |> DotNet.buildPublishArgs
+                |> Args.toWindowsCommandLine
+    
+            let expected = "--configuration Release --manifest Path1 --manifest Path2"
+                
+            Expect.equal cli expected "Push args generated correctly."
     ]


### PR DESCRIPTION
### Description

Dotnet publish parameters lacked `self-contained` param. Without it it is not possible to do publish for specific runtime without embedding the runtime.  While editing it I have added two other missing params - `force` and `manifest`.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored
