### PR TITLE
Fix unintentional unit return

### DIFF
--- a/src/app/Fake.Core.Process/CreateProcess.fs
+++ b/src/app/Fake.Core.Process/CreateProcess.fs
@@ -631,8 +631,8 @@ module CreateProcess =
                     | None ->
                         (sprintf "%s. exit code '%d' <> 0. Command Line: %s" msg exitCode r.CommandLine)
                 //if Env.isVerbose then
-                eprintfn "%s" msg    
-            else data)
+                eprintfn "%s" msg
+            data)
 
     type internal TimeoutState =
         { Stopwatch : System.Diagnostics.Stopwatch

--- a/src/app/Fake.Windows.Chocolatey/Chocolatey.fs
+++ b/src/app/Fake.Windows.Chocolatey/Chocolatey.fs
@@ -835,7 +835,7 @@ module Fake.Windows.Choco
             try
                 callChoco parameters.ToolPath args parameters.Timeout
             with e when n > 1 ->
-                eprintf "pushing to chocolatey server failed, trying again: %O"
+                eprintf "pushing to chocolatey server failed, trying again: %O" e
                 tries (n - 1)
         tries 3         
                 


### PR DESCRIPTION
### Description

`CreateProcess.warnOnExitCode` has a `string -> CreateProcess<unit> -> CreateProcess<unit>` signature.  This is too restrictive.