### PR TITLE
GitVersion with dotnet tool

### DIFF
--- a/help/markdown/fake-tools-gitversion.md
+++ b/help/markdown/fake-tools-gitversion.md
@@ -1,0 +1,34 @@
+# Generate semantic version number from Git with GitVersion
+
+<div class="alert alert-info">
+    <h5>INFO</h5>
+    <p>This documentation is for FAKE version 5.0 or later. The old documentation can be found <a href="apidocs/v4/fake-gitversionhelper.html">here</a></p>
+</div>
+
+[GitVersion] is a tool that generates a Semantic Version number based on your Git history.
+
+[API-Reference](apidocs/v5/fake-tools-gitversion.html)
+
+## Minimal working example
+
+```fsharp
+#r "paket:
+nuget Fake.Core.Target
+nuget Fake.DotNet.Cli
+nuget Fake.Tools.GitVersion
+//"
+
+open Fake.Core
+open Fake.DotNet
+open Fake.Tools
+
+let install = lazy DotNet.install DotNet.Versions.FromGlobalJson
+
+Target.create "Version" (fun _ ->
+    GitVersion.generateProperties gitVersionGenerateProperties (fun p ->
+        { p with ToolType = ToolType.CreateCLIToolReference(install.Value) })
+)
+
+```
+
+[GitVersion]: https://gitversion.net/

--- a/help/templates/template.cshtml
+++ b/help/templates/template.cshtml
@@ -223,6 +223,7 @@
 							<a href="/apidocs/v5/index.html#Fake.Tools" class="navbar-link">Tools</a>
 							<div class="navbar-dropdown" class="navbar-item">
 								<a href="/apidocs/v5/index.html#Fake.Tools.Git" class="navbar-item">Git</a>
+								<a href="/fake-tools-gitversion.html" class="navbar-item">GitVersion</a>
 								<a href="/fake-tools-pickles.html" class="navbar-item">Pickles</a>
 								<a href="/fake-tools-octo.html" class="navbar-item">Octo</a>
 								<a href="/apidocs/v5/fake-tools-rsync.html" class="navbar-item">Rsync</a>

--- a/src/app/Fake.Tools.GitVersion/Fake.Tools.GitVersion.fsproj
+++ b/src/app/Fake.Tools.GitVersion/Fake.Tools.GitVersion.fsproj
@@ -13,11 +13,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="VisibleTo.fs" />
     <Compile Include="GitVersion.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fake.Core.Environment\Fake.Core.Environment.fsproj" />
     <ProjectReference Include="..\Fake.Core.Process\Fake.Core.Process.fsproj" />
+    <ProjectReference Include="..\Fake.DotNet.Cli\Fake.DotNet.Cli.fsproj" />
     <ProjectReference Include="..\Fake.IO.FileSystem\Fake.IO.FileSystem.fsproj" />
   </ItemGroup>
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />

--- a/src/app/Fake.Tools.GitVersion/VisibleTo.fs
+++ b/src/app/Fake.Tools.GitVersion/VisibleTo.fs
@@ -1,0 +1,7 @@
+
+namespace System
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleTo("Fake.Core.IntegrationTests")>]
+[<assembly: InternalsVisibleTo("Fake.Core.UnitTests")>]
+do ()

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\app\Fake.IO.Zip\Fake.IO.Zip.fsproj" />
     <ProjectReference Include="..\..\app\Fake.IO.FileSystem\Fake.IO.FileSystem.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Testing.Fixie\Fake.Testing.Fixie.fsproj" />
+    <ProjectReference Include="..\..\app\Fake.Tools.GitVersion\Fake.Tools.GitVersion.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Tools.Git\Fake.Tools.Git.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Tools.Pickles\Fake.Tools.Pickles.fsproj" />
     <ProjectReference Include="..\..\app\Fake.Core.Context\Fake.Core.Context.fsproj" />
@@ -75,6 +76,7 @@
     <Compile Include="Fake.Core.Context.fs" />
     <Compile Include="Fake.Core.FakeVar.fs" />
     <Compile Include="Fake.Runtime.fs" />
+    <Compile Include="Fake.Tools.GitVersion.fs" />
     <Compile Include="Fake.Tools.Octo.fs" />
     <Compile Include="Fake.Sql.SqlPackage.fs" />
     <Compile Include="Fake.BuildServer.Bitbucket.fs" />

