### PR TITLE
add VSTEST paths for VS2019

### DIFF
--- a/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
+++ b/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
@@ -3,21 +3,16 @@ module Fake.DotNet.Testing.MSTest
 
 open System
 open System.Text
+open BlackFox.VsWhere
 open Fake.Core
+open Fake.IO
 open Fake.Testing.Common
 
-/// [omit]
-let mstestPaths = 
-    [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\";
-       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Professional\Common7\IDE\"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Community\Common7\IDE\"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"; 
-       @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE";
-       @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE";
-       @"[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]
+
+let private getAllVsPath () =
+    VsInstances.getWithPackage "Microsoft.VisualStudio.PackageGroup.TestTools.MSTestV2.Managed" false
+    |> List.map (fun vs -> Path.combine vs.InstallationPath "Common7\\Tools")
+
 
 /// [omit]
 let mstestexe =
@@ -64,7 +59,7 @@ let MSTestDefaults =
       Tests = []
       TimeOut = TimeSpan.FromMinutes 5.
       ToolPath = 
-          match Process.tryFindFile mstestPaths mstestexe with
+          match Process.tryFindFile (getAllVsPath ()) mstestexe with
           | Some path -> path
           | None -> ""
       Details = []

--- a/src/app/Fake.DotNet.Testing.MSTest/paket.references
+++ b/src/app/Fake.DotNet.Testing.MSTest/paket.references
@@ -2,3 +2,4 @@ group netcore
 
 FSharp.Core
 NETStandard.Library
+BlackFox.VsWhere

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -11,6 +11,9 @@ open System.Text
 /// [omit]
 let private vsTestPaths = 
     [|
+        @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+        @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+        @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
         @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
         @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
         @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"


### PR DESCRIPTION
### Description

Adds the paths for VS2019 for vstest exe. 

Solves #2540
