### PR TITLE
Decrease footer z-index so that main menu is not hidden behind it

### DIFF
--- a/help/content/assets/css/style.css
+++ b/help/content/assets/css/style.css
@@ -27,7 +27,7 @@ a i.fa {
 
 footer {
     position: relative;
-    z-index: 99;
+    z-index: 98;
 }
 
 footer ul li {


### PR DESCRIPTION
Main menu is hidden behind footer. This change decreases footer z-index in CSS so that main menu has higher z-index and is always above footer.

![fake-mainmenu-footer-hide](https://user-images.githubusercontent.com/4727257/71006407-97869280-20e5-11ea-8992-b1910b8fedeb.jpg)