### PR TITLE
Keep unreleased changelog section when promote to new version

### DIFF
--- a/src/app/Fake.Core.ReleaseNotes/Changelog.fs
+++ b/src/app/Fake.Core.ReleaseNotes/Changelog.fs
@@ -1,6 +1,27 @@
 /// Contains helpers which allow to parse Change log text files.
 /// These files have to be in a format as described on http://keepachangelog.com/en/1.1.0/
 ///
+/// ## Format
+///
+/// ```markdown
+/// # Changelog
+///
+/// All notable changes to this project will be documented in this file.
+///
+/// The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+/// and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+///
+/// ## [Unreleased]
+///
+/// ## [0.1.0] - 2020-03-17
+/// First release
+///
+/// ### Added
+/// - This release already has lots of features
+///
+/// [0.1.0]: https://github.com/user/MyCoolNewLib.git/releases/tag/v0.1.0
+/// ```
+///
 /// ## Sample
 ///
 ///     let changelogFile = "CHANGELOG.md"

--- a/src/app/Fake.Core.ReleaseNotes/Changelog.fs
+++ b/src/app/Fake.Core.ReleaseNotes/Changelog.fs
@@ -216,9 +216,9 @@ type Changelog =
         match x.Unreleased with
         | None -> x
         | Some u -> 
-            let newEntry = ChangelogEntry.New(assemblyVersion, nugetVersion, Some (System.DateTime.Today), u.Description, u.Changes, false)
-
-            Changelog.New(x.Header, x.Description, None, newEntry :: x.Entries)
+            let newEntry = ChangelogEntry.New(assemblyVersion, nugetVersion, Some DateTime.Today, u.Description, u.Changes, false)
+            let unreleased' = Some { Description = None; Changes = [] }
+            Changelog.New(x.Header, x.Description, unreleased', newEntry :: x.Entries)
 
     member x.PromoteUnreleased(version: string) : Changelog =
         let assemblyVersion, nugetVersion = version |> parseVersions


### PR DESCRIPTION
### Description

- Make the function `Changelog.promoteUnreleased` to keep the `### Unreleased` section in the changelog according to https://keepachangelog.com/en/1.0.0/#effort
- Add `CHANGELOG.md` file format sample to module documentation. This is actually not related to the first change.

### Explanation

There is nothing big, but still. For example if we have following changelog:

```markdown
# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

Next big release

### Fixed
- Nothing else than bugfixes. That was long overdue

## [0.2.0] - 2020-03-17
Second release

### Changed
- All features are changed, because we can

## [0.1.0] - 2020-03-17
First release

### Added
- This release already has lots of features

[0.1.0]: https://github.com/user/MyCoolNewLib.git/releases/tag/v0.1.0
```

Now we call in the `build.fsx` something like this:

```fsharp
changelog 
|> Changelog.promoteUnreleased "0.3.0"
|> Changelog.save "CHANGELOG.md"
```

After that only one line is changed - there is `## [0.3.0] - 2020-03-07` instead of `## [Unreleased]`.

- All unreleased changes are migrated to the `0.3.0` release section, which is correct.
- But the line `## [Unreleased]` is deleted, which is not needed, because it must be added every time manually for future changes again.

This change just brings the section `## [Unreleased]` back.
I don't see it as breaking change, because after that it is the manual change anyway, I guess.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
