### PR TITLE
Fix a wrong decoration

### DIFF
--- a/help/markdown/core-targets.md
+++ b/help/markdown/core-targets.md
@@ -101,7 +101,7 @@ Target.runOrDefault "Deploy"
 Now we have the following options:
 
 - `fake run build.fsx -t "Build"` --> starts the *Build* target and runs the dependency *Clean*
-- `fake run build.fsx -t "Build"` --single-target --> starts only the *Build* target and runs no dependencies
+- `fake run build.fsx -t "Build" --single-target` --> starts only the *Build* target and runs no dependencies
 - `fake run build.fsx -s -t Build` --> starts only the *Build* target and runs no dependencies
 - `fake run build.fsx` --> starts the Deploy target (and runs the dependencies *Clean* and *Build*)
 


### PR DESCRIPTION
### Description

`--single-target` should be included inside of \`…\`

## TODO

This is a trivial documentation fix.  No behaviors should be changed.

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
