### PR TITLE
Remove some hard coded path separators from build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -660,7 +660,7 @@ Target.create "DotNetCoreIntegrationTests" (fun _ ->
 
     runExpecto
         root
-        "src/test/Fake.Core.IntegrationTests/bin/Release/net6.0/Fake.Core.IntegrationTests.dll"
+        ("src" </> "test" </> "Fake.Core.IntegrationTests" </> "bin" </> "Release" </> "net6.0" </> "Fake.Core.IntegrationTests.dll")
         "Fake_Core_IntegrationTests.TestResults.xml")
 
 Target.create "TemplateIntegrationTests" (fun _ ->
@@ -676,13 +676,13 @@ Target.create "DotNetCoreUnitTests" (fun _ ->
     // dotnet run -p src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
     runExpecto
         root
-        "src/test/Fake.Core.UnitTests/bin/Release/net6.0/Fake.Core.UnitTests.dll"
+        ("src" </> "test" </> "Fake.Core.UnitTests" </> "bin" </> "Release" </> "net6.0" </> "Fake.Core.UnitTests.dll")
         "Fake_Core_UnitTests.TestResults.xml"
 
     // dotnet run --project src/test/Fake.Core.CommandLine.UnitTests/Fake.Core.CommandLine.UnitTests.fsproj
     runExpecto
         root
-        "src/test/Fake.Core.CommandLine.UnitTests/bin/Release/net6.0/Fake.Core.CommandLine.UnitTests.dll"
+        ("src" </> "test" </> "Fake.Core.CommandLine.UnitTests" </> "bin" </> "Release" </> "net6.0" </> "Fake.Core.CommandLine.UnitTests.dll")
         "Fake_Core_CommandLine_UnitTests.TestResults.xml")
 
 // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Just a tiny bit more if the .NET 8 update PR broken out

### Description

Just pkcking up a few bits from https://github.com/fsprojects/FAKE/pull/2852/files#diff-5ebd60ceb88910043c04c5a665d836197d7184488edcf52f590e8fcad6101519R660 to minimize the changes a tiny bit more