### PR TITLE
make sure to add both dependencymanager compileroptions wherever they…

### DIFF
--- a/src/app/Fake.Runtime/CompileRunner.fs
+++ b/src/app/Fake.Runtime/CompileRunner.fs
@@ -101,7 +101,9 @@ let fcsDependencyManagerOptions =
             let currentDir = Path.GetDirectoryName s
             sprintf "--compilertool:%s" currentDir
 
-    "--langversion:preview" :: [ dummyPaketDependencyManagerOption ]
+    "--langversion:preview"  // needed because of a design choice(bug?) in FCS that parses dependency managers regardless of langversion
+    :: dummyPaketDependencyManagerOption // needed to handle and swallow the `paket` dependency manager type
+    :: [ "--nowarn:3186" ] // needed because the paket dependencymanager build right now throws some kind of pickling warning.
 
 let compile (context:FakeContext) outDll =
     use _untilCompileFinished = Fake.Profile.startCategory Fake.Profile.Category.Compiling

--- a/src/app/Fake.Runtime/CompileRunner.fs
+++ b/src/app/Fake.Runtime/CompileRunner.fs
@@ -102,7 +102,7 @@ let fcsDependencyManagerOptions =
             [ sprintf "--compilertool:%s" currentDir ]
 
     "--langversion:preview"  // needed because of a design choice(bug?) in FCS that parses dependency managers regardless of langversion
-    @ dummyPaketDependencyManagerOption // needed to handle and swallow the `paket` dependency manager type
+    :: dummyPaketDependencyManagerOption // needed to handle and swallow the `paket` dependency manager type
     @ [ "--nowarn:3186" ] // needed because the paket dependencymanager build right now throws some kind of pickling warning.
 
 let compile (context:FakeContext) outDll =

--- a/src/app/Fake.Runtime/CompileRunner.fs
+++ b/src/app/Fake.Runtime/CompileRunner.fs
@@ -96,14 +96,14 @@ let tryRunCached (c:CoreCacheInfo) (context:FakeContext) : RunResult =
 let fcsDependencyManagerOptions =
     let dummyPaketDependencyManagerOption =
         match typeof<Marker>.Assembly.Location with
-        | "" -> ""
+        | "" -> []
         | s ->
             let currentDir = Path.GetDirectoryName s
-            sprintf "--compilertool:%s" currentDir
+            [ sprintf "--compilertool:%s" currentDir ]
 
     "--langversion:preview"  // needed because of a design choice(bug?) in FCS that parses dependency managers regardless of langversion
-    :: dummyPaketDependencyManagerOption // needed to handle and swallow the `paket` dependency manager type
-    :: [ "--nowarn:3186" ] // needed because the paket dependencymanager build right now throws some kind of pickling warning.
+    @ dummyPaketDependencyManagerOption // needed to handle and swallow the `paket` dependency manager type
+    @ [ "--nowarn:3186" ] // needed because the paket dependencymanager build right now throws some kind of pickling warning.
 
 let compile (context:FakeContext) outDll =
     use _untilCompileFinished = Fake.Profile.startCategory Fake.Profile.Category.Compiling

--- a/src/app/Fake.Runtime/Tooling.fs
+++ b/src/app/Fake.Runtime/Tooling.fs
@@ -132,6 +132,7 @@ let detectFakeScript (file) : DetectionInfo option =
         match FakeRuntime.tryPrepareFakeScript config with
         | FakeRuntime.TryPrepareInfo.Prepared prepared -> Some { Config = config; Prepared = prepared }
         | _ -> None
+
 let getProjectOptions { Config = config; Prepared = prepared } : string[] =
     checkLogging()
     let prov = FakeRuntime.restoreAndCreateCachingProvider prepared
@@ -141,7 +142,7 @@ let getProjectOptions { Config = config; Prepared = prepared } : string[] =
       args |> Seq.toList
       |> List.filter (fun arg -> arg <> "--")
     
-    "--simpleresolution" :: "--targetprofile:netstandard" :: "--nowin32manifest" :: args
+    "--simpleresolution" :: "--targetprofile:netstandard" :: "--nowin32manifest" :: CompileRunner.fcsDependencyManagerOptions @ args
     |> List.toArray
 
 type GetTargetsWarningOrErrorType =


### PR DESCRIPTION
Fixes the last set of issues I found while integrating into FSAC by making sure the options returned from FAKE for a fake script are more similar to the ones used to _compile_ the script by FAKE. 