### PR TITLE
Update Octokit.fsx

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -1,8 +1,8 @@
 #nowarn "211"
 #I __SOURCE_DIRECTORY__
-#I @"../../../../../packages/Octokit/lib/net45"
-#I @"../../packages/Octokit/lib/net45"
-#I @"../../../../../../packages/build/Octokit/lib/net45"
+#I @"../../../../../packages/Octokit/lib/net46"
+#I @"../../packages/Octokit/lib/net46"
+#I @"../../../../../../packages/build/Octokit/lib/net46"
 #r "System.Net.Http"
 #r "Octokit.dll"
 


### PR DESCRIPTION
octokit got updated to work with net46, so the paths need to be updated in order to pick up the dependency.

I am trying to update the CRMTypeProvider to work with net46 and this change is needed to get the fake build to pass since the latest octokit got updated to net46