### PR TITLE
Fix #2423: Coverlet: don't use implicit yield

### DIFF
--- a/src/app/Fake.DotNet.Testing.Coverlet/Coverlet.fs
+++ b/src/app/Fake.DotNet.Testing.Coverlet/Coverlet.fs
@@ -89,28 +89,28 @@ let withMSBuildArguments (param: CoverletParams -> CoverletParams) (args: MSBuil
     let param = param defaults
     let properties =
         [
-            "CollectCoverage", "true"
-            "OutputFormat", outputFormatToString param.OutputFormat
-            "CoverletOutput", param.Output
+            yield "CollectCoverage", "true"
+            yield "OutputFormat", outputFormatToString param.OutputFormat
+            yield "CoverletOutput", param.Output
             if not (List.isEmpty param.Include) then
-                "Include", namespacesToString param.Include
+                yield "Include", namespacesToString param.Include
             if not (List.isEmpty param.Exclude) then
-                "Exclude", namespacesToString param.Exclude
+                yield "Exclude", namespacesToString param.Exclude
             if not (List.isEmpty param.ExcludeByAttribute) then
-                "ExcludeByAttribute", String.concat "," param.ExcludeByAttribute
+                yield "ExcludeByAttribute", String.concat "," param.ExcludeByAttribute
             if not (List.isEmpty param.ExcludeByFile) then
-                "ExcludeByFile", String.concat "," param.ExcludeByFile
+                yield "ExcludeByFile", String.concat "," param.ExcludeByFile
             match param.MergeWith with
-            | Some f -> "MergeWith", f
+            | Some f -> yield "MergeWith", f
             | None -> ()
             match param.Threshold with
             | Some t ->
-                "Threshold", string t
-                "ThresholdType", thresholdTypeToString param.ThresholdType
-                "ThresholdStat", thresholdStatToString param.ThresholdStat
+                yield "Threshold", string t
+                yield "ThresholdType", thresholdTypeToString param.ThresholdType
+                yield "ThresholdStat", thresholdStatToString param.ThresholdStat
             | None -> ()
             if param.UseSourceLink then
-                "UseSourceLink", "true"
+                yield "UseSourceLink", "true"
         ]
     { args with Properties = args.Properties @ properties }
 

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.Coverlet.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Testing.Coverlet.fs
@@ -34,7 +34,8 @@ let tests =
                     ThresholdStat = Coverlet.ThresholdStat.Total
                     UseSourceLink = true
                 })
-            Expect.containsAll [
+            Expect.isTrue (props.Length > 0) "Result should contain some elements"
+            Expect.containsAll props [
                 "CollectCoverage", "true"
                 "CoverletOutput", "coverage.json"
                 "OutputFormat", "cobertura"
@@ -47,13 +48,14 @@ let tests =
                 "ThresholdType", "branch"
                 "ThresholdStat", "total"
                 "UseSourceLink", "true"
-            ] props "expected proper MSBuild properties"
+            ] "expected proper MSBuild properties"
 
         testCase "Test that default properties are converted" <| fun _ ->
             let props = getProps id
-            Expect.containsAll [
+            Expect.isTrue (props.Length > 0) "Result should contain some elements"
+            Expect.containsAll props [
                 "CollectCoverage", "true"
                 "CoverletOutput", "./"
                 "OutputFormat", "json"
-            ] props "expected proper MSBuild properties"
+            ] "expected proper MSBuild properties"
     ]


### PR DESCRIPTION
Use explicit yield to construct the MSBuild param list to make sure that they don't get ignored by an older language version.