### PR TITLE
[Security issue] Fix secrets leakage in certain scenarios (NuGet key, Paket key) 

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -1645,7 +1645,7 @@ module DotNet =
         |> List.concat
         |> List.filter (not << String.IsNullOrEmpty)
 
-    /// nuget push paramters for `dotnet nuget push`
+    /// nuget push parameters for `dotnet nuget push`
     type NuGetPushOptions =
         { Common: Options
           PushParams: NuGet.NuGetPushParams }
@@ -1681,6 +1681,9 @@ module DotNet =
         use __ = Trace.traceTask "DotNet:nuget:push" nupkg
         let param = NuGetPushOptions.Create() |> setParams
         let pushParams = param.PushParams
+        pushParams.ApiKey |> Option.iter (fun key -> TraceSecrets.register "<ApiKey>" key)
+        pushParams.SymbolApiKey |> Option.iter (fun key -> TraceSecrets.register "<SymbolApiKey>" key)
+
         let args = Args.toWindowsCommandLine (nupkg :: buildNugetPushArgs pushParams)
         let result = exec (fun _ -> param.Common) "nuget push" args
 

--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -315,8 +315,8 @@ let private propertiesParam = function
 
 /// Creates a NuGet package without templating (including symbols package if enabled)
 let private pack parameters nuspecFile =
-    TraceSecrets.register parameters.AccessKey "<NuGetKey>"
-    TraceSecrets.register parameters.SymbolAccessKey "<NuGetSymbolKey>"
+    TraceSecrets.register "<NuGetKey>" parameters.AccessKey
+    TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
     let nuspecFile = Path.getFullName nuspecFile
     let properties = propertiesParam parameters.Properties
     let basePath = parameters.BasePath |> Option.map (sprintf "-BasePath \"%s\"") |> Option.defaultValue ""
@@ -433,8 +433,8 @@ let internal toPushCliArgs param =
     |> List.filter (not << String.IsNullOrEmpty)
 
 let rec private push (options : ToolOptions) (parameters : NuGetPushParams) nupkg =
-    parameters.ApiKey |> Option.iter (fun key -> TraceSecrets.register key "<NuGetKey>")
-    parameters.SymbolApiKey |> Option.iter (fun key -> TraceSecrets.register key "<NuGetSymbolKey>")
+    parameters.ApiKey |> Option.iter (fun key -> TraceSecrets.register "<NuGetKey>" key)
+    parameters.SymbolApiKey |> Option.iter (fun key -> TraceSecrets.register "<NuGetSymbolKey>" key)
 
     let pushArgs = parameters |> toPushCliArgs |> Args.toWindowsCommandLine
     let args = sprintf "%s \"%s\" %s" options.Command nupkg pushArgs

--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -178,12 +178,12 @@ let pack setParams =
 let pushFiles setParams files =
     let parameters : PaketPushParams = PaketPushDefaults() |> setParams
 
-    TraceSecrets.register parameters.ApiKey "<PaketApiKey>"
+    TraceSecrets.register "<PaketApiKey>" parameters.ApiKey
     match Environment.environVarOrNone "nugetkey" with
-    | Some k -> TraceSecrets.register k "<PaketApiKey>"
+    | Some k -> TraceSecrets.register "<PaketApiKey>" k
     | None -> ()
     match Environment.environVarOrNone "nuget-key" with
-    | Some k -> TraceSecrets.register k "<PaketApiKey>"
+    | Some k -> TraceSecrets.register "<PaketApiKey>" k
     | None -> ()
     
     let packages = Seq.toList files


### PR DESCRIPTION
### Description

- Fix improper usage of secret registration, so that secrets are actually protected
- Protected keys when using `DotNet.nugetPush` command.

- fixes #2526

I did not cover it with unit tests, as I found that affected methods are not being invoked in tests ATM. So I simply didn't know how to unit test it and without actually executing the real command (i.e. isolation question). If you find that it's important to cover it with tests, please either feel free to contribute unit tests to my branch or show me an example on how to do that.

Thanks!