### PR TITLE
Update keepachangelog.com URL to latest version

### DIFF
--- a/src/app/Fake.Core.ReleaseNotes/Changelog.fs
+++ b/src/app/Fake.Core.ReleaseNotes/Changelog.fs
@@ -1,5 +1,5 @@
 /// Contains helpers which allow to parse Change log text files.
-/// These files have to be in a format as described on http://keepachangelog.com/en/0.1.0/
+/// These files have to be in a format as described on http://keepachangelog.com/en/1.1.0/
 ///
 /// ## Sample
 ///

--- a/src/legacy/FakeLib/ChangeLogHelper.fs
+++ b/src/legacy/FakeLib/ChangeLogHelper.fs
@@ -1,5 +1,5 @@
 /// Contains helpers which allow to parse Change log text files.
-/// These files have to be in a format as described on http://keepachangelog.com/en/0.3.0/
+/// These files have to be in a format as described on http://keepachangelog.com/en/1.1.0/
 ///
 /// ## Sample
 ///


### PR DESCRIPTION
### Description

The links to https://keepachangelog.com/ in the documentation are old, and one of them (which links to version 0.1.0 of KaC) is now a 404. This PR updates those links to point to the latest version of the KaC spec.