### PR TITLE
Add the extra OpenCover registration options (for skipping COM regist…

### DIFF
--- a/src/app/Fake.DotNet.Testing.OpenCover/OpenCover.fs
+++ b/src/app/Fake.DotNet.Testing.OpenCover/OpenCover.fs
@@ -12,7 +12,9 @@ module Fake.DotNet.Testing.OpenCover
         | Manual
         | Register
         | RegisterUser
-    
+        | Path32
+        | Path64
+
     type HideSkippedType =
         | All
         | File
@@ -102,7 +104,9 @@ module Fake.DotNet.Testing.OpenCover
                     (match param.Register with
                     | Manual -> String.Empty
                     | Register -> printParam "register"
-                    | RegisterUser -> printParamWithValue "register" "user")
+                    | RegisterUser -> printParamWithValue "register" "user"
+                    | Path32 -> printParamWithValue "register" "Path32"
+                    | Path64 -> printParamWithValue "register" "Path64")
             |> StringBuilder.appendIfTrueWithoutQuotes (String.isNotNullOrEmpty param.Filter) (printParamWithValue "filter" (quote param.Filter))
             |> StringBuilder.appendIfTrueWithoutQuotes param.MergeByHash (printParam "mergebyhash")
             |> StringBuilder.appendIfTrueWithoutQuotes (not param.ExcludeByAttribute.IsEmpty) (printParamListAsValuesWithQuote "excludebyattribute" param.ExcludeByAttribute)


### PR DESCRIPTION
### Description

- fixes #2386

## TODO

- [X] unit or integration test exists (or short reasoning why it doesn't make sense)

As there are currently none for the module, the change by itself is a minimal increment of technical debt.
