### PR TITLE
[Doc] Fix links inside one of the getting started's info box

### DIFF
--- a/help/markdown/fake-gettingstarted.md
+++ b/help/markdown/fake-gettingstarted.md
@@ -91,7 +91,7 @@ This section is to clarify when an how the intellisense updates when you add new
 
 <div class="alert alert-info">
     <h5>INFO</h5>
-    <p>We recommend [Visual Studio Code](https://code.visualstudio.com/) with the [Ionide extension](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp) for best FAKE tooling support, including proper debugging.</p>
+    <p>We recommend <a href="https://code.visualstudio.com/" rel="nofollow">Visual Studio Code</a> with the <a href="https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp" rel="nofollow">Ionide extension</a> for best FAKE tooling support, including proper debugging.</p>
 </div>
 
 * Assume you have a script `myscript.fsx` with the following contents:


### PR DESCRIPTION
### Description

This PR fixes the representation of links inside the INFO box about  "One note on Intellisense" on the page "Getting started".

The markdown representation is replaced with HTML.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
