### PR TITLE
Add GitHub Actions and GitLab to supported build servers in docs

### DIFF
--- a/docs/guide/buildserver.md
+++ b/docs/guide/buildserver.md
@@ -5,6 +5,8 @@ The `Fake.Core.BuildServer` namespace bundles support for various Build-Servers.
 Supported Build-Servers (Note: Not supported doesn't mean that it won't work, but colors and deep integration might be missing):
 
 - `Fake.BuildServer.AppVeyor`
+- `Fake.BuildServer.GitHubActions`
+- `Fake.BuildServer.GitLab`
 - `Fake.BuildServer.Travis`
 - `Fake.BuildServer.TeamCity`
 - `Fake.BuildServer.TeamFoundation`


### PR DESCRIPTION
### Description

Added two missing CIs with support in Fake.

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "side navigation" menu, edit `docs/data.json`.
- [x] (if new module) the module is in the correct namespace.
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
