### PR TITLE
Pass instance of Diagnostics.Process for addOnStarted

### DIFF
--- a/src/app/Fake.Core.Process/CreateProcess.fs
+++ b/src/app/Fake.Core.Process/CreateProcess.fs
@@ -334,12 +334,23 @@ module CreateProcess =
             (fun prev state exitCode -> prev)
             (fun _ -> f ())
     /// Execute the given function right after the process is started.
-    /// PID for process can be obtained from p parameter (p.Id).
     let addOnStarted f (c:CreateProcess<_>) =
         c
         |> appendSimpleFuncs 
             ignore
-            (fun state p -> f (p))
+            (fun state p -> f ())
+            (fun prev state exitCode -> prev)
+            ignore
+
+    type StartedProcessInfo = { Process : Process }
+    
+    /// Execute the given function right after the process is started.
+    /// PID for process can be obtained from p parameter (p.Process.Id).
+    let addOnStartedEx f (c:CreateProcess<_>) =
+        c
+        |> appendSimpleFuncs 
+            ignore
+            (fun state p -> f { Process = p })
             (fun prev state exitCode -> prev)
             ignore
 

--- a/src/app/Fake.Core.Process/CreateProcess.fs
+++ b/src/app/Fake.Core.Process/CreateProcess.fs
@@ -354,7 +354,7 @@ module CreateProcess =
         c
         |> appendSimpleFuncs 
             ignore
-            (fun state p -> f { Process = p })
+            (fun state p -> f { InternalProcess = p })
             (fun prev state exitCode -> prev)
             ignore
 

--- a/src/app/Fake.Core.Process/CreateProcess.fs
+++ b/src/app/Fake.Core.Process/CreateProcess.fs
@@ -52,6 +52,12 @@ type CreateProcess<'TRes> =
     member x.WorkingDirectory = x.InternalWorkingDirectory
     member x.Environment = x.InternalEnvironment
 
+/// Some information regaring the started process
+type StartedProcessInfo =
+    internal {
+        InternalProcess : Process
+    }
+    member x.Process = x.InternalProcess
 
 /// Module for creating and modifying CreateProcess<'TRes> instances.
 /// You can manage:
@@ -341,12 +347,10 @@ module CreateProcess =
             (fun state p -> f ())
             (fun prev state exitCode -> prev)
             ignore
-
-    type StartedProcessInfo = { Process : Process }
     
     /// Execute the given function right after the process is started.
     /// PID for process can be obtained from p parameter (p.Process.Id).
-    let addOnStartedEx f (c:CreateProcess<_>) =
+    let addOnStartedEx (f:StartedProcessInfo -> _) (c:CreateProcess<_>) =
         c
         |> appendSimpleFuncs 
             ignore

--- a/src/app/Fake.Core.Process/CreateProcess.fs
+++ b/src/app/Fake.Core.Process/CreateProcess.fs
@@ -333,12 +333,13 @@ module CreateProcess =
             (fun state p -> ())
             (fun prev state exitCode -> prev)
             (fun _ -> f ())
-    /// Execute the given function right after the process is started.          
+    /// Execute the given function right after the process is started.
+    /// PID for process can be obtained from p parameter (p.Id).
     let addOnStarted f (c:CreateProcess<_>) =
         c
         |> appendSimpleFuncs 
             ignore
-            (fun state p -> f ())
+            (fun state p -> f (p))
             (fun prev state exitCode -> prev)
             ignore
 


### PR DESCRIPTION
### Description

Pass instance of Diagnostics.Process for created process for function used in addOnStarted
This feature was approved in [gitter](https://gitter.im/fsharp/FAKE?at=5df7c30bc6ce6027ebd1647d)
