### PR TITLE
Change GitHub.createPullRequest to await the call to PullRequest.Create

### DIFF
--- a/src/app/Fake.Api.GitHub/GitHub.fs
+++ b/src/app/Fake.Api.GitHub/GitHub.fs
@@ -469,4 +469,4 @@ module GitHub =
     /// </example>
     let createPullRequest owner repoName (pullRequest: NewPullRequest) (client: Async<GitHubClient>) =
         retryWithArg 5 client
-        <| fun client' -> async { return Async.AwaitTask <| client'.PullRequest.Create(owner, repoName, pullRequest) }
+        <| fun client' -> async { return! Async.AwaitTask <| client'.PullRequest.Create(owner, repoName, pullRequest) }


### PR DESCRIPTION
- fixes #2820 

### Description

Referencing the comments in #2820, and assuming that the return type is actually wrong, I think it should be awating the ```PullRequest.Create``` so that it gets awaited inside the retry machinery?

Still a draft, as if it's a correct cfhange it needs release notes (and It'd be a breaking change to the public API)