### PR TITLE
Limit msbuild escaped characters to the minimum

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -513,7 +513,9 @@ module MSBuild =
         //
         // See https://github.com/fsharp/FAKE/issues/2112 and https://github.com/fsharp/FAKE/issues/2392
         // for some history on this problem
-        v.Replace(";", "%3B").Replace(",", "%2C")
+        v.Replace("%", "%25")
+         .Replace(";", "%3B")
+         .Replace(",", "%2C")
 
     let properties =
         p.Properties

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -501,19 +501,19 @@ module MSBuild =
         | [] -> None
         | t -> Some("t", t |> Seq.map (String.replace "." "_") |> String.separated ";")
 
-    // see https://github.com/fsharp/FAKE/issues/2112
     let escapePropertyValue (v:string) =
-        // https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-special-characters?view=vs-2017
-        v.Replace("%", "%25")
-         .Replace("\\", "%5C")
-         .Replace("\"", "%22")
-         .Replace(";", "%3B")
-         .Replace(",", "%2C")
-         .Replace("$", "%24")
-         .Replace("@", "%40")
-         .Replace("'", "%27")
-         .Replace("?", "%3F")
-         .Replace("*", "%2A")
+        // This list has been found by trial and error but isn't perfect.
+        //
+        // Neither escaping everything (breaks <UsingTask AssemblyFile="$(Path)"" />)
+        // nor only what's documented by Microsoft at https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-special-characters?view=vs-2017
+        // (same problem with paths and ',' isn't covered but is still required to escape) works.
+        //
+        // This escape isn't perfect, mainly passing a a parameter with a ',' inside to a part of
+        // msbuild that doesn't support '%' escaping doesn't work but it's good for 99% of use cases.
+        //
+        // See https://github.com/fsharp/FAKE/issues/2112 and https://github.com/fsharp/FAKE/issues/2392
+        // for some history on this problem
+        v.Replace(";", "%3B").Replace(",", "%2C")
 
     let properties =
         p.Properties

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -14,8 +14,8 @@ let tests =
               ConsoleLogParameters = []
               Properties = ["OutputPath", "C:\\Test\\"] })
       let expected =
-        if Environment.isUnix then "/p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"    
-        else "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"    
+        if Environment.isUnix then "/p:RestorePackages=False /p:OutputPath=C:\\Test\\"
+        else "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:\\Test\\"
       Expect.equal cmdLine expected "Expected a given cmdline."
     testCase "Test that /restore is included #2160" <| fun _ ->
       let _, cmdLine =
@@ -24,7 +24,7 @@ let tests =
               ConsoleLogParameters = []
               DoRestore = true })
       let expected =
-        if Environment.isUnix then "/restore /p:RestorePackages=False"    
-        else "/restore /m /nodeReuse:False /p:RestorePackages=False"    
+        if Environment.isUnix then "/restore /p:RestorePackages=False"
+        else "/restore /m /nodeReuse:False /p:RestorePackages=False"
       Expect.equal cmdLine expected "Expected a given cmdline."
   ]


### PR DESCRIPTION
It's not a perfect solution but it will already solve the biggest problem (paths)

The always-working-solution of generating `/p:X="foo bar"` would be nice but require access to the low level msvcrt escaping and of producing non escaped arguments (like https://github.com/vbfox/FoxSharp/blob/master/src/BlackFox.CommandLine/MsvcrCommandLine.fs#L65 ) and that would require some changes to the command line escaping API or ugly code.

Also it looks always working but I didn't test it on linux or via the dotnet.exe wrapper so one day maybe.

Fixes #2392