### PR TITLE
Update the `dotnet-install` script URL in `Fake.DotNet.getGenericDotNetCliInstallerUrl`

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -136,7 +136,7 @@ module DotNet =
     /// Get .NET Core SDK download uri
     /// </summary>
     let private getGenericDotNetCliInstallerUrl branch installerName =
-        sprintf "https://raw.githubusercontent.com/dotnet/cli/%s/scripts/obtain/%s" branch installerName
+        sprintf "https://raw.githubusercontent.com/dotnet/install-scripts/%s/src/%s" branch installerName
 
     let private getPowershellDotNetCliInstallerUrl branch =
         getGenericDotNetCliInstallerUrl branch "dotnet-install.ps1"
@@ -188,7 +188,7 @@ module DotNet =
         /// Parameter default values.
         static member Default =
             { AlwaysDownload = false
-              Branch = "master"
+              Branch = "main"
               CustomDownloadDir = None }
 
     /// <summary>


### PR DESCRIPTION
refs https://github.com/fsprojects/FAKE/issues/2848

### Description

The scripts have been updated due to https://github.com/dotnet/core/issues/9671, but according to https://github.com/dotnet/sdk/blob/main/scripts/obtain/dotnet-install-readme the source for the scripts was changed from https://github.com/dotnet/sdk to https://github.com/dotnet/install-scripts some years ago, so it looks like FAKE was already using an old version of the scripts?
