### PR TITLE
Get by packageid and an api to search by title

### DIFF
--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -803,8 +803,14 @@ let extractFeedPackageFromJson (data : JObject) isLatestVersion =
       Title = data.["title"].ToString()
     }
 
+/// Gets a Package information from NuGet feed by package id.
+/// ## Parameters
+///
+///  - `repoUrl` - Query endpoint of NuGet search service
+///  - `packageName` - The package to get
+///  - `version` - The specific version to get
 let getPackage (repoUrl:string) (packageName:string) (version:string) =
-    let url : string = repoUrl.TrimEnd('/') + "?q=title:" + packageName + "&take=1"
+    let url : string = repoUrl.TrimEnd('/') + "?q=packageid:" + packageName + "&take=1"
     let resp = webClient.DownloadString(url)
     let json = JObject.Parse resp
     let data = (json.["data"] :?> JArray).[0] :?> JObject
@@ -821,13 +827,30 @@ let getPackage (repoUrl:string) (packageName:string) (version:string) =
     data.["version"] <- JValue version
     extractFeedPackageFromJson data isLatest
 
-
+/// Gets the latest published package from NuGet feed by package id.
+/// ## Parameters
+///
+///  - `repoUrl` - Query endpoint of NuGet search service
+///  - `packageName` - The package to get
 let getLatestPackage (repoUrl:string) packageName =
-    let url : string = repoUrl.TrimEnd('/') + "?q=title:" + packageName + "&take=1"
+    let url : string = repoUrl.TrimEnd('/') + "?q=packageid:" + packageName + "&take=1"
     let resp = webClient.DownloadString(url)
     let json = JObject.Parse resp
     let data = (json.["data"] :?> JArray).[0] :?> JObject
     extractFeedPackageFromJson data true
+
+/// Search NuGet query endpoint for packages macthing given name by title
+/// ## Parameters
+///
+///  - `repoUrl` - Query endpoint of NuGet search service
+///  - `packageName` - The package to search for
+let searchByTitle (repoUrl:string) (packageName:string) =
+    let url : string = repoUrl.TrimEnd('/') + "?q=title:" + packageName
+    let resp = webClient.DownloadString(url)
+    let json = JObject.Parse resp
+    let data = (json.["data"] :?> JArray).ToObject<List<JObject>>()
+    data
+    |> List.map(fun datum -> extractFeedPackageFromJson datum false)
 
 /// [omit]
 let downloadPackage targetDir (package : NuSpecPackage) =

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.NuGet.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.NuGet.fs
@@ -96,5 +96,20 @@ let tests =
             Expect.isNotEmpty package.ProjectUrl "ProjectUrl filled"
             Expect.isNotEmpty package.LicenseUrl "LicenseUrl filled"
             Expect.equal package.Title "FAKE" "Title filled"
+        
+        testCase "Search by title returns results for matching packages by provided title" <| fun _ ->
+            let packages: NuGet.NugetPackageInfo list = NuGet.searchByTitle (NuGet.getRepoUrl()) "FAKE"
+            Expect.isGreaterThanOrEqual packages.Length 1 "Expected result has at least one element"
+            Expect.equal packages.[0].Id "FAKE" "Id filled"
+            Expect.isNotEmpty packages.[0].Version "Version filled"
+            Expect.isNotEmpty packages.[0].Description "Description filled"
+            Expect.isNotEmpty packages.[0].Summary "Id filled"
+            Expect.isFalse packages.[0].IsLatestVersion "IsLatestVersion filled"
+            Expect.isNotEmpty packages.[0].Authors "Authors filled"
+            Expect.isNotEmpty packages.[0].Owners "Owners filled"
+            Expect.isNotEmpty packages.[0].Tags "Tags filled"
+            Expect.isNotEmpty packages.[0].ProjectUrl "ProjectUrl filled"
+            Expect.isNotEmpty packages.[0].LicenseUrl "LicenseUrl filled"
+            Expect.equal packages.[0].Title "FAKE" "Title filled"
     ]
 


### PR DESCRIPTION
### Description

This PR modifies the NuGet feed APIs and opens a new API to search for packages. Fixes #2575

This [PR](https://github.com/fsharp/FAKE/pull/2574) fixes the NuGet feed APIs and ported them to use V3 of the NuGet feed. It uses the title query parameter to get information about a requested package. The issue with the title query parameter is that it doesn't return exact results as intended. For example,

```
"Pulumi.FSharp.AzureAD" |> NuGet.getLatestPackage (NuGet.getRepoUrl())
```
Returns results for `Azure.Storage.Blobs`.  Likewise, if the title was replaced by id in the NuGet query endpoint it will behave the same.
To solve this the `packageid` query parameter is the one that returns exact matches by `packageid`
So, in this PR, the `getPackage` and `getLatestPackage` APIs now use the `packageid` in the search.
The underlying HTTPS request would be like:
```
https://azuresearch-usnc.nuget.org/query?q=packageid:Pulumi.FSharp.AzureAD&take=1
```
To make API more flexible, a new API was added `searchByTitle` which uses the `title` query parameter in the search and returns more than one result, unlike the other two APIs which return one result only.