### PR TITLE
Add a direct reference to System.Configuration.ConfigurationManager v…

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/paket.references
+++ b/src/app/Fake.DotNet.MSBuild/paket.references
@@ -4,3 +4,4 @@ FSharp.Core
 NETStandard.Library
 MSBuild.StructuredLogger
 BlackFox.VsWhere
+System.Configuration.ConfigurationManager


### PR DESCRIPTION
…6.0.0 to Fake.DotNet.MSBuild

refs https://github.com/fsprojects/FAKE/issues/2871

This attempts to remove a transient reference to old versions of System.Drawing.Common with known CVEs by directly referencing a newer version of ConfigurationManager

fake-cli is already using v6 (it's included in the fake-cli tool nuget package) which hopefully means it's already had some testing with that version
