### PR TITLE
Fix a couple of deprecation warnings when building with the .NET 10 SDK

### DIFF
--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.FxCop.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.FxCop.fs
@@ -288,7 +288,7 @@ let testCases =
                   }
 
               let dummy = Guid.NewGuid().ToString()
-              let levels = { 0..5 }
+              let levels = seq { 0..5 }
 
               let maps =
                   [| [ ("string(count(//Issue[@Level='CriticalError']))", 1)
@@ -317,7 +317,7 @@ let testCases =
                        ("string(count(//Issue[@Level='Warning']))", 0) ]
                      |> Map.ofList |]
 
-              let mapIndexes = { 0..4 }
+              let mapIndexes = seq { 0..4 }
 
               let messages =
                   [| "FxCop found 1 critical errors."


### PR DESCRIPTION
A trivial thing in the tests, but building with the .NET 10 RC2 compiler gives

%FAKE%\src\test\Fake.Core.UnitTests\Fake.DotNet.FxCop.fs(291,28): warning FS3873: This construct is deprecated. Sequence expressions should be of the form 'seq { ... }'
%FAKE%\src\test\Fake.Core.UnitTests\Fake.DotNet.FxCop.fs(320,32): warning FS3873: This construct is deprecated. Sequence expressions should be of the form 'seq { ... }'

