### PR TITLE
Add seq-based overload for Docopt.Parse

### DIFF
--- a/src/app/Fake.Core.CommandLineParsing/docopt.fs/Docopt/Docopt.fs
+++ b/src/app/Fake.Core.CommandLineParsing/docopt.fs/Docopt/Docopt.fs
@@ -105,6 +105,7 @@ type Docopt(doc', ?soptChars':string) =
           |> addKey opt.DefaultValue opt.FullLong
           |> addKey opt.DefaultValue opt.FullShort
         ) map) result
+    member this.Parse(argv':#seq<string>) = this.Parse(argv' |> Seq.toArray)
 
     member __.Usage = String.Join("\n", uStrs)
     member __.UsageParser = pusage


### PR DESCRIPTION
### Description

Fix #2433 by adding an overload to Docopt.Parse that takes an `IEnumerable<string>`. All existing unit tests continue to pass after this PR.

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`):

**Help needed:** there's no API documentation for Docopt yet, and as I tried to write it, I realized I don't quite know what to write to explain the main Parse() implementation.

- [ ] unit or integration test exists (or short reasoning why it doesn't make sense):

**Help needed:** there are no unit tests for Docopt, and I don't feel up to writing them at the moment.
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [X] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in):

This is a one-line PR, so I didn't really look at any other code except the Docopt class, and I didn't see anything in the Docopt class that needed fixing.

- [X] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.

N/A

- [X] (if new module) the module is in the correct namespace

N/A

- [X] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)

N/A

- [X] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
