### PR TITLE
update paths for VS2019

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -130,6 +130,11 @@ module private MSBuildExeFromVsWhere =
 module private MSBuildExe =
   let knownMSBuildEntries =
     [
+        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin"
+                                     @"\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\15.0\Bin"] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -130,11 +130,10 @@ module private MSBuildExeFromVsWhere =
 module private MSBuildExe =
   let knownMSBuildEntries =
     [
-        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin"
-                                     @"\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\15.0\Bin"] }
+        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" ] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"

--- a/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
+++ b/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
@@ -8,7 +8,10 @@ open Fake.Testing.Common
 
 /// [omit]
 let mstestPaths = 
-    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
+    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Professional\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Community\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 

--- a/src/legacy/FakeLib/MSBuildHelper.fs
+++ b/src/legacy/FakeLib/MSBuildHelper.fs
@@ -28,11 +28,10 @@ type MsBuildEntry = {
 [<System.Obsolete("Use Fake.DotNet.MSBuild instead")>]
 let knownMsBuildEntries =
     [
-        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin"
-                                     @"\MSBuild\15.0\Bin"
-                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\15.0\Bin"] }
+        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" ] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"

--- a/src/legacy/FakeLib/MSBuildHelper.fs
+++ b/src/legacy/FakeLib/MSBuildHelper.fs
@@ -28,6 +28,11 @@ type MsBuildEntry = {
 [<System.Obsolete("Use Fake.DotNet.MSBuild instead")>]
 let knownMsBuildEntries =
     [
+        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin"
+                                     @"\MSBuild\15.0\Bin"
+                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\15.0\Bin"] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"

--- a/src/legacy/FakeLib/UnitTest/MSTest.fs
+++ b/src/legacy/FakeLib/UnitTest/MSTest.fs
@@ -7,7 +7,10 @@ open System.Text
 /// [omit]
 [<System.Obsolete("use Fake.DotNet.Testing.MSTest instead")>]
 let mstestPaths = 
-    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
+    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\"; 
+       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Professional\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Community\Common7\IDE\"; 
        @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 


### PR DESCRIPTION
The MSBuild for VS2019 is not found by default when building from a VS2019 command prompt. I've also updated some other paths I've found. Untested, I just noticed this in the latest Fabulous repo

@jackfoxy I'm not sure if the "vswhere" stuff solves this?