### PR TITLE
Release 5.13.7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,8 @@
 # Release Notes
 
-## 5.13.7-alpha - tbd
+## 5.13.7 - 2019-05-11
 
 * BUGFIX: Xamarin Android x86_64 build fails - https://github.com/fsharp/FAKE/issues/2313
-* tbd
 
 ## 5.13.6 - 2019-05-11
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## 5.13.7-alpha - tbd
 
+* BUGFIX: Xamarin Android x86_64 build fails - https://github.com/fsharp/FAKE/issues/2313
 * tbd
 
 ## 5.13.6 - 2019-05-11

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 5.13.7-alpha - tbd
+
+* tbd
+
 ## 5.13.6 - 2019-05-11
 
 * BUGFIX: update dependencies (Paket.Core update to 5.206)

--- a/src/app/Fake.DotNet.Xamarin/Xamarin.fs
+++ b/src/app/Fake.DotNet.Xamarin/Xamarin.fs
@@ -313,7 +313,7 @@ let AndroidBuildPackages setParams =
                        | AndroidAbiTarget.ArmEabi _ -> "armeabi"
                        | AndroidAbiTarget.ArmEabiV7a _ -> "armeabi-v7a"
                        | AndroidAbiTarget.Arm64V8a _ -> "arm64-v8a"
-                       | AndroidAbiTarget.X86And64 _ -> "X86_64"
+                       | AndroidAbiTarget.X86And64 _ -> "x86_64"
                        | _ -> ""
 
     let createTargetPackage param (manifestFile:string) (target:AndroidAbiTarget) transformVersion =


### PR DESCRIPTION

* BUGFIX: Xamarin Android x86_64 build fails - https://github.com/fsharp/FAKE/issues/2313