### PR TITLE
Make Paket.restore include the "restore" argument (fixes #2411)

### DIFF
--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -256,7 +256,7 @@ let getDependenciesForReferencesFile (referencesFile:string) =
 let restore setParams =
     let parameters : PaketRestoreParams = PaketRestoreDefaults() |> setParams
     let args =
-        Arguments.Empty
+        Arguments.OfArgs ["restore"]
         |> Arguments.appendNotEmpty "--group" parameters.Group
         |> Arguments.appendIf parameters.ForceDownloadOfPackages "--force"
         |> Arguments.appendIf parameters.OnlyReferencedFiles "--only-referenced"


### PR DESCRIPTION
### Description

Adds "restore" to the start of the list of arguments passed to Paket by `Paket.restore`.

- fixes #2411 
