### PR TITLE
Fix for #2361

### DIFF
--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -33,11 +33,11 @@ type PaketPackParams =
       PinProjectReferences : bool }
 
 let private findPaketExecutable () =
-    match Tools.tryFindToolFolderInSubPath "paket" with
+    match Tools.tryFindToolFolderInSubPath "paket.exe" with
     | Some folder ->
-        folder @@ "paket"
+        folder @@ "paket.exe" 
     | None ->
-        (Tools.findToolFolderInSubPath "paket.exe" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket.exe"
+        (Tools.findToolFolderInSubPath "paket" (Directory.GetCurrentDirectory() @@ ".paket")) @@ "paket"
 
 /// Paket pack default parameters
 let PaketPackDefaults() : PaketPackParams =


### PR DESCRIPTION
### Description

Fixes #2361 by inverting the original logic.
The code used to first search for `paket`. On Windows when using the paket dotnet tool installed with `-toolpath`, this would find a `paket` subfolder of the dotnet tool.
It would never reach the code to search for`paket.exe`.

I've changed this to first search for `paket.exe`, if not found, then it will search for `paket`.