### PR TITLE
Fix Paket.restore references-files

### DIFF
--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -151,7 +151,7 @@ let internal createProcess (runType:StartType) =
         |> Arguments.appendNotEmpty "--group" parameters.Group
         |> Arguments.appendIf parameters.ForceDownloadOfPackages "--force"
         |> Arguments.appendIf parameters.OnlyReferencedFiles "--only-referenced"
-        |> List.foldBack (fun ref -> Arguments.append ["--reference-files"; ref]) parameters.ReferenceFiles
+        |> List.foldBack (fun ref -> Arguments.append ["--references-files"; ref]) parameters.ReferenceFiles
         |> startPaket parameters.ToolType parameters.ToolPath parameters.WorkingDir parameters.TimeOut
 
 /// Creates a new NuGet package by using Paket pack on all paket.template files in the working directory.

--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -151,7 +151,7 @@ let internal createProcess (runType:StartType) =
         |> Arguments.appendNotEmpty "--group" parameters.Group
         |> Arguments.appendIf parameters.ForceDownloadOfPackages "--force"
         |> Arguments.appendIf parameters.OnlyReferencedFiles "--only-referenced"
-        |> List.foldBack (fun ref -> Arguments.append ["--references-files"; ref]) parameters.ReferenceFiles
+        |> List.foldBack (fun ref -> Arguments.append ["--references-file"; ref]) parameters.ReferenceFiles
         |> startPaket parameters.ToolType parameters.ToolPath parameters.WorkingDir parameters.TimeOut
 
 /// Creates a new NuGet package by using Paket pack on all paket.template files in the working directory.


### PR DESCRIPTION
### Description
This PR fixes #2473 

Since the changes from 225b9b54668a72c1c245e859bef82cd7c3a68910 `Paket.restore` won't work when using the RestoreParams `ReferenceFiles`. For ReferenceFiles it uses the Paket argument `--reference-files` but the `s` is missplaced. Actual argument is `--references-file` (See [Paket restore command](https://fsprojects.github.io/Paket/paket-restore.html))