### PR TITLE
add access token option to sqlpackage

### DIFF
--- a/help/markdown/sql-sqlpackage.md
+++ b/help/markdown/sql-sqlpackage.md
@@ -24,6 +24,24 @@ Ensure that you have already built your database project (you can do this with s
         SqlPackage.deployDb (fun args -> { args with Source = dacPacPath; Destination = connectionString }) |> ignore
     )
 
+The following sample shows how to deploy a database project to Azure using an access token:
+
+    open Fake.Core
+    open Fake.Sql
+
+    /// the database for local development + compile
+    Target.create "DeployLocalDb" (fun _ ->
+        let dacPacPath = "path/to/dbProject.dacpac"
+        let accessToken = "your-access-token"
+        let connectionString = "Data Source=your-server-name.database.windows.net; Initial Catalog=your-database-name;" 
+        SqlPackage.deployDb (fun args -> 
+            { args with 
+                    Destination = connectionString
+                    AccessToken = accessToken
+                    Source = dacPacPath 
+            }) |> ignore
+    )
+
 ## Deployment Options
 
 You can optionally specify the type of command to use (again, refer to the documentation above for more detail): -
@@ -41,6 +59,7 @@ You can provide following arguments (in brackets are given sqlpackage.exe parame
 
 * SqlPackageToolPath - path to sqlpackage.exe
 * Action - deployment option (/a)
+* AccessToken - An Access token to use in authentication instead of username and password
 * Source - specifies a source file to be used as the source of action instead of a database (/SourceFile)
 * Destination - specifies a valid SQL Server/Azure connection string to the target database (/TargetConnectionString)
 * Timeout - specifies the command timeout in seconds when executing queries against SQL Server (/p:CommandTimeout)

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\Fake.ExpectoSupport\Fake.ExpectoSupport.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Tools.SignTool\Fake.Tools.SignTool.fsproj" />
     <ProjectReference Include="..\..\app\Fake.BuildServer.GitLab\Fake.BuildServer.GitLab.fsproj" />
+    <ProjectReference Include="..\..\app\Fake.Sql.SqlPackage\Fake.Sql.SqlPackage.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="runtimeconfig.template.json" />
@@ -70,6 +71,7 @@
     <Compile Include="Fake.Core.FakeVar.fs" />
     <Compile Include="Fake.Runtime.fs" />
     <Compile Include="Fake.Tools.Octo.fs" />
+    <Compile Include="Fake.Sql.SqlPackage.fs" />
     <Compile Include="Main.fs" />
     <None Include="TestFiles/Fake.DotNet.AssemblyInfoFile/AssemblyInfo.cs" CopyToOutputDirectory="PreserveNewest" />
     <None Include="TestFiles/Fake.DotNet.AssemblyInfoFile/AssemblyInfo.fs" CopyToOutputDirectory="PreserveNewest" />

--- a/src/test/Fake.Core.UnitTests/Fake.Sql.SqlPackage.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Sql.SqlPackage.fs
@@ -1,0 +1,34 @@
+﻿module Fake.Sql.SqlPackageTests
+
+open Fake.Core
+open Fake.Sql
+open Expecto
+
+[<Tests>]
+let tests =
+  testList "Fake.Sql.SqlPackage.Tests" [
+    testCase "Test that it produces correct command when using access token" <| fun _ ->
+      let action = "Publish"
+      let outputPath = ""
+      let additionalParameters = ""
+      let variables = ""
+      let args: SqlPackage.DeployDbArgs = 
+        { SqlPackageToolPath = ""
+          Action = SqlPackage.DeployAction.Deploy
+          AccessToken = "my-access-token"
+          Source = ""
+          Destination = "Data Source=your-server-name.database.windows.net; Initial Catalog=your-database-name;"
+          Timeout = None
+          BlockOnPossibleDataLoss = None
+          DropObjectsNotInSource = None
+          RecreateDb = None
+          AdditionalSqlPackageProperties = []
+          Variables = []
+          Profile = "" }
+
+      let cmd = SqlPackage.formatArgument args action outputPath additionalParameters variables "AccessToken"
+
+      Expect.equal cmd
+        (sprintf "/AccessToken:\"my-access-token\" ") "expected access token to be enclosed in quotes"
+
+  ]


### PR DESCRIPTION
### Description

This PR adds the access token to sqlpackage module. It will open the possibility to deploy a DacPac project using an access token instead of a username and password. Here is an example usage of it:

```
open Fake.Core
open Fake.Sql

/// the database for local development + compile
Target.create "DeployLocalDb" (fun _ ->
    let dacPacPath = "path/to/dbProject.dacpac"
    let accessToken = "your-access-token"
    let connectionString = "Data Source=your-server-name.database.windows.net; Initial Catalog=your-database-name;" 
    SqlPackage.deployDb (fun args -> 
        { args with 
                Destination = connectionString
                AccessToken = accessToken
                Source = dacPacPath 
        }) |> ignore
)
```

- fixes #2568

## TODO

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