--- a/src/test/Fake.Core.UnitTests/Fake.Tools.GitVersion.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Tools.GitVersion.fs
@@ -1,0 +1,117 @@
+module Fake.Tools.GitVersionTests
+
+open System.IO
+open Fake.Core
+open Fake.DotNet
+open Fake.Testing
+open Fake.Tools
+open Expecto
+
+let rawCreateProcess setParams =
+   Fake.Tools.GitVersion.createProcess (fun param ->
+       { param with
+           ToolPath = Path.Combine("gitversion", "GitVersion.exe")}
+       |> setParams)
+
+let runCreateProcess setParams =
+  let cp = rawCreateProcess setParams
+
+  let file, args =
+    match cp.Command with
+    | RawCommand(file, args) -> file, args
+    | _ -> failwithf "expected RawCommand"
+    |> ArgumentHelper.checkIfMono
+
+  let expectedPath = Path.Combine("gitversion", "GitVersion.exe")
+  Expect.equal file expectedPath "Expected GitVersion.exe"
+
+  expectedPath, (RawCommand(file, args)).CommandLine.Trim()
+
+[<Tests>]
+let tests =
+  testList "Fake.Tools.GitVersion.Tests" [
+    testCase "Test that new argument generation  with default parameters" <| fun _ ->
+      let expectedPath, commandLine =
+        runCreateProcess id
+
+      Expect.equal commandLine expectedPath "expected proper command line"
+    
+    testCase "Test that full Framework works" <| fun _ ->
+      let path = "another/path/for/tool.exe"
+      let cp =
+        rawCreateProcess (fun p ->
+          { p with
+              ToolPath = path
+              ToolType = ToolType.CreateFullFramework() })
+      let file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+        |> ArgumentHelper.checkIfMono
+
+      Expect.equal file path "Expected tool.exe"
+      Expect.equal ((RawCommand(file, args)).CommandLine.Trim()) path "expected proper command line"
+
+    testCase "Test that global tool works" <| fun _ ->
+      let path = "another/path/for/globaltool.exe"
+      let cp =
+        rawCreateProcess (fun p ->
+          { p with
+              ToolPath = path
+              ToolType = ToolType.CreateGlobalTool() })
+      let file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+
+      Expect.equal file path "Expected globaltool.exe"
+      Expect.equal ((RawCommand(file, args)).CommandLine.Trim()) file "expected proper command line"
+
+    testCase "Test that local tool override works" <| fun _ ->
+      let cp =
+        rawCreateProcess (fun p ->
+          { p with
+              ToolType =
+                ToolType.CreateLocalTool()
+                |> ToolType.withDefaultToolCommandName "alternative" })
+      let dotnet, file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+        |> ArgumentHelper.checkIfDotNet
+
+      Expect.equal file "alternative" "Expected alternative"
+      Expect.equal ((RawCommand(file, args)).CommandLine.Trim()) file "expected proper command line"
+
+    testCase "Test that local tool works" <| fun _ ->
+      let cp =
+        rawCreateProcess (fun p ->
+          { p with
+              ToolType = ToolType.CreateLocalTool () })
+      let dotnet, file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+        |> ArgumentHelper.checkIfDotNet
+
+      Expect.equal file "gitversion" "Expected gitversion argument"
+      Expect.equal (RawCommand(file, args)).CommandLine "gitversion " "expected proper command line"
+
+    testCase "Test that DotNet can override dotnet" <| fun _ ->
+      let cp =
+        rawCreateProcess (fun p ->
+          { p with
+              ToolType =
+                ToolType.CreateLocalTool()
+                |> ToolType.withDotNetOptions (fun o -> {o with DotNetCliPath = "some/dotnet/path/dotnet.exe"}) })
+      let dotnet, file, args =
+        match cp.Command with
+        | RawCommand(file, args) -> file, args
+        | _ -> failwithf "expected RawCommand"
+        |> ArgumentHelper.checkIfDotNet
+
+      Expect.equal dotnet "some/dotnet/path/dotnet.exe" "Expected dotnet path"
+      Expect.equal (RawCommand(file, args)).CommandLine "gitversion " "expected proper command line"
+
+  ]
+


### PR DESCRIPTION
### Description

Mimicking the work done for Reporgenerator in https://github.com/fsharp/FAKE/pull/2399/ this PR adds the same for GitVersion without breaking backwards compatibility.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
