### PR TITLE
Remove ILRepack from the Build group in Paket

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,7 +10,6 @@ group Build
     nuget FSharp.Core
     nuget Suave
     nuget NuGet.CommandLine
-    nuget ILRepack
     nuget Newtonsoft.Json
     nuget System.Net.Http
     nuget Octokit

--- a/paket.lock
+++ b/paket.lock
@@ -5,7 +5,6 @@ CONTENT: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (8.0.301)
-    ILRepack (2.0.18)
     Microsoft.CSharp (4.7) - restriction: || (&& (< net20) (>= netstandard1.0) (< netstandard1.3)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0))
       NETStandard.Library (>= 1.6.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))


### PR DESCRIPTION
It doesnt look like it's actually used by the current build, and if it can go that's one less thing that needs to be updated

(The .NET 8 update PR currently ups this to a newer version, so if it's not actually used that's one less thing to change.)