### PR TITLE
Gitlab collapsible trace reporter

### DIFF
--- a/src/app/Fake.BuildServer.GitLab/GitLab.fs
+++ b/src/app/Fake.BuildServer.GitLab/GitLab.fs
@@ -186,11 +186,15 @@ module GitLab =
                 | TraceData.LogMessage(text, newLine) | TraceData.TraceMessage(text, newLine) ->
                     write false color newLine text
                 | TraceData.OpenTag (tag, descr) ->
+                    let unixTimestamp = System.DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    let sectionHeader = sprintf "section_start:%d:%s_%s\r\e[0K%s" unixTimestamp tag.Type tag.Name
                     match descr with
-                    | Some d -> write false color true (sprintf "Starting %s '%s': %s" tag.Type tag.Name d)
-                    | _ -> write false color true (sprintf "Starting %s '%s'" tag.Type tag.Name)  
+                    | Some d -> write false color true (sectionHeader d)
+                    | None -> write false color true (sectionHeader "")
                 | TraceData.CloseTag (tag, time, state) ->
-                    write false color true (sprintf "Finished (%A) '%s' in %O" state tag.Name time)
+                    let unixTimestamp = System.DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    let sectionFooter = sprintf "section_end:%d:%s_%s\r\e[0K" unixTimestamp tag.Type tag.Name
+                    write false color true sectionFooter
                 | TraceData.BuildState (state, _) ->
                     write false color true (sprintf "Changing BuildState to: %A" state)
                 | TraceData.ImportData (typ, path) ->

--- a/src/app/Fake.Core.String/String.fs
+++ b/src/app/Fake.Core.String/String.fs
@@ -24,7 +24,7 @@ let inline isNullOrWhiteSpace value = isNullOrEmpty value || value |> Seq.forall
 let inline replace (pattern : string) replacement (text : string) = text.Replace(pattern, replacement)
 
 /// Converts a sequence of strings to a string with delimiters
-let inline separated delimiter (items : string seq) = String.Join(delimiter, Array.ofSeq items)
+let inline separated (delimiter: string) (items : string seq) = String.Join(delimiter, Array.ofSeq items)
 
 /// Removes the slashes from the end of the given string
 let inline trimSlash (s : string) = s.TrimEnd('\\')
@@ -40,10 +40,10 @@ let inline splitStr (delimiterStr : string) (text : string) =
 let inline toLines text = separated Environment.NewLine text
 
 /// Checks whether the given text starts with the given prefix
-let startsWith prefix (text : string) = text.StartsWith prefix
+let startsWith (prefix: string) (text : string) = text.StartsWith prefix
 
 /// Checks whether the given text ends with the given suffix
-let endsWith suffix (text : string) = text.EndsWith suffix
+let endsWith (suffix: string) (text : string) = text.EndsWith suffix
 
 /// Determines whether the last character of the given <see cref="string" />
 /// matches Path.DirectorySeparatorChar.         
@@ -95,17 +95,17 @@ let inline trim (x : string) =
     else x.Trim()
 
 /// Trims the given string
-let inline trimChars chars (x : string) = 
+let inline trimChars (chars: char []) (x : string) =
     if isNullOrEmpty x then x
     else x.Trim chars
 
 /// Trims the start of the given string
-let inline trimStartChars chars (x : string) =
+let inline trimStartChars (chars: char []) (x : string) =
     if isNullOrEmpty x then x
     else x.TrimStart chars
 
 /// Trims the end of the given string
-let inline trimEndChars chars (x : string) =
+let inline trimEndChars (chars: char []) (x : string) =
     if isNullOrEmpty x then x
     else x.TrimEnd chars
 

--- a/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
+++ b/src/app/Fake.IO.FileSystem/GlobbingFileSystem.fs
@@ -97,7 +97,7 @@ module GlobbingPatternExtensions =
         
         /// Checks if a particular file is matched
         member this.IsMatch (path : string) =
-            let fullDir pattern = 
+            let fullDir (pattern: string) =
                 if Path.IsPathRooted(pattern) then
                     pattern
                 else

--- a/src/app/Fake.IO.FileSystem/Path.fs
+++ b/src/app/Fake.IO.FileSystem/Path.fs
@@ -51,13 +51,13 @@ let changeExtension extension fileName = Path.ChangeExtension(fileName, extensio
 ///
 /// - 'extension' - The extension to fine containing the leading '.'.
 /// - 'fileName' - Name of the file from which the extension is retrieved.
-let hasExtension extension fileName = System.String.Equals(Path.GetExtension fileName, extension, System.StringComparison.OrdinalIgnoreCase)
+let hasExtension extension (fileName: string) = System.String.Equals(Path.GetExtension fileName, extension, System.StringComparison.OrdinalIgnoreCase)
 
 /// Get the directory of the specified path
 /// ## Parameters
 ///
 /// - 'path' - The path from which the directory is retrieved.
-let getDirectory path = Path.GetDirectoryName path
+let getDirectory (path: string) = Path.GetDirectoryName path
 
 /// The directory separator string. On most systems / or \
 let directorySeparator =


### PR DESCRIPTION
### Description

Implements the new collapsible-section logging for Gitlab CI runners as described in [the docs](https://docs.gitlab.com/ee/ci/pipelines.html#custom-collapsible-sections).

- fixes #2453 

TODO:
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
