### PR TITLE
Suppress copyright messages when invoking `dotnet build`

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -1420,6 +1420,8 @@ module DotNet =
             OutputPath: string option
             /// Native flag (--native)
             Native: bool
+            /// Don't show copyright messages. (--nologo)
+            NoLogo: bool
             /// Doesn't execute an implicit restore during build. (--no-restore)
             NoRestore: bool
             /// Other msbuild specific parameters
@@ -1435,6 +1437,7 @@ module DotNet =
             BuildBasePath = None
             OutputPath = None
             Native = false
+            NoLogo = false
             NoRestore = false
             MSBuildParams = MSBuild.CliArguments.Create()
         }
@@ -1463,6 +1466,7 @@ module DotNet =
             param.BuildBasePath |> Option.toList |> argList2 "build-base-path"
             param.OutputPath |> Option.toList |> argList2 "output"
             (if param.Native then [ "--native" ] else [])
+            (if param.NoLogo then [ "--nologo" ] else [])
             param.NoRestore |> argOption "no-restore"
         ]
         |> List.concat


### PR DESCRIPTION
### Description

Suppress copyright messages when invoking `dotnet build`.

Currently, there is no easy way to do that.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
