### PR TITLE
Fixed "Visual Studio for Windows" download link

### DIFF
--- a/help/markdown/contributing.md
+++ b/help/markdown/contributing.md
@@ -34,7 +34,7 @@ For FAKE development, [Visual Studio Code](https://code.visualstudio.com/Downloa
 
 - JetBrains Rider [[download](https://www.jetbrains.com/rider/download)]
 - Visual Studio for Mac [[download](https://visualstudio.microsoft.com/vs/mac/)]
-- Visual Studio for Windows [[download](https://www.jetbrains.com/rider/download)]
+- Visual Studio for Windows [[download](https://visualstudio.microsoft.com/vs/)]
 
 
 ### Install FAKE


### PR DESCRIPTION
Fixed "Visual Studio for Windows" download link on the Contributing page.