### PR TITLE
Add null check for values with null as default value

### DIFF
--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -315,8 +315,8 @@ let private propertiesParam = function
 
 /// Creates a NuGet package without templating (including symbols package if enabled)
 let private pack parameters nuspecFile =
-    if not (isNull parameters.AccessKey) then TraceSecrets.register "<NuGetKey>" parameters.AccessKey
-    if not (isNull parameters.SymbolAccessKey) then TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
+    if String.isNotNullOrEmpty parameters.AccessKey then TraceSecrets.register "<NuGetKey>" parameters.AccessKey
+    if String.isNotNullOrEmpty parameters.SymbolAccessKey then TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
     let nuspecFile = Path.getFullName nuspecFile
     let properties = propertiesParam parameters.Properties
     let basePath = parameters.BasePath |> Option.map (sprintf "-BasePath \"%s\"") |> Option.defaultValue ""

--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -315,8 +315,8 @@ let private propertiesParam = function
 
 /// Creates a NuGet package without templating (including symbols package if enabled)
 let private pack parameters nuspecFile =
-    if parameters.AccessKey <> null then TraceSecrets.register "<NuGetKey>" parameters.AccessKey
-    if parameters.SymbolAccessKey <> null then TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
+    if not (isNull parameters.AccessKey) then TraceSecrets.register "<NuGetKey>" parameters.AccessKey
+    if not (isNull parameters.SymbolAccessKey) then TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
     let nuspecFile = Path.getFullName nuspecFile
     let properties = propertiesParam parameters.Properties
     let basePath = parameters.BasePath |> Option.map (sprintf "-BasePath \"%s\"") |> Option.defaultValue ""

--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -315,8 +315,8 @@ let private propertiesParam = function
 
 /// Creates a NuGet package without templating (including symbols package if enabled)
 let private pack parameters nuspecFile =
-    TraceSecrets.register "<NuGetKey>" parameters.AccessKey
-    TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
+    if parameters.AccessKey <> null then TraceSecrets.register "<NuGetKey>" parameters.AccessKey
+    if parameters.SymbolAccessKey <> null then TraceSecrets.register "<NuGetSymbolKey>" parameters.SymbolAccessKey
     let nuspecFile = Path.getFullName nuspecFile
     let properties = propertiesParam parameters.Properties
     let basePath = parameters.BasePath |> Option.map (sprintf "-BasePath \"%s\"") |> Option.defaultValue ""


### PR DESCRIPTION
### Description

Added null check for values with null as default value

- fixes #2530 

## Considerations

* Consider making the fields optional instead using nulls, which would be a breaking change
* Consider other ways of doing the null check, as I don't know the preferred way in this repo:

```
    // Using ofObj
    parameters.AccessKey |> Option.ofObj |> Option.iter (TraceSecrets.register "<NuGetKey>")

    // Using null compare
    if parameters.AccessKey <> null then TraceSecrets.register "<NuGetKey>" parameters.AccessKey

    // Using match expression
    match parameters.AccessKey with
    | null -> ()
    | key -> TraceSecrets.register "<NuGetKey>" key
```

- [-] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [-] unit or integration test exists (or short reasoning why it doesn't make sense)  
- [-] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [-] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [-] (if new module) the module is in the correct namespace
- [-] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
