### PR TITLE
Support VSTest parallel test execution setting

### DIFF
--- a/src/app/Fake.DotNet.Testing.VSTest/Fake.DotNet.Testing.VSTest.fsproj
+++ b/src/app/Fake.DotNet.Testing.VSTest/Fake.DotNet.Testing.VSTest.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NO_DOTNETCORE_BOOTSTRAP</DefineConstants>
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="VisibleTo.fs" />
     <Compile Include="VSTest.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -30,6 +30,8 @@ type VSTestParams =
       SettingsPath : string
       /// Names of the tests that should be run (optional).
       Tests : seq<string>
+      /// Enables parallel test execution (optional).
+      Parallel : bool
       /// Enables code coverage collection (optional).
       EnableCodeCoverage : bool
       /// Run the tests in an isolated process (optional).
@@ -69,6 +71,7 @@ type VSTestParams =
 let private VSTestDefaults = 
     { SettingsPath = null
       Tests = []
+      Parallel = false
       EnableCodeCoverage = false
       InIsolation = true
       UseVsixExtensions = false
@@ -100,6 +103,7 @@ let buildArgs (parameters : VSTestParams) (assembly: string) =
     |> StringBuilder.appendIfTrue (assembly <> null) assembly
     |> StringBuilder.appendIfNotNull parameters.SettingsPath "/Settings:"
     |> StringBuilder.appendIfTrue (testsToRun <> null) testsToRun
+    |> StringBuilder.appendIfTrue parameters.Parallel "/Parallel"
     |> StringBuilder.appendIfTrue parameters.EnableCodeCoverage "/EnableCodeCoverage"
     |> StringBuilder.appendIfTrue parameters.InIsolation "/InIsolation"
     |> StringBuilder.appendIfTrue parameters.UseVsixExtensions "/UseVsixExtensions:true"

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -86,7 +86,7 @@ let private VSTestDefaults =
       ListLoggers = false
       ListSettingsProviders = false
       ToolPath = 
-          match Process.tryFindFile vsTestPaths vsTestExe with
+          match ProcessUtils.tryFindFile vsTestPaths vsTestExe with
           | Some path -> path
           | None -> ""
       WorkingDir = null

--- a/src/app/Fake.DotNet.Testing.VSTest/VisibleTo.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VisibleTo.fs
@@ -1,0 +1,6 @@
+
+namespace System
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleTo("Fake.Core.UnitTests")>]
+do ()

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\app\Fake.DotNet.Fsi\Fake.DotNet.Fsi.fsproj" />
     <ProjectReference Include="..\..\app\Fake.DotNet.ILMerge\Fake.DotNet.ILMerge.fsproj" />
     <ProjectReference Include="..\..\app\Fake.DotNet.FxCop\Fake.DotNet.FxCop.fsproj" />
+    <ProjectReference Include="..\..\app\Fake.DotNet.Testing.VSTest\Fake.DotNet.Testing.VSTest.fsproj" />
     <ProjectReference Include="..\..\app\Fake.IO.Zip\Fake.IO.Zip.fsproj" />
     <ProjectReference Include="..\..\app\Fake.IO.FileSystem\Fake.IO.FileSystem.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Tools.Git\Fake.Tools.Git.fsproj" />
@@ -41,6 +42,7 @@
     <Compile Include="Fake.DotNet.MSBuild.fs" />
     <Compile Include="Fake.DotNet.NuGet.fs" />
     <Compile Include="Fake.DotNet.Testing.NUnit.fs" />
+    <Compile Include="Fake.DotNet.Testing.VSTest.fs" />
     <Compile Include="Fake.DotNet.Testing.SpecFlow.fs" />
     <Compile Include="Fake.DotNet.Fsi.fs" />
     <Compile Include="Fake.DotNet.Xdt.fs" />

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.VSTest.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.VSTest.fs
@@ -33,4 +33,29 @@ let tests =
         Expect.sequenceEqual args ["assembly.dll"; "/InIsolation"] "Expected arg file to be correct"
         )
       Expect.isFalse (File.Exists argFile) "File should be deleted"
+
+    testCase "Test that we can set Parallel setting" <| fun _ ->
+        let cp =
+          VSTest.createProcess Path.GetTempFileName (fun param ->
+            { param with
+                ToolPath = "vstest.console.exe"
+                Parallel = true
+                }) [| "assembly1.dll"; "assembly2.dll" |]
+        let file, args =
+          match cp.Command with
+          | RawCommand(file, args) -> file, args
+          | _ -> failwithf "expected RawCommand"
+          |> ArgumentHelper.checkIfMono
+        Expect.equal file "vstest.console.exe" "Expected vstest.console.exe"
+        Expect.equal (args |> Arguments.toArray).Length 1 "expected a single argument"
+        let arg = (args |> Arguments.toArray).[0]
+        Expect.stringStarts arg "@" "Expected arg to start with @"
+        let argFile = arg.Substring(1)
+        
+        ( use _state = cp.Hook.PrepareState()
+          let contents = File.ReadAllText argFile
+          let args = Args.fromWindowsCommandLine contents
+          Expect.sequenceEqual args ["assembly1.dll"; "assembly2.dll"; "/Parallel"; "/InIsolation"] "Expected arg file to be correct"
+          )
+        Expect.isFalse (File.Exists argFile) "File should be deleted"
   ]

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.VSTest.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.VSTest.fs
@@ -1,0 +1,36 @@
+﻿module Fake.DotNet.Testing.VSTestTests
+
+open System.IO
+open Fake.Core
+open Fake.DotNet
+open Fake.DotNet.Testing
+open Fake.Testing
+open Expecto
+
+[<Tests>]
+let tests =
+  testList "Fake.DotNet.Testing.VSTest.Tests" [
+    testCase "Test that we write and delete arguments file" <| fun _ ->
+      let cp =
+        VSTest.createProcess Path.GetTempFileName (fun param ->
+          { param with
+              ToolPath = "vstest.exe"
+              }) [| "assembly.dll" |]
+      let file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+        |> ArgumentHelper.checkIfMono
+      Expect.equal file "vstest.exe" "Expected vstest.exe"
+      Expect.equal (args |> Arguments.toArray).Length 1 "expected a single argument"
+      let arg = (args |> Arguments.toArray).[0]
+      Expect.stringStarts arg "@" "Expected arg to start with @"
+      let argFile = arg.Substring(1)
+      
+      ( use _state = cp.Hook.PrepareState()
+        let contents = File.ReadAllText argFile
+        let args = Args.fromWindowsCommandLine contents
+        Expect.sequenceEqual args ["assembly.dll"; "/InIsolation"] "Expected arg file to be correct"
+        )
+      Expect.isFalse (File.Exists argFile) "File should be deleted"
+  ]


### PR DESCRIPTION
This PR enables the use of `/Parallel` setting in `vstest.console.exe`.

I haven't added `/Parallel` to the legacy counterpart at https://github.com/fsharp/FAKE/blob/1f8de0538209376f73e964f71957ddb6dabaa45c/src/legacy/FakeLib/UnitTest/VSTest.fs#L34. Please let me know if the setting is also required there.

See these references for more details about the setting:

 - https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2017
 - https://devblogs.microsoft.com/devops/parallel-test-execution/


## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design) is honored