### PR TITLE
Support running Octo from .net core tool-manifest

### DIFF
--- a/help/markdown/fake-tools-octo.md
+++ b/help/markdown/fake-tools-octo.md
@@ -41,6 +41,7 @@ It is a good idea to create an account in Octopus Deploy for your Continuous Int
 You can define a function defining shared parameters like `ToolPath`  or your Octopus Deploy instance details. Then the function can be used in subsequent `Octo` calls.
 
 ```fsharp
+open Fake.DotNet // needed for ToolType
 open Fake.Tools
 
 let setCommon (ps:Octo.Options) = 
@@ -49,7 +50,7 @@ let setCommon (ps:Octo.Options) =
 			    Server = {
     	                    ServerUrl = "Your Octopus Server URL"
                		        ApiKey = "Your API key"
-                            UseManifestTool = "true" // if using a .net core tool-manifest installed executable. Defaults to false.
+                            ToolType = ToolType.CreateLocalTool() // default is ToolType.FullFramework
                           }
     }
 ```

--- a/help/markdown/fake-tools-octo.md
+++ b/help/markdown/fake-tools-octo.md
@@ -19,6 +19,13 @@ You will also need to install and configure at least one [Tentacle](http://octop
 
 This module is a wrapper around the [Octo.exe](https://octopus.com/docs/api-and-integration/octo.exe-command-line) CLI tool which controls Octopus Deploy API. You'll need the Octo.exe tool itself accessible to your FAKE script. Download it from [here](https://octopus.com/downloads).
 
+This module also supports use via a .NET Core Tool-Manifest. Installation is simple! From the root of your repository run the following
+
+```bash
+dotnet new tool-manifest # if one doesn't already exist
+dotnet tool install Octopus.DotNet.Cli 
+```
+
 ### Generate an API Key
 
 In order to communicate with the Octopus Deploy API you will need an *API key* to authenticate with.
@@ -42,6 +49,7 @@ let setCommon (ps:Octo.Options) =
 			    Server = {
     	                    ServerUrl = "Your Octopus Server URL"
                		        ApiKey = "Your API key"
+                            UseManifestTool = "true" // if using a .net core tool-manifest installed executable. Defaults to false.
                           }
     }
 ```

--- a/src/app/Fake.Tools.Octo/Fake.Tools.Octo.fsproj
+++ b/src/app/Fake.Tools.Octo/Fake.Tools.Octo.fsproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Fake.Core.Environment\Fake.Core.Environment.fsproj" />
     <ProjectReference Include="..\Fake.Core.Process\Fake.Core.Process.fsproj" />
     <ProjectReference Include="..\Fake.IO.FileSystem\Fake.IO.FileSystem.fsproj" />
+    <ProjectReference Include="..\Fake.DotNet.Cli\Fake.DotNet.Cli.fsproj" />
   </ItemGroup>
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/test/Fake.Core.UnitTests/Fake.Tools.Octo.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Tools.Octo.fs
@@ -1,6 +1,7 @@
 module Fake.Tools.Testing.Octo
 
 open Expecto
+open Fake.DotNet
 
 [<Tests>]
 let defaultTests =
@@ -36,13 +37,13 @@ let defaultTests =
                 Common={
                     ToolName="ToolName-1"
                     ToolPath="ToolPath-1"
+                    ToolType = ToolType.FullFramework
                     WorkingDirectory="WorkingDirectory-1"
                     Server = {
                         ServerUrl="ServerUrl"
                         ApiKey="ApiKey"
                     }
                     Timeout=System.TimeSpan.MaxValue
-                    UseManifestTool = false
                 }
             }
             let actual =
@@ -138,13 +139,13 @@ let defaultTests =
                 Common = {
                     ToolName="ToolName-1"
                     ToolPath="ToolPath-1"
+                    ToolType=ToolType.FullFramework
                     WorkingDirectory="WorkingDirectory-1"
                     Server = {
                         ServerUrl="ServerUrl"
                         ApiKey="ApiKey"
                     }
                     Timeout=System.TimeSpan.MaxValue
-                    UseManifestTool=false
                 }
             }
 
@@ -185,13 +186,13 @@ let defaultTests =
                 Common={
                     ToolName="ToolName-1"
                     ToolPath="ToolPath-1"
+                    ToolType=ToolType.FullFramework
                     WorkingDirectory="WorkingDirectory-1"
                     Server = {
                         ServerUrl="ServerUrl"
                         ApiKey="ApiKey"
                     }
                     Timeout=System.TimeSpan.MaxValue
-                    UseManifestTool=false
                     }
                 }
 
@@ -218,13 +219,13 @@ let defaultTests =
                 Common={
                     ToolName="ToolName-1"
                     ToolPath="ToolPath-1"
+                    ToolType=ToolType.FullFramework
                     WorkingDirectory="WorkingDirectory-1"
                     Server = {
                         ServerUrl="ServerUrl"
                         ApiKey="ApiKey"
                     }
                     Timeout=System.TimeSpan.MaxValue
-                    UseManifestTool=false
                 }
             }
 
@@ -256,49 +257,4 @@ let defaultTests =
             let args = (List.append (Fake.Tools.Octo.commandLine command) (Fake.Tools.Octo.serverCommandLine releaseOptions.Common.Server)) |> Fake.Core.Arguments.OfArgs
             let command = args.ToWindowsCommandLine
             Expect.equal command "create-release --project=MyProject --version=1234567890.12.34 --package=MyPackage:1234567890.12.34 --project=MyProject --deployto=MyEnvironment --version=1234567890.12.34 --progress --server=https://myoctopus-server.com --apikey=octoApiKey" "The output should be runnable on windows."
-
-        testCase "UseManifestTool=true produces correct tool" <| fun _ ->
-            let expected = "dotnet"
-            let opts = { Fake.Tools.Octo.commonOptions with UseManifestTool = true }
-            let actual = 
-                opts 
-                |> Fake.Tools.Octo.getTool 
-            Expect.equal actual expected "UseManifestTool=true should return dotnet"
-
-        testCase "UseManifestTool=false produces correct tool" <| fun _ ->
-            let expected = "Octo.exe"
-            let opts = { Fake.Tools.Octo.commonOptions with UseManifestTool = true }
-            let actual = 
-                opts 
-                |> Fake.Tools.Octo.getTool 
-            Expect.stringEnds actual expected "UseManifestTool=true should return dotnet"
-
-        testCase "Create Release Default with UseManifestTool=true" <| fun _ ->
-            let expectedCommand = [
-                "dotnet-octo"
-                "create-release"
-                ]
-            let opts = { Fake.Tools.Octo.commonOptions with UseManifestTool = true }
-            let releaseOptions = 
-                ({ Fake.Tools.Octo.releaseOptions with Common = opts }, None) 
-                |> Fake.Tools.Octo.Command.CreateRelease  
-            let actual = 
-                opts
-                |> Fake.Tools.Octo.getArgs releaseOptions
-            Expect.hasLength actual expectedCommand.Length "With UseManifestTool options expects two commands"
-            Expect.sequenceEqual actual expectedCommand "CreateRelease command with UseManifestTool should have dotnet-octo and create-release"
-        
-        testCase "Create Release Default with UseManifestTool=false" <| fun _ ->
-            let expectedCommand = [
-                "create-release"
-                ]
-            let opts = Fake.Tools.Octo.commonOptions
-            let releaseOptions = 
-                (Fake.Tools.Octo.releaseOptions, None) 
-                |> Fake.Tools.Octo.Command.CreateRelease  
-            let actual = 
-                opts
-                |> Fake.Tools.Octo.getArgs releaseOptions
-            Expect.hasLength actual expectedCommand.Length "With default options only expect the command"
-            Expect.sequenceEqual actual expectedCommand "CreateRelease command should be the create-release string"
     ]


### PR DESCRIPTION
### Description

Adds support for running `octo.exe` as a .NET Core tool installed via a tool-manifest.

Local verification (macOS):

```bash
dotnet new fake
dotnet tool install Octopus.DotNet.Cli
```

```fsharp
#r "paket:
source https://api.nuget.org/v3/index.json
source /Users/jeremy/code/FAKE/src/app/Fake.Tools.Octo/bin/Debug
nuget Fake.DotNet.Cli
nuget Fake.IO.FileSystem
nuget Fake.Core.Target
nuget Fake.Tools.Octo 1.0.0 //"
#load ".fake/build.fsx/intellisense.fsx"
open Fake.Core
open Fake.DotNet
open Fake.Core.TargetOperators

Target.initEnvironment ()

Target.create "Octo" (fun _ ->
    
    Fake.Tools.Octo.listEnvironments
      (fun opts ->
        { opts with 
            ToolType = ToolType.CreateLocalTool()
            Server = { opts.Server with ServerUrl = "https://octopus.server"; ApiKey="API-ABCDEFG123"}
        })
)

Target.runOrDefault "Octo"
```

## TODO

There are two obsolete calls in this module, but I'm not sure how to use the suggested replacement method.

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
