### PR TITLE
Remove unused opens in Fake.Runtime.SdkAssemblyResolver

### DIFF
--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -2,15 +2,11 @@ module Fake.Runtime.SdkAssemblyResolver
 
 open System
 open System.IO
-open System.Net
-open System.Net.Http
-open System.Threading
 open System.Runtime.InteropServices
 open Fake.Core
 open Fake.IO.FileSystemOperators
 open Fake.DotNet
 open Fake.Runtime
-open Newtonsoft.Json
 open Paket
 open Microsoft.Deployment.DotNet.Releases
 


### PR DESCRIPTION
### Description

I was just having a look at what is still using Newtonsoft.Json and saw the unused opens here, so - may as well tidy it up

