### PR TITLE
Allow users of nunit3 set environment variables in the runner

### DIFF
--- a/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
+++ b/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
@@ -217,6 +217,9 @@ type NUnit3Params =
 
       /// A test parameter specified in the form name=value. Multiple parameters may be specified, separated by semicolons
       Params : string
+
+      /// list or environment variables that will be set in the nunit-console.exe process
+      EnvironmentVariables : (string * string) list
     }
 
 /// The [NUnit3Params](fake-testing-nunit3-nunit3params.html) default parameters.
@@ -245,6 +248,7 @@ type NUnit3Params =
 /// - `TraceLevel` - `Default` (By default NUnit3 sets this to off internally)
 /// - `SkipNonTestAssemblies` - `false`
 /// - `Params` - `""`
+/// - `EnvironmentVariables` - `[]`
 /// ## Defaults
 let NUnit3Defaults =
     {
@@ -273,6 +277,7 @@ let NUnit3Defaults =
       TraceLevel= NUnit3TraceLevel.Default
       SkipNonTestAssemblies = false
       Params = ""
+      EnvironmentVariables = []
     }
 
 /// Tries to detect the working directory as specified in the parameters or via TeamCity settings
@@ -331,6 +336,9 @@ let internal createProcess createTempFile (setParams : NUnit3Params -> NUnit3Par
     CreateProcess.fromRawCommandLine tool argLine
     |> CreateProcess.withFramework
     |> CreateProcess.withWorkingDirectory (getWorkingDir parameters)
+    |> fun cp -> 
+        parameters.EnvironmentVariables 
+            |> Seq.fold (fun acc (k,v)-> CreateProcess.setEnvironmentVariable k v acc) cp  
     //|> CreateProcess.withTimeout processTimeout
     |> CreateProcess.addOnSetup (fun () ->
         File.WriteAllText(path, generatedArgs)

--- a/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
+++ b/src/app/Fake.DotNet.Testing.NUnit/NUnit3.fs
@@ -338,6 +338,7 @@ let internal createProcess createTempFile (setParams : NUnit3Params -> NUnit3Par
     let argLine = Args.toWindowsCommandLine [ (sprintf "@%s" path) ]
     CreateProcess.fromRawCommandLine tool argLine
     |> CreateProcess.withFramework
+    |> CreateProcess.withWorkingDirectory (getWorkingDir parameters)
     |> CreateProcess.withEnvironment  (parameters.Environment |> Map.toList)
     //|> CreateProcess.withTimeout processTimeout
     |> CreateProcess.addOnSetup (fun () ->


### PR DESCRIPTION
I need this for an obscure reason, maybe other people will too?
