### PR TITLE
test and fix the gitlab reporter

### DIFF
--- a/src/app/Fake.BuildServer.GitLab/GitLabInternal.fs
+++ b/src/app/Fake.BuildServer.GitLab/GitLabInternal.fs
@@ -3,6 +3,9 @@ namespace Fake.BuildServer
 
 open Fake.Core
 
+[<assembly:System.Runtime.CompilerServices.InternalsVisibleTo("Fake.Core.UnitTests")>]
+do ()
+
 module internal GitLabInternal =
     let environVar = Environment.environVar
     let getJobId () = environVar "CI_JOB_ID"

--- a/src/test/Fake.Core.UnitTests/Fake.BuildServer.GitLab.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.BuildServer.GitLab.fs
@@ -1,0 +1,38 @@
+module Fake.BuildServer.GitLab
+
+open Expecto
+open Fake.Core
+open Fake.BuildServer
+
+let testCases = [
+    test "can emit correct collapsed output" {
+        let mutable messages = []
+        let writer _ _ newLine message = 
+            let message = if newLine then message + @"\n" else message
+            messages <- message :: messages
+        let sameTicks _ = 1L
+        let sameColorMapper _ = System.ConsoleColor.White
+        let listener = GitLab.GitLabTraceListener(writer, sameColorMapper, sameTicks) :> Fake.Core.ITraceListener
+
+        let tag = KnownTags.Target("my_first_section")
+        let traceMessages = [
+            TraceData.OpenTag(tag, Some "Header of the 1st collapsible section")
+            TraceData.LogMessage("this line should be hidden when collapsed", true)
+            TraceData.CloseTag(tag, System.TimeSpan.FromSeconds 1., TagStatus.Success)
+        ]
+        for trace in traceMessages do
+            listener.Write trace
+
+        let inOrder = List.rev messages
+        let expected = [
+            @"section_start:1:target_my_first_section\r\e[0KHeader of the 1st collapsible section\n"
+            @"this line should be hidden when collapsed\n"
+            @"section_end:1:target_my_first_section\r\e[0K\n"
+        ]
+        Expect.equal inOrder expected "should have output the correct collapsible trace"
+    }
+]
+
+
+[<Tests>]
+let tests = testList "Fake.BuildeServer.GitLab.Tests" testCases

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -35,10 +35,12 @@
     <ProjectReference Include="..\..\app\Fake.Tools.Octo\Fake.Tools.Octo.fsproj" />
     <ProjectReference Include="..\Fake.ExpectoSupport\Fake.ExpectoSupport.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Tools.SignTool\Fake.Tools.SignTool.fsproj" />
+    <ProjectReference Include="..\..\app\Fake.BuildServer.GitLab\Fake.BuildServer.GitLab.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="runtimeconfig.template.json" />
     <None Include="paket.references" />
+    <Compile Include="Fake.BuildServer.GitLab.fs" />
     <Compile Include="Fake.ContextHelper.fs" />
     <Compile Include="Fake.Testing.ArgumentHelper.fs" />
     <Compile Include="Fake.IO.Globbing.fs" />


### PR DESCRIPTION
### Description

Puts the gitlab trace writer under tests and establishes that it does in fact write the log messages expected by the documentation on gitlab.

The problem before was the console escape sequences were not being escaped in the format strings, so .Net was applying the for us.